### PR TITLE
Re-download SSM agent installer, on checksum mismatch

### DIFF
--- a/internal/node/hybrid/daemons.go
+++ b/internal/node/hybrid/daemons.go
@@ -30,7 +30,7 @@ func (hnp *hybridNodeProvider) GetDaemons() ([]daemon.Daemon, error) {
 
 func (hnp *hybridNodeProvider) PreProcessDaemon() error {
 	if hnp.nodeConfig.IsSSM() {
-		ssmDaemon := ssm.NewSsmDaemon(hnp.daemonManager, hnp.nodeConfig)
+		ssmDaemon := ssm.NewSsmDaemon(hnp.daemonManager, hnp.nodeConfig, hnp.logger)
 		if err := ssmDaemon.Configure(); err != nil {
 			return err
 		}

--- a/internal/ssm/config.go
+++ b/internal/ssm/config.go
@@ -17,7 +17,7 @@ type HybridInstanceRegistration struct {
 }
 
 func (s *ssm) registerMachine(cfg *api.NodeConfig, force bool) error {
-	registerCmd := exec.Command(InstallerPath, "-register", "-activation-code", cfg.Spec.Hybrid.SSM.ActivationCode,
+	registerCmd := exec.Command(installerPath, "-register", "-activation-code", cfg.Spec.Hybrid.SSM.ActivationCode,
 		"-activation-id", cfg.Spec.Hybrid.SSM.ActivationID, "-region", cfg.Spec.Cluster.Region)
 	if force {
 		registerCmd.Args = append(registerCmd.Args, "-override")


### PR DESCRIPTION
*Description of changes:*
SSM's installer `ssm-setup-cli` on every invocation, downloads the latest version of `ssm-setup-cli` and runs a checksum match on the downloaded vs the current process invoked binary. If there is a mismatch, the `ssm-setup-cli` will error out. This change will regex on the error, to figure out if its a checksum mismatch error. If it is, nodeamd will delete the installer and re-download it, and re-try the register command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
