### PR TITLE
Download ssm from configured region when checksum mismatch occurs

### DIFF
--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -127,7 +127,7 @@ func Install(ctx context.Context, eksRelease eks.PatchRelease, credentialProvide
 			return err
 		}
 	case creds.SsmCredentialProvider:
-		ssmInstaller := ssm.NewSSMInstaller()
+		ssmInstaller := ssm.NewSSMInstaller(ssm.DefaultSsmInstallerRegion)
 
 		log.Info("Installing SSM agent installer...")
 		if err := ssm.Install(ctx, trackerConf, ssmInstaller); err != nil && !errors.Is(err, fs.ErrExist) {

--- a/internal/ssm/daemon.go
+++ b/internal/ssm/daemon.go
@@ -49,10 +49,11 @@ func (s *ssm) Configure() error {
 	if err != nil {
 		// SSM register command will download a new ssm agent installer and verify checksums to match with
 		// downloaded and current running agent installer. If checksums do not match, re-download and run
-		// register again.
+		// register again. Checksum mismatch can happen due to new ssm agent releases or switching regions.
 		if match := checksumMismatchErrorRegex.MatchString(err.Error()); match {
-			s.logger.Info("Encountered checksum mismatch on SSM agent installer. Re-downloading...")
-			if err := redownloadInstaller(); err != nil {
+			s.logger.Info("Encountered checksum mismatch on SSM agent installer. Re-downloading installer from",
+				zap.Reflect("region", s.nodeConfig.Spec.Cluster.Region))
+			if err := redownloadInstaller(s.nodeConfig.Spec.Cluster.Region); err != nil {
 				return err
 			}
 			return s.registerMachine(s.nodeConfig, registerOverride)

--- a/internal/ssm/install.go
+++ b/internal/ssm/install.go
@@ -88,7 +88,7 @@ func Uninstall(pkgSource PkgSource) error {
 }
 
 // redownloadInstaller deletes and downloads a new ssm installer
-func redownloadInstaller() error {
+func redownloadInstaller(region string) error {
 	if err := os.RemoveAll(installerPath); err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func redownloadInstaller() error {
 	if err != nil {
 		return err
 	}
-	installer := NewSSMInstaller()
+	installer := NewSSMInstaller(region)
 	if err := Install(context.Background(), trackerConf, installer); err != nil {
 		return err
 	}


### PR DESCRIPTION
*Description of changes:*
Download ssm installer from configured region when redownloading due to checksum mismatch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
