### PR TITLE
Install to overwrite artifacts if they exists

### DIFF
--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"io/fs"
-
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 
@@ -123,14 +121,14 @@ func Install(ctx context.Context, eksRelease eks.PatchRelease, credentialProvide
 		signingHelper := iamrolesanywhere.NewSigningHelper()
 
 		log.Info("Installing AWS signing helper...")
-		if err := iamrolesanywhere.Install(ctx, trackerConf, signingHelper); err != nil && !errors.Is(err, fs.ErrExist) {
+		if err := iamrolesanywhere.Install(ctx, trackerConf, signingHelper); err != nil {
 			return err
 		}
 	case creds.SsmCredentialProvider:
 		ssmInstaller := ssm.NewSSMInstaller(ssm.DefaultSsmInstallerRegion)
 
 		log.Info("Installing SSM agent installer...")
-		if err := ssm.Install(ctx, trackerConf, ssmInstaller); err != nil && !errors.Is(err, fs.ErrExist) {
+		if err := ssm.Install(ctx, trackerConf, ssmInstaller); err != nil {
 			return err
 		}
 	default:
@@ -138,27 +136,27 @@ func Install(ctx context.Context, eksRelease eks.PatchRelease, credentialProvide
 	}
 
 	log.Info("Installing kubelet...")
-	if err := kubelet.Install(ctx, trackerConf, eksRelease); err != nil && !errors.Is(err, fs.ErrExist) {
+	if err := kubelet.Install(ctx, trackerConf, eksRelease); err != nil {
 		return err
 	}
 
 	log.Info("Installing kubectl...")
-	if err := kubectl.Install(ctx, trackerConf, eksRelease); err != nil && !errors.Is(err, fs.ErrExist) {
+	if err := kubectl.Install(ctx, trackerConf, eksRelease); err != nil {
 		return err
 	}
 
 	log.Info("Installing cni-plugins...")
-	if err := cni.Install(ctx, trackerConf, eksRelease); err != nil && !errors.Is(err, fs.ErrExist) {
+	if err := cni.Install(ctx, trackerConf, eksRelease); err != nil {
 		return err
 	}
 
 	log.Info("Installing image credential provider...")
-	if err := imagecredentialprovider.Install(ctx, trackerConf, eksRelease); err != nil && !errors.Is(err, fs.ErrExist) {
+	if err := imagecredentialprovider.Install(ctx, trackerConf, eksRelease); err != nil {
 		return err
 	}
 
 	log.Info("Installing IAM authenticator...")
-	if err := iamauthenticator.Install(ctx, trackerConf, eksRelease); err != nil && !errors.Is(err, fs.ErrExist) {
+	if err := iamauthenticator.Install(ctx, trackerConf, eksRelease); err != nil {
 		return err
 	}
 

--- a/internal/artifact/install.go
+++ b/internal/artifact/install.go
@@ -20,7 +20,7 @@ func InstallFile(dst string, src io.Reader, perms fs.FileMode) error {
 		return err
 	}
 
-	fh, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_RDWR, perms)
+	fh, err := os.OpenFile(dst, os.O_CREATE|os.O_RDWR|os.O_TRUNC, perms)
 	if err != nil {
 		return err
 	}
@@ -32,6 +32,9 @@ func InstallFile(dst string, src io.Reader, perms fs.FileMode) error {
 
 // InstallTarGz untars the src file into the dst directory and deletes the src tgz file
 func InstallTarGz(dst string, src string) error {
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(dst, DefaultDirPerms); err != nil {
 		return err
 	}

--- a/internal/artifact/install_test.go
+++ b/internal/artifact/install_test.go
@@ -52,7 +52,7 @@ func TestInstallFile_FileExists(t *testing.T) {
 	}
 
 	err := artifact.InstallFile(dst, src, perms)
-	if !os.IsExist(err) {
+	if err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/cni/install.go
+++ b/internal/cni/install.go
@@ -32,12 +32,12 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 	if err := artifact.InstallFile(TgzPath, cniPlugins, 0755); err != nil {
 		return fmt.Errorf("cni-plugins: %w", err)
 	}
-	if err = tracker.Add(artifact.CniPlugins); err != nil {
-		return err
-	}
 
 	if !cniPlugins.VerifyChecksum() {
 		return fmt.Errorf("cni-plugins: %w", artifact.NewChecksumError(cniPlugins))
+	}
+	if err = tracker.Add(artifact.CniPlugins); err != nil {
+		return err
 	}
 
 	if err := artifact.InstallTarGz(BinPath, TgzPath); err != nil {

--- a/internal/iamauthenticator/install.go
+++ b/internal/iamauthenticator/install.go
@@ -29,12 +29,12 @@ func Install(ctx context.Context, tracker *tracker.Tracker, iamAuthSrc IAMAuthen
 	if err := artifact.InstallFile(IAMAuthenticatorBinPath, authenticator, 0755); err != nil {
 		return fmt.Errorf("aws-iam-authenticator: %w", err)
 	}
-	if err = tracker.Add(artifact.IamAuthenticator); err != nil {
-		return err
-	}
 
 	if !authenticator.VerifyChecksum() {
 		return fmt.Errorf("aws-iam-authenticator: %w", artifact.NewChecksumError(authenticator))
+	}
+	if err = tracker.Add(artifact.IamAuthenticator); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/imagecredentialprovider/install.go
+++ b/internal/imagecredentialprovider/install.go
@@ -28,12 +28,12 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 	if err := artifact.InstallFile(BinPath, imageCredentialProvider, 0755); err != nil {
 		return fmt.Errorf("image-credential-provider: %w", err)
 	}
-	if err = tracker.Add(artifact.ImageCredentialProvider); err != nil {
-		return err
-	}
 
 	if !imageCredentialProvider.VerifyChecksum() {
 		return fmt.Errorf("image-credential-provider: %w", artifact.NewChecksumError(imageCredentialProvider))
+	}
+	if err = tracker.Add(artifact.ImageCredentialProvider); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/kubectl/install.go
+++ b/internal/kubectl/install.go
@@ -28,12 +28,12 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 	if err := artifact.InstallFile(BinPath, kubectl, 0755); err != nil {
 		return fmt.Errorf("kubectl: %w", err)
 	}
-	if err = tracker.Add(artifact.Kubectl); err != nil {
-		return err
-	}
 
 	if !kubectl.VerifyChecksum() {
 		return fmt.Errorf("kubectl: %w", artifact.NewChecksumError(kubectl))
+	}
+	if err = tracker.Add(artifact.Kubectl); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/kubelet/install.go
+++ b/internal/kubelet/install.go
@@ -39,12 +39,12 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 	if err := artifact.InstallFile(BinPath, kubelet, 0755); err != nil {
 		return fmt.Errorf("kubelet: %w", err)
 	}
-	if err = tracker.Add(artifact.Kubelet); err != nil {
-		return err
-	}
 
 	if !kubelet.VerifyChecksum() {
 		return fmt.Errorf("kubelet: %w", artifact.NewChecksumError(kubelet))
+	}
+	if err = tracker.Add(artifact.Kubelet); err != nil {
+		return err
 	}
 
 	buf := bytes.NewBuffer(kubeletUnitFile)


### PR DESCRIPTION
*Description of changes:*
Post install the node needs to be in an "Expected state" to ensure desired cluster operation after the node has joined the cluster. With this change, install will overwrite existing artifacts if any, checksum validate the artifacts and only then save the artifact in the tracker file. Exceptions to the artifacts being containerd, since the expectation for now is there is a containerd installed and not any particular version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
