### PR TITLE
Add lint make target

### DIFF
--- a/internal/configprovider/userdata_test.go
+++ b/internal/configprovider/userdata_test.go
@@ -69,6 +69,7 @@ var completeMergedWithPartial = api.NodeConfig{
 	},
 }
 
+// nolint:unused
 func indent(in string) string {
 	var mid interface{}
 	err := json.Unmarshal([]byte(in), &mid)


### PR DESCRIPTION
*Description of changes:*
Adding `lint` make target which allows you to run the same lint as the one configured on GitHub runner locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
