### PR TITLE
Change default hybrid node label to compute type

### DIFF
--- a/internal/kubelet/config.go
+++ b/internal/kubelet/config.go
@@ -37,7 +37,7 @@ const (
 	kubeletConfigDir  = "config.json.d"
 	kubeletConfigPerm = 0644
 
-	hybridNodeLabel = "eks.amazonaws.com/hybrid-node=true"
+	hybridNodeLabel = "eks.amazonaws.com/compute-type=hybrid"
 )
 
 func (k *kubelet) writeKubeletConfig(cfg *api.NodeConfig) error {


### PR DESCRIPTION
*Description of changes:*
I didn't add a unit test because the method to add the label has no logic. We should be testing it through `GenerateKubeletConfig` but right now we lack the ability to mock certain external calls (like `kubelet` binary invocations).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
