### PR TITLE
Always restart containerd, as it might be already running during install

### DIFF
--- a/internal/containerd/daemon.go
+++ b/internal/containerd/daemon.go
@@ -23,12 +23,15 @@ func (cd *containerd) Configure(c *api.NodeConfig) error {
 	return writeContainerdConfig(c)
 }
 
+// EnsureRunning ensures containerd is running with the written configuration
+// With some installations, containerd daemon is already in an running state
+// This enables the daemon and restarts or starts depending on the state of daemon
 func (cd *containerd) EnsureRunning() error {
 	err := cd.daemonManager.EnableDaemon(ContainerdDaemonName)
 	if err != nil {
 		return err
 	}
-	return cd.daemonManager.StartDaemon(ContainerdDaemonName)
+	return cd.daemonManager.RestartDaemon(ContainerdDaemonName)
 }
 
 func (cd *containerd) PostLaunch(c *api.NodeConfig) error {


### PR DESCRIPTION
*Description of changes:*
While installing containerd with some package managers, they start the daemon with post-install scripts. This prohibits from taking in the new configuration written to containerd. Restarting daemon if already started, and starting the daemon if not started ensures the new configuration is used by containerd.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
