### PR TITLE
Uninstall without nodeconfig

### DIFF
--- a/cmd/nodeadm/init/init.go
+++ b/cmd/nodeadm/init/init.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/utils/strings/slices"
 
 	"github.com/aws/eks-hybrid/internal/api"
-	"github.com/aws/eks-hybrid/internal/aws"
 	"github.com/aws/eks-hybrid/internal/cli"
 	"github.com/aws/eks-hybrid/internal/configenricher"
 	"github.com/aws/eks-hybrid/internal/configprovider"
@@ -73,15 +72,6 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return err
 	}
 
-	awsConfigProvider, err := aws.NewConfig(nodeConfig)
-	if err != nil {
-		return err
-	}
-	awsConfig, err := awsConfigProvider.GetConfig()
-	if err != nil {
-		return err
-	}
-
 	log.Info("Creating daemon manager..")
 	daemonManager, err := daemon.NewDaemonManager()
 	if err != nil {
@@ -104,7 +94,7 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 
 	daemons = append(daemons,
 		containerd.NewContainerdDaemon(daemonManager),
-		kubelet.NewKubeletDaemon(daemonManager, awsConfig),
+		kubelet.NewKubeletDaemon(daemonManager),
 	)
 
 	if !slices.Contains(c.skipPhases, configPhase) {

--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -1,14 +1,12 @@
 package uninstall
 
 import (
-	"github.com/aws/eks-hybrid/internal/aws"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 	"os"
 
 	"github.com/aws/eks-hybrid/internal/cli"
 	"github.com/aws/eks-hybrid/internal/cni"
-	"github.com/aws/eks-hybrid/internal/configprovider"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/iamauthenticator"
 	"github.com/aws/eks-hybrid/internal/iamrolesanywhere"
@@ -46,32 +44,12 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return cli.ErrMustRunAsRoot
 	}
 
-	log.Info("Loading configuration", zap.String("configSource", opts.ConfigSource))
-	provider, err := configprovider.BuildConfigProvider(opts.ConfigSource)
-	if err != nil {
-		return err
-	}
-	nodeCfg, err := provider.Provide()
-	if err != nil {
-		return err
-	}
-	log.Info("Loaded configuration", zap.Reflect("config", nodeCfg))
-
 	log.Info("Loading installed components")
 	installed, err := tracker.GetInstalledArtifacts()
 	if err != nil && os.IsNotExist(err) {
 		log.Info("Nodeadm components are already uninstalled")
 		return nil
 	} else if err != nil {
-		return err
-	}
-
-	awsConfigProvider, err := aws.NewConfig(nodeCfg)
-	if err != nil {
-		return err
-	}
-	awsConfig, err := awsConfigProvider.GetConfig()
-	if err != nil {
 		return err
 	}
 
@@ -115,7 +93,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 	if artifacts.Kubelet {
 		log.Info("Uninstalling kubelet...")
-		kubeletDaemon := kubelet.NewKubeletDaemon(daemonManager, awsConfig)
+		kubeletDaemon := kubelet.NewKubeletDaemon(daemonManager)
 		if err := kubeletDaemon.Stop(); err != nil {
 			return err
 		}
@@ -129,7 +107,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		if err := ssmDaemon.Stop(); err != nil {
 			return err
 		}
-		if err := ssm.Uninstall(awsConfig); err != nil {
+		if err := ssm.Uninstall(); err != nil {
 			return err
 		}
 	}

--- a/internal/kubelet/cluster.go
+++ b/internal/kubelet/cluster.go
@@ -6,30 +6,41 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
-
 	"github.com/aws/eks-hybrid/internal/api"
+
+	internalaws "github.com/aws/eks-hybrid/internal/aws"
 )
 
 func (k *kubelet) ensureClusterDetails(cfg *api.NodeConfig) error {
-	eksClient := eks.NewFromConfig(k.awsConfig)
-	cluster, err := eksClient.DescribeCluster(context.Background(), &eks.DescribeClusterInput{
-		Name: aws.String(cfg.Spec.Cluster.Name),
-	})
-	if err != nil {
-		return err
-	}
-	if cfg.Spec.Cluster.APIServerEndpoint == "" {
-		cfg.Spec.Cluster.APIServerEndpoint = *cluster.Cluster.Endpoint
-	}
-
-	if cfg.Spec.Cluster.CertificateAuthority == nil {
-		// CertificateAuthority from describeCluster api call returns base64 encoded data as a string
-		// Decoding the string to byte array ensures the proper data format when writing to file
-		decoded, err := base64.StdEncoding.DecodeString(*cluster.Cluster.CertificateAuthority.Data)
+	if cfg.Spec.Cluster.APIServerEndpoint == "" || cfg.Spec.Cluster.CertificateAuthority == nil {
+		awsConfigProvider, err := internalaws.NewConfig(cfg)
 		if err != nil {
 			return err
 		}
-		cfg.Spec.Cluster.CertificateAuthority = decoded
+		awsConfig, err := awsConfigProvider.GetConfig()
+		if err != nil {
+			return err
+		}
+		eksClient := eks.NewFromConfig(awsConfig)
+		cluster, err := eksClient.DescribeCluster(context.Background(), &eks.DescribeClusterInput{
+			Name: aws.String(cfg.Spec.Cluster.Name),
+		})
+		if err != nil {
+			return err
+		}
+		if cfg.Spec.Cluster.APIServerEndpoint == "" {
+			cfg.Spec.Cluster.APIServerEndpoint = *cluster.Cluster.Endpoint
+		}
+
+		if cfg.Spec.Cluster.CertificateAuthority == nil {
+			// CertificateAuthority from describeCluster api call returns base64 encoded data as a string
+			// Decoding the string to byte array ensures the proper data format when writing to file
+			decoded, err := base64.StdEncoding.DecodeString(*cluster.Cluster.CertificateAuthority.Data)
+			if err != nil {
+				return err
+			}
+			cfg.Spec.Cluster.CertificateAuthority = decoded
+		}
 	}
 	return nil
 }

--- a/internal/kubelet/daemon.go
+++ b/internal/kubelet/daemon.go
@@ -1,7 +1,6 @@
 package kubelet
 
 import (
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/daemon"
 )
@@ -16,16 +15,13 @@ type kubelet struct {
 	environment map[string]string
 	// kubelet config flags without leading dashes
 	flags map[string]string
-	// awsConfig used to make aws calls
-	awsConfig aws.Config
 }
 
-func NewKubeletDaemon(daemonManager daemon.DaemonManager, awsConfig aws.Config) daemon.Daemon {
+func NewKubeletDaemon(daemonManager daemon.DaemonManager) daemon.Daemon {
 	return &kubelet{
 		daemonManager: daemonManager,
 		environment:   make(map[string]string),
 		flags:         make(map[string]string),
-		awsConfig:     awsConfig,
 	}
 }
 

--- a/internal/ssm/config.go
+++ b/internal/ssm/config.go
@@ -43,3 +43,17 @@ func GetManagedHybridInstanceId() (string, error) {
 	}
 	return registration.ManagedInstanceID, nil
 }
+
+func GetManagedHybridInstanceIdAndRegion() (string, string, error) {
+	data, err := os.ReadFile(registrationFilePath)
+	if err != nil {
+		return "", "", err
+	}
+
+	var registration HybridInstanceRegistration
+	err = json.Unmarshal(data, &registration)
+	if err != nil {
+		return "", "", err
+	}
+	return registration.ManagedInstanceID, registration.Region, nil
+}


### PR DESCRIPTION
*Description of changes:*
Uninstall flows to run without requiring node config. The only requirement for node config is the use of region when using SSM as credential provider. This could be obtained from the SSM registration configuration stored on the node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
