### PR TITLE
Updating e2e instance types for nodeadm validate tests

### DIFF
--- a/crds/node.eks.aws_nodeconfigs.yaml
+++ b/crds/node.eks.aws_nodeconfigs.yaml
@@ -85,11 +85,6 @@ spec:
                     description: IAMRolesAnywhere includes IAM Roles Anywhere specific
                       configuration and is mutually exclusive with SSM.
                     properties:
-                      assumeRoleArn:
-                        description: AssumeRoleARN is the role to assume after authorized
-                          as RoleARN. This role will have permissions to add a node
-                          to the cluster.
-                        type: string
                       awsConfigPath:
                         description: AwsConfigPath is the path where the Aws config
                           is stored for hybrid nodes. This field is only used to init

--- a/internal/validation/validator/os_validate_test.go
+++ b/internal/validation/validator/os_validate_test.go
@@ -70,7 +70,6 @@ func TestOSValidateGetOSError(t *testing.T) {
 	}
 }
 
-
 func FakeOSUbuntuFail() (validator.OS, error) {
 
 	return validator.OS{"ubuntu", "18.04"}, nil

--- a/test/e2e/validate/validate_test.go
+++ b/test/e2e/validate/validate_test.go
@@ -21,13 +21,13 @@ const (
 	passVolumeSize = int64(30)
 	failVolumeSize = int64(10)
 
-	passUbuntuEC2Type                = "t2.large"
+	passUbuntuEC2Type                = "t3.large"
 	failNotEnoughMemoryUbuntuEC2Type = "t3.micro"
-	failNotEnoughCPUUbuntuEC2Type    = "t2.small"
+	failNotEnoughCPUUbuntuEC2Type    = "t3.small"
 	passRhelEC2Type                  = "t4g.xlarge"
 	failNotEnoughMemoryRhelEC2Type   = "t4g.micro"
 	failNotEnoughCPURhelEC2Type      = "c6g.medium"
-	failSuseEC2Type                  = "t2.large"
+	failSuseEC2Type                  = "t3.large"
 
 	ubuntuUserData = `#!/bin/bash
 	echo "ssh_pwauth: false" >> /etc/cloud/cloud.cfg`


### PR DESCRIPTION
*Description of changes:*
Instance types with t2 are getting deprecated. Making them all t3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
