### PR TITLE
Enable systemd units

### DIFF
--- a/internal/containerd/daemon.go
+++ b/internal/containerd/daemon.go
@@ -24,6 +24,10 @@ func (cd *containerd) Configure(c *api.NodeConfig) error {
 }
 
 func (cd *containerd) EnsureRunning() error {
+	err := cd.daemonManager.EnableDaemon(ContainerdDaemonName)
+	if err != nil {
+		return err
+	}
 	return cd.daemonManager.StartDaemon(ContainerdDaemonName)
 }
 

--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -65,16 +65,15 @@ func (m *systemdDaemonManager) GetDaemonStatus(name string) (DaemonStatus, error
 	}
 }
 
+// EnableDaemon enables the daemon with the given name.
+// If the daemon is already enabled, this is a no-op.
 func (m *systemdDaemonManager) EnableDaemon(name string) error {
 	unitName := getServiceUnitName(name)
 	_, changes, err := m.conn.EnableUnitFilesContext(context.TODO(), []string{unitName}, false, false)
 	if err != nil {
 		return err
 	}
-	if len(changes) != 1 {
-		return fmt.Errorf("unexpected number of unit file changes: %d", len(changes))
-	}
-	if changes[0].Type != TypeSymlink {
+	if len(changes) != 0 && changes[0].Type != TypeSymlink {
 		return fmt.Errorf("unexpected unit file change type: %s", changes[0].Type)
 	}
 	return nil

--- a/internal/kubelet/daemon.go
+++ b/internal/kubelet/daemon.go
@@ -45,6 +45,10 @@ func (k *kubelet) Configure(cfg *api.NodeConfig) error {
 }
 
 func (k *kubelet) EnsureRunning() error {
+	err := k.daemonManager.EnableDaemon(KubeletDaemonName)
+	if err != nil {
+		return err
+	}
 	return k.daemonManager.StartDaemon(KubeletDaemonName)
 }
 

--- a/internal/ssm/daemon.go
+++ b/internal/ssm/daemon.go
@@ -25,6 +25,10 @@ func (s *ssm) Configure(cfg *api.NodeConfig) error {
 }
 
 func (s *ssm) EnsureRunning() error {
+	err := s.daemonManager.EnableDaemon(SsmDaemonName)
+	if err != nil {
+		return err
+	}
 	return s.daemonManager.StartDaemon(SsmDaemonName)
 }
 


### PR DESCRIPTION
*Description of changes:*
Enable systemd units for kubelet, containerd, and ssm (if installed) post initialization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
