### PR TITLE
Add aws profile name and path for iam-roles-anywhere flow

### DIFF
--- a/internal/kubelet/hybrid-kubeconfig.template.yaml
+++ b/internal/kubelet/hybrid-kubeconfig.template.yaml
@@ -18,6 +18,11 @@ users:
       exec:
         apiVersion: client.authentication.k8s.io/v1beta1
         command: aws-iam-authenticator
+        env:
+          - name: "AWS_PROFILE"
+            value: "hybrid"
+          - name: "AWS_CONFIG_FILE"
+            value: "{{.ConfigPath}}"
         args:
           - "token"
           - "--cluster-id"


### PR DESCRIPTION
*Description of changes:*
Export aws profile name and config path for aws-iam-authenticator

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
