### PR TITLE
Add AssumeRole ARN for IAM roles anywhere & export kubelet args

### DIFF
--- a/api/v1alpha1/nodeconfig_types.go
+++ b/api/v1alpha1/nodeconfig_types.go
@@ -115,6 +115,10 @@ type HybridOptions struct {
 	// SSM includes Systems Manager specific configuration and is mutually exclusive with
 	// IAMRolesAnywhere.
 	SSM *SSM `json:"ssm,omitempty"`
+
+	// AwsConfigPath is the path where the Aws config is stored for hybrid nodes.
+	// This field is only used to init phase
+	AwsConfigPath string `json:"awsConfigPath,omitempty"`
 }
 
 // IsHybridNode returns true when the nc.Hybrid configuration is non-nil.
@@ -136,11 +140,15 @@ type IAMRolesAnywhere struct {
 	// ProfileARN is the ARN of the profile linked with the Hybrid IAM Role.
 	ProfileARN string `json:"profileArn,omitempty"`
 
-	// RoleARN is the role to assume when retrieving temporary credentials.
+	// RoleARN is the role to IAM roles anywhere gets authorized as to get temporary credentials.
 	RoleARN string `json:"roleArn,omitempty"`
+
+	// AssumeRoleARN is the role to assume after authorized as RoleARN.
+	// This role will have permissions to add a node to the cluster.
+	AssumeRoleARN string `json:"assumeRoleArn,omitempty"`
 }
 
-// SSM defines Systems MAnager specific configuration.
+// SSM defines Systems Manager specific configuration.
 type SSM struct {
 	// ActivationToken is the token generated when creating an SSM activation.
 	ActivationToken string `json:"activationToken,omitempty"`

--- a/cmd/nodeadm/init/init.go
+++ b/cmd/nodeadm/init/init.go
@@ -32,7 +32,6 @@ func NewInitCommand() cli.Command {
 	init.cmd = flaggy.NewSubcommand("init")
 	init.cmd.StringSlice(&init.daemons, "d", "daemon", "specify one or more of `containerd` and `kubelet`. This is intended for testing and should not be used in a production environment.")
 	init.cmd.StringSlice(&init.skipPhases, "s", "skip", "phases of the bootstrap you want to skip")
-	init.cmd.String(&init.awsConfig, "", "aws-config", "An aws config path to use for hybrid configuration (/etc/aws/hybrid/config)")
 	init.cmd.Description = "Initialize this instance as a node in an EKS cluster"
 	return &init
 }
@@ -41,7 +40,6 @@ type initCmd struct {
 	cmd        *flaggy.Subcommand
 	skipPhases []string
 	daemons    []string
-	awsConfig  string
 }
 
 func (c *initCmd) Flaggy() *flaggy.Subcommand {
@@ -73,24 +71,24 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return err
 	}
 
-	// Default and validate aws config
-	if c.awsConfig == "" {
-		c.awsConfig = iamrolesanywhere.DefaultAWSConfigPath
-	}
-
 	zap.L().Info("Validating configuration..")
 	if err := api.ValidateNodeConfig(nodeConfig); err != nil {
 		return err
 	}
 
-	if err := iamrolesanywhere.EnsureAWSConfig(iamrolesanywhere.AWSConfig{
-		TrustAnchorARN: nodeConfig.Spec.Hybrid.IAMRolesAnywhere.TrustAnchorARN,
-		ProfileARN:     nodeConfig.Spec.Hybrid.IAMRolesAnywhere.ProfileARN,
-		RoleARN:        nodeConfig.Spec.Hybrid.IAMRolesAnywhere.RoleARN,
-		Region:         nodeConfig.Spec.Hybrid.Region,
-		ConfigPath:     c.awsConfig,
-	}); err != nil {
-		return err
+	if nodeConfig.IsHybridNode() {
+		if nodeConfig.Spec.Hybrid.AwsConfigPath == "" {
+			nodeConfig.Spec.Hybrid.AwsConfigPath = iamrolesanywhere.DefaultAWSConfigPath
+		}
+		if err := iamrolesanywhere.EnsureAWSConfig(iamrolesanywhere.AWSConfig{
+			TrustAnchorARN: nodeConfig.Spec.Hybrid.IAMRolesAnywhere.TrustAnchorARN,
+			ProfileARN:     nodeConfig.Spec.Hybrid.IAMRolesAnywhere.ProfileARN,
+			RoleARN:        nodeConfig.Spec.Hybrid.IAMRolesAnywhere.RoleARN,
+			Region:         nodeConfig.Spec.Hybrid.Region,
+			ConfigPath:     nodeConfig.Spec.Hybrid.AwsConfigPath,
+		}); err != nil {
+			return err
+		}
 	}
 
 	log.Info("Creating daemon manager..")

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -111,6 +111,7 @@ type HybridOptions struct {
 	Region           string            `json:"region,omitempty"`
 	IAMRolesAnywhere *IAMRolesAnywhere `json:"iamRolesAnywhere,omitempty"`
 	SSM              *SSM              `json:"ssm,omitempty"`
+	AwsConfigPath    string            `json:"awsConfigPath,omitempty"`
 }
 
 func (nc NodeConfig) IsHybridNode() bool {
@@ -134,6 +135,7 @@ type IAMRolesAnywhere struct {
 	TrustAnchorARN string `json:"trustAnchorArn,omitempty"`
 	ProfileARN     string `json:"profileArn,omitempty"`
 	RoleARN        string `json:"roleArn,omitempty"`
+	AssumeRoleARN  string `json:"assumeRoleARN,omitempty"`
 }
 
 type SSM struct {

--- a/internal/api/validation.go
+++ b/internal/api/validation.go
@@ -25,11 +25,25 @@ func ValidateNodeConfig(cfg *NodeConfig) error {
 		if cfg.Spec.Hybrid.Region == "" {
 			return fmt.Errorf("Region is missing in hybrid configuration")
 		}
-		if cfg.Spec.Hybrid.IAMRolesAnywhere == nil && cfg.Spec.Hybrid.SSM == nil {
+		if !cfg.IsIAMRolesAnywhere() && !cfg.IsSSM() {
 			return fmt.Errorf("Either IAMRolesAnywhere or SSM must be provided for hybrid node configuration")
 		}
-		if cfg.Spec.Hybrid.IAMRolesAnywhere != nil && cfg.Spec.Hybrid.SSM != nil {
+		if cfg.IsIAMRolesAnywhere() && cfg.IsSSM() {
 			return fmt.Errorf("Only one of IAMRolesAnywhere or SSM must be provided for hybrid node configuration")
+		}
+		if cfg.IsIAMRolesAnywhere() {
+			if cfg.Spec.Hybrid.IAMRolesAnywhere.AssumeRoleARN == "" {
+				return fmt.Errorf("AssumeRoleARN is missing in hybrid iam roles anywhere configuration")
+			}
+			if cfg.Spec.Hybrid.IAMRolesAnywhere.RoleARN == "" {
+				return fmt.Errorf("RoleARN is missing in hybrid iam roles anywhere configuration")
+			}
+			if cfg.Spec.Hybrid.IAMRolesAnywhere.ProfileARN == "" {
+				return fmt.Errorf("ProfileARN is missing in hybrid iam roles anywhere configuration")
+			}
+			if cfg.Spec.Hybrid.IAMRolesAnywhere.TrustAnchorARN == "" {
+				return fmt.Errorf("TrustAnchroARN is missing in hybrid iam roles anywhere configuration")
+			}
 		}
 	}
 	return nil

--- a/internal/containerd/sandbox.go
+++ b/internal/containerd/sandbox.go
@@ -32,7 +32,7 @@ func cacheSandboxImage(cfg *api.NodeConfig) error {
 	zap.L().Info("Found sandbox image", zap.String("image", sandboxImage))
 
 	zap.L().Info("Fetching ECR authorization token..")
-	ecrUserToken, err := ecr.GetAuthorizationToken(cfg.Status.Instance.Region)
+	ecrUserToken, err := ecr.GetAuthorizationToken(cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/imagecredentialprovider/install.go
+++ b/internal/imagecredentialprovider/install.go
@@ -8,9 +8,9 @@ import (
 )
 
 // BinPath is the path to the image-credential-provider binary.
-const BinPath = "/etc/eks/image-credential-provider/image-credential-provider"
+const BinPath = "/etc/eks/image-credential-provider/ecr-credential-provider"
 
-// Source represents a source that serves a image-credential-provider binary.
+// Source represents a source that serves an image-credential-provider binary.
 type Source interface {
 	GetImageCredentialProvider(context.Context) (artifact.Source, error)
 }

--- a/internal/kubelet/hybrid-kubeconfig.template.yaml
+++ b/internal/kubelet/hybrid-kubeconfig.template.yaml
@@ -22,7 +22,7 @@ users:
           - name: "AWS_PROFILE"
             value: "hybrid"
           - name: "AWS_CONFIG_FILE"
-            value: "{{.ConfigPath}}"
+            value: "{{.AwsConfigPath}}"
         args:
           - "token"
           - "--cluster-id"

--- a/internal/kubelet/kubeconfig.go
+++ b/internal/kubelet/kubeconfig.go
@@ -50,6 +50,7 @@ type kubeconfigTemplateVars struct {
 	CaCertPath        string
 	SessionName       string
 	AssumeRole        string
+	AwsConfigPath     string
 }
 
 func newKubeconfigTemplateVars(cfg *api.NodeConfig) *kubeconfigTemplateVars {
@@ -68,7 +69,8 @@ func (kct *kubeconfigTemplateVars) withOutpostVars(cfg *api.NodeConfig) {
 func (kct *kubeconfigTemplateVars) withHybridVars(cfg *api.NodeConfig) {
 	kct.Region = cfg.Spec.Hybrid.Region
 	kct.SessionName = cfg.Spec.Hybrid.NodeName
-	kct.AssumeRole = cfg.Spec.Hybrid.IAMRolesAnywhere.RoleARN
+	kct.AssumeRole = cfg.Spec.Hybrid.IAMRolesAnywhere.AssumeRoleARN
+	kct.AwsConfigPath = cfg.Spec.Hybrid.AwsConfigPath
 }
 
 func generateKubeconfig(cfg *api.NodeConfig) ([]byte, error) {

--- a/internal/kubelet/kubelet.service
+++ b/internal/kubelet/kubelet.service
@@ -6,12 +6,13 @@ Requires=containerd.service
 
 [Service]
 Slice=runtime.slice
+EnvironmentFile=/etc/eks/kubelet/environment
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
 ExecStart=/usr/bin/kubelet \
     --config /etc/kubernetes/kubelet/config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime-endpoint unix:///run/containerd/containerd.sock \
-    $KUBELET_ARGS \
+    $NODEADM_KUBELET_ARGS\
     $KUBELET_EXTRA_ARGS
 
 Restart=on-failure


### PR DESCRIPTION
*Description of changes:*
1. Moves aws config file from argument to node config struct
2. Adds AssumeRole ARN that aws-iam-authenticator should assume as. This is used by kubelet, once the node is authorized by iam-roles-anywhere to add itself as a node to the kubernetes cluster.
3. Containerd caching pause image to use hybrid aws config as opposed to IMDS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
