### PR TITLE
Use amazonaws.com for service domain on hybrid nodes

### DIFF
--- a/internal/aws/ecr/ecr.go
+++ b/internal/aws/ecr/ecr.go
@@ -15,6 +15,8 @@ import (
 	"github.com/aws/eks-hybrid/internal/api"
 )
 
+const hybridServicesDomain = "amazonaws.com"
+
 // Returns the base64 encoded authorization token string for ECR of the format "AWS:XXXXX"
 func GetAuthorizationToken(nodeCfg *api.NodeConfig) (string, error) {
 	var awsConfig aws.Config
@@ -54,11 +56,20 @@ func (r *ECRRegistry) GetSandboxImage() string {
 }
 
 func GetEKSRegistry(region string) (ECRRegistry, error) {
-	account, region := getEKSRegistryCoordinates(region)
 	servicesDomain, err := imds.GetProperty(imds.ServicesDomain)
 	if err != nil {
 		return "", err
 	}
+
+	return getEksRegistryWithServiceDomain(region, servicesDomain)
+}
+
+func GetEKSHybridRegistry(region string) (ECRRegistry, error) {
+	return getEksRegistryWithServiceDomain(region, hybridServicesDomain)
+}
+
+func getEksRegistryWithServiceDomain(region, servicesDomain string) (ECRRegistry, error) {
+	account, region := getEKSRegistryCoordinates(region)
 	fipsInstalled, fipsEnabled, err := system.GetFipsInfo()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
*Description of changes:*
nodeamd uses IMDS to pull the services/domain information to get the ECR registry. Defaulting this to amazonaws.com for hybrid. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
