### PR TITLE
Install iptables on AL2023

### DIFF
--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/eks-hybrid/internal/kubectl"
 	"github.com/aws/eks-hybrid/internal/kubelet"
 	"github.com/aws/eks-hybrid/internal/ssm"
+	"github.com/aws/eks-hybrid/internal/system"
 	"github.com/aws/eks-hybrid/internal/tracker"
 )
 
@@ -85,6 +86,11 @@ func Install(ctx context.Context, eksRelease eks.PatchRelease, credentialProvide
 
 	if err := containerd.ValidateSystemdUnitFile(); err != nil {
 		return fmt.Errorf("please install systemd unit file for containerd: %v", err)
+	}
+
+	log.Info("Checking and installing OS dependencies...")
+	if err := system.InstallIptables(); err != nil {
+		return err
 	}
 
 	switch credentialProvider {

--- a/internal/system/iptables.go
+++ b/internal/system/iptables.go
@@ -1,0 +1,17 @@
+package system
+
+import (
+	"github.com/aws/eks-hybrid/internal/artifact"
+	"github.com/aws/eks-hybrid/internal/util"
+)
+
+func InstallIptables() error {
+	osName := util.GetOsName()
+	if osName == util.AmazonOsName {
+		// AL2023 doesn't come with iptables installed
+		if err := artifact.InstallPackage("iptables", util.YumPackageManager, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
*Description of changes:*
AL2023 doesnt come installed with iptables. Nodeadm will install it during install phase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
