### PR TITLE
Install containerd using package manager

### DIFF
--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/eks-hybrid/internal/cli"
 	"github.com/aws/eks-hybrid/internal/cni"
+	"github.com/aws/eks-hybrid/internal/containerd"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/iamauthenticator"
 	"github.com/aws/eks-hybrid/internal/iamrolesanywhere"
@@ -82,6 +83,16 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 			return err
 		}
 		if err := ssm.Uninstall(); err != nil {
+			return err
+		}
+	}
+	if artifacts.Containerd {
+		log.Info("Uninstalling containerd...")
+		containerdDaemon := containerd.NewContainerdDaemon(daemonManager)
+		if err := containerdDaemon.Stop(); err != nil {
+			return err
+		}
+		if err := containerd.Uninstall(); err != nil {
 			return err
 		}
 	}

--- a/cmd/nodeadm/upgrade/upgrade.go
+++ b/cmd/nodeadm/upgrade/upgrade.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/eks-hybrid/internal/cli"
 	"github.com/aws/eks-hybrid/internal/configenricher"
 	"github.com/aws/eks-hybrid/internal/configprovider"
+	"github.com/aws/eks-hybrid/internal/containerd"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/kubelet"
 	"github.com/aws/eks-hybrid/internal/ssm"
@@ -125,6 +126,18 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		}
 
 	}
+
+	if artifacts.Containerd {
+		log.Info("Uninstalling containerd...")
+		containerdDaemon := containerd.NewContainerdDaemon(daemonManager)
+		if err := containerdDaemon.Stop(); err != nil {
+			return err
+		}
+		if err := containerd.Uninstall(); err != nil {
+			return err
+		}
+	}
+
 	if err := tracker.Clear(); err != nil {
 		return err
 	}

--- a/internal/artifact/hybrid.go
+++ b/internal/artifact/hybrid.go
@@ -8,4 +8,5 @@ const (
 	Kubectl                 = "kubectl"
 	Kubelet                 = "kubelet"
 	Ssm                     = "ssm"
+	Containerd              = "containerd"
 )

--- a/internal/artifact/install.go
+++ b/internal/artifact/install.go
@@ -47,3 +47,21 @@ func InstallTarGz(dst string, src string) error {
 	}
 	return nil
 }
+
+func InstallPackage(packageName, packageManager string) error {
+	installCmd := exec.Command(packageManager, "install", packageName, "-y")
+	out, err := installCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("running install command using package manager: %s, error: %v", out, err)
+	}
+	return nil
+}
+
+func UninstallPackage(packageName, packageManager string) error {
+	removeCmd := exec.Command(packageManager, "remove", packageName, "-y")
+	out, err := removeCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("running uninstall command using package manager: %s, error: %v", out, err)
+	}
+	return nil
+}

--- a/internal/containerd/install.go
+++ b/internal/containerd/install.go
@@ -1,0 +1,67 @@
+package containerd
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/aws/eks-hybrid/internal/artifact"
+	"github.com/aws/eks-hybrid/internal/daemon"
+	"github.com/aws/eks-hybrid/internal/tracker"
+	"github.com/aws/eks-hybrid/internal/util"
+)
+
+const (
+	containerdPackageName = "containerd"
+	containerdBinPath     = "/usr/bin/containerd"
+	runcBinPath           = "/usr/bin/runc"
+)
+
+// Install installs containerd on the node using package manager
+// todo: Installs using docker builds with source options
+func Install(tracker *tracker.Tracker) error {
+	// check if containerd or runc is already installed
+	_, containerdErr := os.Stat(containerdBinPath)
+	_, runcErr := os.Stat(runcBinPath)
+	if os.IsNotExist(containerdErr) || os.IsNotExist(runcErr) {
+		pkgManagers, osName := util.GetOsPackageManagers()
+		if osName == util.RhelOsName {
+			return fmt.Errorf("installing containerd is not supported on RedHat Os. Please install containerd " +
+				"and systemd unit for containerd before running nodeadm")
+		}
+
+		for _, manager := range pkgManagers {
+			if err := artifact.InstallPackage(containerdPackageName, manager); err == nil {
+				return tracker.Add(artifact.Containerd)
+			}
+		}
+		return fmt.Errorf("no package managers qualified to install containerd. Please install before running nodeadm")
+	}
+
+	return fs.ErrExist
+}
+
+func Uninstall() error {
+	pkgManagers, _ := util.GetOsPackageManagers()
+	for _, manager := range pkgManagers {
+		if err := artifact.UninstallPackage(containerdPackageName, manager); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("No package managers qualified to remove containerd package")
+}
+
+func ValidateSystemdUnitFile() error {
+	daemonManager, err := daemon.NewDaemonManager()
+	if err != nil {
+		return err
+	}
+	if err := daemonManager.DaemonReload(); err != nil {
+		return err
+	}
+	daemonStatus, err := daemonManager.GetDaemonStatus(ContainerdDaemonName)
+	if daemonStatus == daemon.DaemonStatusUnknown || err != nil {
+		return fmt.Errorf("containerd daemon not found")
+	}
+	return nil
+}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -26,6 +26,8 @@ type DaemonManager interface {
 	// DisableDaemon disables the daemon with the given name.
 	// If the daemon is not enabled, this is a no-op.
 	DisableDaemon(name string) error
+	// DaemonReload will reload all the daemons
+	DaemonReload() error
 	// Close cleans up any underlying resources used by the daemon manager.
 	Close()
 }

--- a/internal/daemon/noop.go
+++ b/internal/daemon/noop.go
@@ -34,4 +34,8 @@ func (m *noopDaemonManager) DisableDaemon(name string) error {
 	return nil
 }
 
+func (m *noopDaemonManager) DaemonReload() error {
+	return nil
+}
+
 func (m *noopDaemonManager) Close() {}

--- a/internal/tracker/artifacts.go
+++ b/internal/tracker/artifacts.go
@@ -19,6 +19,7 @@ type Tracker struct {
 }
 
 type InstalledArtifacts struct {
+	Containerd              bool
 	CniPlugins              bool
 	IamAuthenticator        bool
 	IamRolesAnywhere        bool
@@ -45,6 +46,8 @@ func (tracker *Tracker) Add(componentName string) error {
 		tracker.Artifacts.Kubelet = true
 	case artifact.Ssm:
 		tracker.Artifacts.Ssm = true
+	case artifact.Containerd:
+		tracker.Artifacts.Containerd = true
 	default:
 		return fmt.Errorf("invalid artifact to track")
 	}

--- a/internal/util/os.go
+++ b/internal/util/os.go
@@ -8,10 +8,27 @@ const (
 	UbuntuOsName = "ubuntu"
 	RhelOsName   = "rhel"
 	AmazonOsName = "amzn"
+
+	AptPackageManager  = "apt"
+	SnapPackageManager = "snap"
+	YumPackageManager  = "yum"
 )
 
 // GetOsName reads the /etc/os-release file and returns the os name
 func GetOsName() string {
 	cfg, _ := ini.Load("/etc/os-release")
 	return cfg.Section("").Key("ID").String()
+}
+
+func GetOsPackageManagers() ([]string, string) {
+	osName := GetOsName()
+	packageManagers := map[string][]string{
+		UbuntuOsName: {AptPackageManager, SnapPackageManager},
+		AmazonOsName: {YumPackageManager},
+		RhelOsName:   {YumPackageManager},
+	}
+	if managers, ok := packageManagers[osName]; ok {
+		return managers, osName
+	}
+	return nil, osName
 }


### PR DESCRIPTION
*Description of changes:*
Install containerd using package manager on ubuntu and amazon linux 2023. Skips installation if on RHEL. This also validates presence of containerd unit file to further install, if user installs it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
