### PR TITLE
Open ports for worker nodes if firewalld or ufw is enabled

### DIFF
--- a/internal/firewall/firewalld.go
+++ b/internal/firewall/firewalld.go
@@ -1,0 +1,75 @@
+package firewall
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+)
+
+const firewalldBinary = "firewall-cmd"
+
+var firewalldActiveRegex = regexp.MustCompile(`.*running*`)
+
+type firewalld struct {
+	binPath string
+}
+
+func NewFirewalld() Manager {
+	path, _ := exec.LookPath(firewalldBinary)
+	return &firewalld{
+		binPath: path,
+	}
+}
+
+// IsEnabled returns true if firewalld is enabled and running on the node
+func (fd *firewalld) IsEnabled() (bool, error) {
+	// Check if firewalld is installed
+	if fd.binPath != "" {
+		enabledCmd := exec.Command(fd.binPath, "--state")
+		out, err := enabledCmd.CombinedOutput()
+		if err != nil {
+			return false, fmt.Errorf("failed to get firewalld status: %s, error: %v", out, err)
+		}
+		// check for running status output
+		if match := firewalldActiveRegex.MatchString(string(out)); match {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// AllowTcpPort adds a rule to the firewall to open input port
+func (fd *firewalld) AllowTcpPort(port string) error {
+	portAddCmd := exec.Command(fd.binPath, "--permanent", fmt.Sprintf("--add-port=%s/tcp", port))
+	out, err := portAddCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to allow port %s in firewall: %s, error: %v", port, out, err)
+	}
+	return nil
+}
+
+// AllowTcpPortRange adds a rule to the firewall to open the range of input port
+func (fd *firewalld) AllowTcpPortRange(startPort, endPort string) error {
+	portAddCmd := exec.Command(fd.binPath, "--permanent", fmt.Sprintf("--add-port=%s-%s/tcp", startPort, endPort))
+	out, err := portAddCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to allow ports in firewall: %s, error: %v", out, err)
+	}
+	return nil
+}
+
+// FlushRules flushes the rules and reloads the firewall to enforce the rules
+func (fd *firewalld) FlushRules() error {
+	reloadCmd := exec.Command(fd.binPath, "--reload")
+	out, err := reloadCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to reload firewall: %s, error: %v", out, err)
+	}
+
+	persistCmd := exec.Command(fd.binPath, "--runtime-to-permanent")
+	out, err = persistCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to persist firewall rules: %s, error: %v", out, err)
+	}
+	return nil
+}

--- a/internal/firewall/interface.go
+++ b/internal/firewall/interface.go
@@ -1,0 +1,16 @@
+package firewall
+
+// Manager is an interface for providing firewall functionalities
+type Manager interface {
+	// IsEnabled returns if firewall is enabled
+	IsEnabled() (bool, error)
+
+	// AllowTcpPort adds a rule to open a port on the host
+	AllowTcpPort(string) error
+
+	// AllowTcpPortRange adds a rule to open a range of port on the host
+	AllowTcpPortRange(string, string) error
+
+	// FlushRules writes newly added rules to disk and reloads the firewall
+	FlushRules() error
+}

--- a/internal/firewall/ufw.go
+++ b/internal/firewall/ufw.go
@@ -1,0 +1,65 @@
+package firewall
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+)
+
+const ufwBinary = "ufw"
+
+var ufwActiveRegex = regexp.MustCompile(`.*Status: active*`)
+
+type UncomplicatedFireWall struct {
+	binPath string
+}
+
+func NewUncomplicatedFirewall() Manager {
+	path, _ := exec.LookPath(ufwBinary)
+	return &UncomplicatedFireWall{
+		binPath: path,
+	}
+}
+
+// IsEnabled returns true if ufw is enabled and running on the node
+func (ufw *UncomplicatedFireWall) IsEnabled() (bool, error) {
+	// Check if ufw is installed
+	if ufw.binPath != "" {
+		statusCmd := exec.Command(ufw.binPath, "status")
+		out, err := statusCmd.CombinedOutput()
+		if err != nil {
+			return false, fmt.Errorf("failed to get status of uncomplicated firewall: %s, error: %v", out, err)
+		}
+		// Check for active status output
+		if match := ufwActiveRegex.MatchString(string(out)); match {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// AllowTcpPort adds a rule to the firewall to open input port
+func (ufw *UncomplicatedFireWall) AllowTcpPort(port string) error {
+	portAddCmd := exec.Command(ufw.binPath, "allow", fmt.Sprintf("%s/tcp", port))
+	out, err := portAddCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to allow port %s in firewall: %s, error: %v", port, out, err)
+	}
+	return nil
+}
+
+// AllowTcpPortRange adds a rule to the firewall to open the range of input port
+func (ufw *UncomplicatedFireWall) AllowTcpPortRange(startPort, endPort string) error {
+	portAddCmd := exec.Command(ufw.binPath, "allow", fmt.Sprintf("%s:%s/tcp", startPort, endPort))
+	out, err := portAddCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to allow ports in firewall: %s, error: %v", out, err)
+	}
+	return nil
+}
+
+// FlushRules flushes the rules and reloads the firewall to enforce the rules
+func (ufw *UncomplicatedFireWall) FlushRules() error {
+	// UFW activates the rules the moment its added, there is no need to flush them out to disk explicitly
+	return nil
+}

--- a/internal/node/hybrid/aspects.go
+++ b/internal/node/hybrid/aspects.go
@@ -6,5 +6,6 @@ func (hnp *hybridNodeProvider) GetAspects() []system.SystemAspect {
 	return []system.SystemAspect{
 		system.NewSysctlAspect(hnp.nodeConfig),
 		system.NewSwapAspect(hnp.nodeConfig),
+		system.NewPortsAspect(hnp.nodeConfig, hnp.logger),
 	}
 }

--- a/internal/system/ports.go
+++ b/internal/system/ports.go
@@ -1,0 +1,73 @@
+package system
+
+import (
+	"fmt"
+	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/api"
+	"github.com/aws/eks-hybrid/internal/firewall"
+)
+
+const (
+	portsAspectName        = "ports"
+	kubeletServePort       = "10250"
+	kubeProxyHealthzPort   = "10256"
+	nodePortStartRangePort = "30000"
+	nodePortEndRangePort   = "32767"
+)
+
+type portsAspect struct {
+	nodeConfig      *api.NodeConfig
+	logger          *zap.Logger
+	firewallManager firewall.Manager
+}
+
+var _ SystemAspect = &portsAspect{}
+
+func NewPortsAspect(cfg *api.NodeConfig, logger *zap.Logger) SystemAspect {
+	var firewallManager firewall.Manager
+	osName := GetOsName()
+	if osName == UbuntuOsName {
+		firewallManager = firewall.NewUncomplicatedFirewall()
+	} else {
+		firewallManager = firewall.NewFirewalld()
+	}
+	return &portsAspect{
+		nodeConfig:      cfg,
+		logger:          logger,
+		firewallManager: firewallManager,
+	}
+}
+
+func (s *portsAspect) Name() string {
+	return portsAspectName
+}
+
+func (s *portsAspect) Setup() error {
+	firewallEnabled, err := s.firewallManager.IsEnabled()
+	if err != nil {
+		return err
+	}
+	if firewallEnabled {
+		s.logger.Info("Allowing port on firewall", zap.Reflect("kubelet-server-port", kubeletServePort))
+		if err = s.firewallManager.AllowTcpPort(kubeletServePort); err != nil {
+			return err
+		}
+		s.logger.Info("Allowing port on firewall", zap.Reflect("kube-proxy-port", kubeProxyHealthzPort))
+		if err = s.firewallManager.AllowTcpPort(kubeProxyHealthzPort); err != nil {
+			return err
+		}
+		s.logger.Info("Allowing port on firewall", zap.Reflect("node-port-services",
+			fmt.Sprintf("%s-%s", nodePortStartRangePort, nodePortStartRangePort)))
+		if err = s.firewallManager.AllowTcpPortRange(nodePortStartRangePort, nodePortEndRangePort); err != nil {
+			return err
+		}
+		s.logger.Info("Flushing firewall rules")
+		if err = s.firewallManager.FlushRules(); err != nil {
+			return err
+		}
+	} else {
+		s.logger.Info("No firewall enabled on the host. Skipping setting firewall rules...")
+	}
+	return nil
+}


### PR DESCRIPTION
*Description of changes:*
Modern operating systems come with firewall enabled depending on their configuration. Firewall when enabled, can cause the cluster to be non-operational or other issues after the node joins the cluster. This PR addresses two most common firewalls present in the supported operating systems. 
- firewalld in yum OSes like Amazon linux 2023 & RHEL
- ufw in Ubuntu 22, 24

If the firewall is present and enabled, nodeadm will open up ports that are required for normal cluster operations. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
