### PR TITLE
Install command to run without requiring nodeConfig file

### DIFF
--- a/cmd/nodeadm/upgrade/upgrade.go
+++ b/cmd/nodeadm/upgrade/upgrade.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/eks-hybrid/internal/configenricher"
 	"github.com/aws/eks-hybrid/internal/configprovider"
 	"github.com/aws/eks-hybrid/internal/containerd"
+	"github.com/aws/eks-hybrid/internal/creds"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/kubelet"
 	"github.com/aws/eks-hybrid/internal/ssm"
@@ -142,8 +143,13 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return err
 	}
 
+	credsProvider, err := creds.GetCredentialProviderFromNodeConfig(nodeConfig)
+	if err != nil {
+		return err
+	}
+
 	// Installing new version of artifacts
-	if err := install.Install(ctx, nodeConfig, release, log); err != nil {
+	if err := install.Install(ctx, release, credsProvider, log); err != nil {
 		return err
 	}
 

--- a/internal/creds/creds.go
+++ b/internal/creds/creds.go
@@ -1,0 +1,34 @@
+package creds
+
+import (
+	"fmt"
+
+	"github.com/aws/eks-hybrid/internal/api"
+)
+
+type CredentialProvider string
+
+const (
+	SsmCredentialProvider              CredentialProvider = "ssm"
+	IamRolesAnywhereCredentialProvider CredentialProvider = "iam-ra"
+)
+
+func GetCredentialProvider(credProcess string) (CredentialProvider, error) {
+	switch credProcess {
+	case string(SsmCredentialProvider):
+		return SsmCredentialProvider, nil
+	case string(IamRolesAnywhereCredentialProvider):
+		return IamRolesAnywhereCredentialProvider, nil
+	default:
+		return "", fmt.Errorf("invalid credential process provided. Valid options are ssm and iam")
+	}
+}
+
+func GetCredentialProviderFromNodeConfig(nodeCfg *api.NodeConfig) (CredentialProvider, error) {
+	if nodeCfg.IsSSM() {
+		return SsmCredentialProvider, nil
+	} else if nodeCfg.IsIAMRolesAnywhere() {
+		return IamRolesAnywhereCredentialProvider, nil
+	}
+	return "", fmt.Errorf("no credential process provided in nodeConfig")
+}

--- a/internal/ssm/source.go
+++ b/internal/ssm/source.go
@@ -11,22 +11,24 @@ import (
 	"time"
 )
 
+// Initial region ssm installer is downloaded from. When installer runs, it will
+// down the agent from the proper region configured in the nodeConfig during init command
+const ssmInstallerRegion = "us-west-2"
+
 // SSMInstaller provides a Source that retrieves the SSM installer from the official
 // release endpoint.
-func NewSSMInstaller(region string) Source {
+func NewSSMInstaller() Source {
 	return ssmInstallerSource{
 		client: http.Client{Timeout: 120 * time.Second},
-		region: region,
 	}
 }
 
 type ssmInstallerSource struct {
 	client http.Client
-	region string
 }
 
 func (s ssmInstallerSource) GetSSMInstaller(ctx context.Context) (io.ReadCloser, error) {
-	endpoint, err := buildSSMURL(s.region)
+	endpoint, err := buildSSMURL()
 	if err != nil {
 		return nil, err
 	}
@@ -43,14 +45,14 @@ func (s ssmInstallerSource) GetSSMInstaller(ctx context.Context) (io.ReadCloser,
 	return resp.Body, nil
 }
 
-func buildSSMURL(region string) (string, error) {
+func buildSSMURL() (string, error) {
 	variant, err := detectPlatformVariant()
 	if err != nil {
 		return "", err
 	}
 
 	platform := fmt.Sprintf("%v_%v", variant, runtime.GOARCH)
-	return fmt.Sprintf("https://amazon-ssm-%v.s3.%v.amazonaws.com/latest/%v/ssm-setup-cli", region, region, platform), nil
+	return fmt.Sprintf("https://amazon-ssm-%v.s3.%v.amazonaws.com/latest/%v/ssm-setup-cli", ssmInstallerRegion, ssmInstallerRegion, platform), nil
 }
 
 // detectPlatformVariant returns a portion of the SSM installers URL that is dependent on the


### PR DESCRIPTION
*Description of changes:*
Adding a `--credential-provider` flag for install command to install ssm vs iam roles anywhere, as opposed to requiring nodeConfig as input.

Example:
```
./nodeadm install 1.30 --credential-provider ssm
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
