### PR TITLE
Fix: Validate provided eks version to match one of the available releases

### DIFF
--- a/internal/aws/eks/release.go
+++ b/internal/aws/eks/release.go
@@ -93,7 +93,7 @@ func FindLatestRelease(ctx context.Context, version string) (PatchRelease, error
 		return PatchRelease{}, fmt.Errorf("input semver did not match with available releases. Try again with major.minor version")
 	}
 
-	return PatchRelease{}, nil
+	return PatchRelease{}, fmt.Errorf("input semver did not match with any available releases")
 }
 
 // Read from the manifest file on s3 and parse into Manifest struct


### PR DESCRIPTION
*Description of changes:*
Error if the provided release does not match with any of the releases available for nodeadm.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
