### PR TITLE
Install cni plugins for hybrid node

### DIFF
--- a/internal/artifact/install.go
+++ b/internal/artifact/install.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path"
 )
 
@@ -26,4 +27,22 @@ func InstallFile(dst string, src io.Reader, perms fs.FileMode) error {
 
 	_, err = io.Copy(fh, src)
 	return err
+}
+
+// InstallTarGz untars the src file into the dst directory and deletes the src tgz file
+func InstallTarGz(dst string, src string) error {
+	if err := os.MkdirAll(path.Dir(dst), DefaultDirPerms); err != nil {
+		return err
+	}
+
+	tgzExtractCmd := exec.Command("tar", "xvf", src, "-C", dst)
+	if err := tgzExtractCmd.Run(); err != nil {
+		return err
+	}
+
+	// Remove the tgz file
+	if err := os.Remove(src); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/aws/eks/release.go
+++ b/internal/aws/eks/release.go
@@ -132,6 +132,10 @@ func (r PatchRelease) GetImageCredentialProvider(ctx context.Context) (artifact.
 	return r.getSource(ctx, "ecr-credential-provider")
 }
 
+func (r PatchRelease) GetCniPlugins(ctx context.Context) (artifact.Source, error) {
+	return r.getSource(ctx, "cni-plugins")
+}
+
 func (r PatchRelease) getSource(ctx context.Context, artifactName string) (artifact.Source, error) {
 	for _, releaseArtifact := range r.Artifacts {
 		if releaseArtifact.Name == artifactName && releaseArtifact.Arch == runtime.GOARCH && releaseArtifact.OS == runtime.GOOS {

--- a/internal/cni/install.go
+++ b/internal/cni/install.go
@@ -1,0 +1,42 @@
+package cni
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/eks-hybrid/internal/artifact"
+)
+
+const (
+	// BinPath is the path to the cni plugins binary.
+	BinPath = "/opt/cni/plugins"
+
+	// TgzPath is the path to install the cni-plugins tgz file
+	TgzPath = "/opt/cni/plugins/cni-plugins.tgz"
+)
+
+// Source represents a source that serves a cni plugins binary.
+type Source interface {
+	GetCniPlugins(context.Context) (artifact.Source, error)
+}
+
+func Install(ctx context.Context, src Source) error {
+	cniPlugins, err := src.GetCniPlugins(ctx)
+	if err != nil {
+		return fmt.Errorf("cni-plugins: %w", err)
+	}
+	defer cniPlugins.Close()
+
+	if err := artifact.InstallFile(TgzPath, cniPlugins, 0755); err != nil {
+		return fmt.Errorf("cni-plugins: %w", err)
+	}
+
+	if !cniPlugins.VerifyChecksum() {
+		return fmt.Errorf("cni-plugins: %w", artifact.NewChecksumError(cniPlugins))
+	}
+
+	if err := artifact.InstallTarGz(BinPath, TgzPath); err != nil {
+		return fmt.Errorf("cni-plugins: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
*Description of changes:*
Install cni plugins for hybrid nodes.

*Testing*
```
{"level":"info","ts":1718220642.6403947,"caller":"install/install.go:64","msg":"Validating configuration"}
{"level":"info","ts":1718220642.6405752,"caller":"install/install.go:70","msg":"Validating Kubernetes version","kubernetes version":"1.29"}
{"level":"info","ts":1718220642.8795075,"caller":"install/install.go:76","msg":"Using Kubernetes version","kubernetes version":"1.29.3"}
{"level":"info","ts":1718220642.8798702,"caller":"install/install.go:89","msg":"Installing SSM agent installer..."}
{"level":"info","ts":1718220642.977752,"caller":"install/install.go:97","msg":"Installing kubelet..."}
{"level":"info","ts":1718220643.1774492,"caller":"install/install.go:102","msg":"Installing kubectl..."}
{"level":"info","ts":1718220643.2650604,"caller":"install/install.go:107","msg":"Installing cni-plugins..."}
{"level":"info","ts":1718220645.3530946,"caller":"install/install.go:112","msg":"Installing image credential provider..."}
{"level":"info","ts":1718220645.4998674,"caller":"install/install.go:117","msg":"Installing IAM authenticator..."}
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
