### PR TITLE
Set aws profile and aws config path for ecr-credential-provider

### DIFF
--- a/crds/node.eks.aws_nodeconfigs.yaml
+++ b/crds/node.eks.aws_nodeconfigs.yaml
@@ -76,17 +76,26 @@ spec:
                 description: HybridOptions defines the options specific to hybrid
                   node enrollment.
                 properties:
+                  awsConfigPath:
+                    description: AwsConfigPath is the path where the Aws config is
+                      stored for hybrid nodes. This field is only used to init phase
+                    type: string
                   iamRolesAnywhere:
                     description: IAMRolesAnywhere includes IAM Roles Anywhere specific
                       configuration and is mutually exclusive with SSM.
                     properties:
+                      assumeRoleArn:
+                        description: AssumeRoleARN is the role to assume after authorized
+                          as RoleARN. This role will have permissions to add a node
+                          to the cluster.
+                        type: string
                       profileArn:
                         description: ProfileARN is the ARN of the profile linked with
                           the Hybrid IAM Role.
                         type: string
                       roleArn:
-                        description: RoleARN is the role to assume when retrieving
-                          temporary credentials.
+                        description: RoleARN is the role to IAM roles anywhere gets
+                          authorized as to get temporary credentials.
                         type: string
                       trustAnchorArn:
                         description: TrustAnchorARN is the ARN of the trust anchor.

--- a/doc/api.md
+++ b/doc/api.md
@@ -48,6 +48,7 @@ _Appears in:_
 | `region` _string_ | Region is an AWS region (e.g. us-east-1) used to retrieve regional artifacts. |
 | `iamRolesAnywhere` _[IAMRolesAnywhere](#iamrolesanywhere)_ | IAMRolesAnywhere includes IAM Roles Anywhere specific configuration and is mutually exclusive with SSM. |
 | `ssm` _[SSM](#ssm)_ | SSM includes Systems Manager specific configuration and is mutually exclusive with IAMRolesAnywhere. |
+| `awsConfigPath` _string_ | AwsConfigPath is the path where the Aws config is stored for hybrid nodes. This field is only used to init phase |
 
 #### IAMRolesAnywhere
 
@@ -60,7 +61,8 @@ _Appears in:_
 | --- | --- |
 | `trustAnchorArn` _string_ | TrustAnchorARN is the ARN of the trust anchor. |
 | `profileArn` _string_ | ProfileARN is the ARN of the profile linked with the Hybrid IAM Role. |
-| `roleArn` _string_ | RoleARN is the role to assume when retrieving temporary credentials. |
+| `roleArn` _string_ | RoleARN is the role to IAM roles anywhere gets authorized as to get temporary credentials. |
+| `assumeRoleArn` _string_ | AssumeRoleARN is the role to assume after authorized as RoleARN. This role will have permissions to add a node to the cluster. |
 
 #### InstanceOptions
 
@@ -136,7 +138,7 @@ _Appears in:_
 
 #### SSM
 
-SSM defines Systems MAnager specific configuration.
+SSM defines Systems Manager specific configuration.
 
 _Appears in:_
 - [HybridOptions](#hybridoptions)

--- a/internal/api/bridge/zz_generated.conversion.go
+++ b/internal/api/bridge/zz_generated.conversion.go
@@ -189,6 +189,7 @@ func autoConvert_v1alpha1_HybridOptions_To_api_HybridOptions(in *v1alpha1.Hybrid
 	out.Region = in.Region
 	out.IAMRolesAnywhere = (*api.IAMRolesAnywhere)(unsafe.Pointer(in.IAMRolesAnywhere))
 	out.SSM = (*api.SSM)(unsafe.Pointer(in.SSM))
+	out.AwsConfigPath = in.AwsConfigPath
 	return nil
 }
 
@@ -202,6 +203,7 @@ func autoConvert_api_HybridOptions_To_v1alpha1_HybridOptions(in *api.HybridOptio
 	out.Region = in.Region
 	out.IAMRolesAnywhere = (*v1alpha1.IAMRolesAnywhere)(unsafe.Pointer(in.IAMRolesAnywhere))
 	out.SSM = (*v1alpha1.SSM)(unsafe.Pointer(in.SSM))
+	out.AwsConfigPath = in.AwsConfigPath
 	return nil
 }
 
@@ -214,6 +216,7 @@ func autoConvert_v1alpha1_IAMRolesAnywhere_To_api_IAMRolesAnywhere(in *v1alpha1.
 	out.TrustAnchorARN = in.TrustAnchorARN
 	out.ProfileARN = in.ProfileARN
 	out.RoleARN = in.RoleARN
+	out.AssumeRoleARN = in.AssumeRoleARN
 	return nil
 }
 
@@ -226,6 +229,7 @@ func autoConvert_api_IAMRolesAnywhere_To_v1alpha1_IAMRolesAnywhere(in *api.IAMRo
 	out.TrustAnchorARN = in.TrustAnchorARN
 	out.ProfileARN = in.ProfileARN
 	out.RoleARN = in.RoleARN
+	out.AssumeRoleARN = in.AssumeRoleARN
 	return nil
 }
 

--- a/internal/kubelet/hybrid-image-credential-provider.template.json
+++ b/internal/kubelet/hybrid-image-credential-provider.template.json
@@ -1,0 +1,28 @@
+{
+  "apiVersion": "{{.ConfigApiVersion}}",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "{{.EcrProviderName}}",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "{{.ProviderApiVersion}}",
+      "env": [
+        {
+          "name": "AWS_CONFIG_FILE",
+          "value": "{{.AwsConfigPath}}"
+        },
+        {
+          "name": "AWS_PROFILE",
+          "value": "hybrid"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
*Description of changes:*
Hybrid nodes use aws config that is present on non-default path. These changes set the aws config file path as well as the aws profile to use by ecr-credential-provider, when kubelet requests to pull an image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
