### PR TITLE
Fix mkdir to create full path before untar

### DIFF
--- a/internal/artifact/install.go
+++ b/internal/artifact/install.go
@@ -1,6 +1,7 @@
 package artifact
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -31,13 +32,13 @@ func InstallFile(dst string, src io.Reader, perms fs.FileMode) error {
 
 // InstallTarGz untars the src file into the dst directory and deletes the src tgz file
 func InstallTarGz(dst string, src string) error {
-	if err := os.MkdirAll(path.Dir(dst), DefaultDirPerms); err != nil {
+	if err := os.MkdirAll(dst, DefaultDirPerms); err != nil {
 		return err
 	}
 
 	tgzExtractCmd := exec.Command("tar", "xvf", src, "-C", dst)
 	if err := tgzExtractCmd.Run(); err != nil {
-		return err
+		return fmt.Errorf("unable to untar: %v", err)
 	}
 
 	// Remove the tgz file


### PR DESCRIPTION
*Description of changes:*
Create directory's full path before un-tarring the tgz file to destination.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
