### PR TITLE
Fix CNI plugins install dir

### DIFF
--- a/internal/cni/install.go
+++ b/internal/cni/install.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// BinPath is the path to the cni plugins binary.
-	BinPath = "/opt/cni/plugins"
+	BinPath = "/opt/cni/bin"
 
 	// TgzPath is the path to install the cni-plugins tgz file
 	TgzPath = "/opt/cni/plugins/cni-plugins.tgz"


### PR DESCRIPTION
*Description of changes:*
/opt/cni/bin is where we configure containerd to look for the plugins.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
