### PR TITLE
Setup EKS hybrid ci architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,3 +175,7 @@ $(GOLANGCI_LINT): $(LOCALBIN) $(GOLANGCI_LINT_CONFIG)
 .PHONY: e2e-tests-binary
 e2e-tests-binary:
 	GOMAXPROCS=10 go test ./test/e2e/validate -c -o "./_bin/e2e.test" -tags "e2e"
+
+.PHONY: e2e-setup
+e2e-setup:
+	go build -o _bin/e2e-test-runner ./cmd/nodeadm/e2e-test-runner/main.go 

--- a/cmd/nodeadm/e2e-test-runner/cmd/cleanup/cleanup.go
+++ b/cmd/nodeadm/e2e-test-runner/cmd/cleanup/cleanup.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/aws/eks-hybrid/internal/cli"
+	"github.com/integrii/flaggy"
+	"go.uber.org/zap"
+)
+
+type command struct {
+	flaggy *flaggy.Subcommand
+}
+
+func NewCleanupCommand() cli.Command {
+	cmd := command{}
+
+	cleanup := flaggy.NewSubcommand("cleanup")
+	cleanup.Description = "Cleaning up E2E test architecture"
+	cleanup.AdditionalHelpPrepend = "This command will cleanup E2E test architecture."
+
+	cmd.flaggy = cleanup
+
+	return &cmd
+}
+
+func (c *command) Flaggy() *flaggy.Subcommand {
+	return c.flaggy
+}
+
+func (s *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+	fmt.Println("Cleaning up E2E resources...")
+	// clean up logic
+	return nil
+}

--- a/cmd/nodeadm/e2e-test-runner/cmd/setup/setup.go
+++ b/cmd/nodeadm/e2e-test-runner/cmd/setup/setup.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/integrii/flaggy"
+	"go.uber.org/zap"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/eks-hybrid/internal/cli"
+	"github.com/aws/eks-hybrid/internal/test/e2e"
+)
+
+type command struct {
+	flaggy        *flaggy.Subcommand
+	clusterConfig e2e.ClusterConfig
+}
+
+func NewSetupCommand() cli.Command {
+	cmd := command{}
+
+	setupCmd := flaggy.NewSubcommand("setup")
+	setupCmd.Description = "Setup E2E test architecture"
+	setupCmd.AdditionalHelpPrepend = "This command will run the setup architecture for running E2E tests"
+
+	setupCmd.String(&cmd.clusterConfig.ClusterName, "c", "clustername", "Name of the EKS cluster")
+	setupCmd.String(&cmd.clusterConfig.ClusterRegion, "r", "region", "AWS region where the cluster is created")
+	setupCmd.StringSlice(&cmd.clusterConfig.KubernetesVersions, "k", "kubernetes-versions", "List of supported kubernetes versions")
+	setupCmd.String(&cmd.clusterConfig.ClusterVpcCidr, "v", "cluster-vpc-cidr", "EKS cluster VPC CIDR")
+	setupCmd.String(&cmd.clusterConfig.ClusterPublicSubnetCidr, "u", "cluster-public-subnet", "CIDR for public subnet of EKS VPC")
+	setupCmd.String(&cmd.clusterConfig.ClusterPrivateSubnetCidr, "s", "cluster-private-subnet", "CIDR for private subnet of EKS VPC")
+	setupCmd.String(&cmd.clusterConfig.HybridNodeCidr, "e", "ec2-vpc-cidr", "CIDR for hybrid EC2 VPC")
+	setupCmd.String(&cmd.clusterConfig.HybridPodCidr, "p", "ec2-pod-cidr", "Hybrid EC2 instance pod CIDR")
+	setupCmd.String(&cmd.clusterConfig.HybridPubicSubnetCidr, "b", "ec2-public-subnet", "CIDR for public subnet of hybrid EC2 VPC")
+	setupCmd.String(&cmd.clusterConfig.HybridPrivateSubnetCidr, "i", "ec2-private-cidr", "CIDR for private subnet of hybrid EC2 VPC")
+	setupCmd.StringSlice(&cmd.clusterConfig.Networking, "n", "cnis", "List of supported CNIs")
+
+	cmd.flaggy = setupCmd
+
+	return &cmd
+}
+
+func (c *command) Flaggy() *flaggy.Subcommand {
+	return c.flaggy
+}
+
+func (s *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+	fmt.Println("Starting cluster setup...")
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(s.clusterConfig.ClusterRegion),
+	})
+	if err != nil {
+		return fmt.Errorf("error creating AWS session: %v", err)
+	}
+
+	s.clusterConfig.Session = sess
+
+	err = e2e.CreateResources(&s.clusterConfig)
+	if err != nil {
+		fmt.Println(err)
+		return fmt.Errorf("error while setting up E2E test architecture: %v", err)
+	}
+
+	fmt.Println("Cluster setup completed successfully!")
+	return nil
+}

--- a/cmd/nodeadm/e2e-test-runner/main.go
+++ b/cmd/nodeadm/e2e-test-runner/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	cleanup "github.com/aws/eks-hybrid/cmd/nodeadm/e2e-test-runner/cmd/cleanup"
+	setup "github.com/aws/eks-hybrid/cmd/nodeadm/e2e-test-runner/cmd/setup"
+	"github.com/aws/eks-hybrid/internal/cli"
+	"github.com/integrii/flaggy"
+	"go.uber.org/zap"
+)
+
+func main() {
+	flaggy.SetName("e2e-test-runner")
+	flaggy.SetDescription("An E2E test runner for setting up test architecture for E2E tests")
+
+	cmds := []cli.Command{
+		setup.NewSetupCommand(),
+		cleanup.NewCleanupCommand(),
+	}
+
+	for _, cmd := range cmds {
+		flaggy.AttachSubcommand(cmd.Flaggy(), 1)
+	}
+
+	flaggy.Parse()
+
+	opts := cli.NewGlobalOptions()
+	log := cli.NewLogger(opts)
+
+	for _, cmd := range cmds {
+		if cmd.Flaggy().Used {
+			err := cmd.Run(log, opts)
+			if err != nil {
+				log.Fatal("Command failed", zap.Error(err))
+			}
+			return
+		}
+	}
+	flaggy.ShowHelpAndExit("No command specified")
+}

--- a/go.mod
+++ b/go.mod
@@ -37,8 +37,8 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/tools v0.22.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
-	google.golang.org/grpc v1.59.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240314234333-6e1732d8331c // indirect
+	google.golang.org/grpc v1.62.1 // indirect
 	k8s.io/component-base v0.29.5 // indirect
 )
 
@@ -87,7 +87,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.29.5
 	k8s.io/klog/v2 v2.110.1 // indirect
-	k8s.io/utils v0.0.0-20240102154912-e7106e64919e // indirect; direct
+	k8s.io/utils v0.0.0-20240102154912-e7106e64919e // direct
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -190,10 +190,10 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f h1:ultW7fxlIvee4HYrtnaRPon9HpEgFk5zYpmfMgtKB5I=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f/go.mod h1:L9KNLi232K1/xB6f7AlSX692koaRnKaWSR0stBki0Yc=
-google.golang.org/grpc v1.59.0 h1:Z5Iec2pjwb+LEOqzpB2MR12/eKFhDPhuqW91O+4bwUk=
-google.golang.org/grpc v1.59.0/go.mod h1:aUPDwccQo6OTjy7Hct4AfBPD1GptF4fyUjIkQ9YtF98=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240314234333-6e1732d8331c h1:lfpJ/2rWPa/kJgxyyXM8PrNnfCzcmxJ265mADgwmvLI=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240314234333-6e1732d8331c/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
+google.golang.org/grpc v1.62.1 h1:B4n+nfKzOICUXMgyrNd19h/I9oH0L1pizfk1d4zSgTk=
+google.golang.org/grpc v1.62.1/go.mod h1:IWTG0VlJLCh1SkC58F7np9ka9mx/WNkjl4PGJaiq+QE=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/test/e2e/cluster.go
+++ b/internal/test/e2e/cluster.go
@@ -1,0 +1,67 @@
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+)
+
+func (config *ClusterConfig) createEKSCluster(clusterName, kubernetesVersion string) error {
+	// Join the subnet IDs into a single comma-separated string
+	subnetIdsStr := strings.Join(config.ClusterSubnetIDs, ",")
+	hybridNetworkConfig := fmt.Sprintf(`{"remoteNodeNetworks":[{"cidrs":["%s"]}],"remotePodNetworks":[{"cidrs":["%s"]}]}`, config.HybridNodeCidr, config.HybridPodCidr)
+
+	// AWS CLI command to create the cluster
+	cmd := exec.Command("aws", "eksbeta", "create-cluster",
+		"--name", clusterName,
+		"--endpoint-url", fmt.Sprintf("https://eks.%s.amazonaws.com", config.ClusterRegion),
+		"--role-arn", config.RoleArn,
+		"--resources-vpc-config", fmt.Sprintf("subnetIds=%s", subnetIdsStr),
+		"--remote-network-config", hybridNetworkConfig,
+		"--access-config", "authenticationMode=API_AND_CONFIG_MAP",
+		"--tags", "Name=hybrid-eks-cluster,App=hybrid-eks-beta")
+
+	// Run the command and get the output
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println(err)
+		return fmt.Errorf("failed to create EKS cluster: %v\nOutput: %s", err, string(output))
+	}
+
+	fmt.Printf("Successfully started creating EKS cluster: %s\nOutput: %s", clusterName, string(output))
+	return nil
+}
+
+// waitForClusterCreation waits until the EKS cluster is in the 'ACTIVE' state.
+func (config *ClusterConfig) waitForClusterCreation(clusterName string) error {
+	svc := eks.New(config.Session)
+
+	fmt.Printf("Waiting for cluster %s to be created...\n", clusterName)
+
+	// Poll the cluster status every 30 secs
+	for {
+		input := &eks.DescribeClusterInput{
+			Name: aws.String(clusterName),
+		}
+
+		result, err := svc.DescribeCluster(input)
+		if err != nil {
+			return fmt.Errorf("failed to describe cluster: %v", err)
+		}
+
+		clusterStatus := *result.Cluster.Status
+		if clusterStatus == eks.ClusterStatusActive {
+			fmt.Printf("Cluster %s is now active.\n", clusterName)
+			break
+		}
+
+		fmt.Printf("Cluster status: %s. Waiting...\n", clusterStatus)
+		time.Sleep(30 * time.Second) // Wait for 30 seconds before checking again
+	}
+
+	return nil
+}

--- a/internal/test/e2e/iam.go
+++ b/internal/test/e2e/iam.go
@@ -1,0 +1,49 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+const assumeRolePolicyDocument = `{
+	"Version": "2012-10-17",
+	"Statement": [
+	  {
+		"Effect": "Allow",
+		"Principal": {
+		  "Service": "eks.amazonaws.com"
+		},
+		"Action": "sts:AssumeRole"
+	  }
+	]
+  }`
+
+const eksClusterPolicyArn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+
+func (config *ClusterConfig) createEKSClusterRole() (string, error) {
+	svc := iam.New(config.Session)
+	roleName := fmt.Sprintf("%s-eks-role", config.ClusterName)
+
+	// Create IAM role
+	role, err := svc.CreateRole(&iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(assumeRolePolicyDocument),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create role: %v", err)
+	}
+
+	// Attach AmazonEKSClusterPolicy
+	_, err = svc.AttachRolePolicy(&iam.AttachRolePolicyInput{
+		RoleName:  aws.String(roleName),
+		PolicyArn: aws.String(eksClusterPolicyArn),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to attach policy: %v", err)
+	}
+
+	fmt.Printf("Successfully created IAM role: %s\n", *role.Role.Arn)
+	return *role.Role.Arn, nil
+}

--- a/internal/test/e2e/patchawscli.go
+++ b/internal/test/e2e/patchawscli.go
@@ -1,0 +1,38 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// patchEksServiceModel downloads a patch from an S3 bucket to a local directory and applies to the AWS CLI installation
+func patchEksServiceModel(awsPatchLocation string, localDir string) error {
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create local directory: %v", err)
+	}
+
+	patchFilePath := filepath.Join(localDir, filepath.Base(awsPatchLocation))
+
+	cmd := exec.Command("aws", "s3", "cp", awsPatchLocation, patchFilePath)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to download patch from S3: %v\nOutput: %s", err, string(output))
+	}
+
+	fmt.Printf("Successfully downloaded patch to: %s\n", patchFilePath)
+
+	cmd = exec.Command("aws", "configure", "add-model",
+		"--service-model", fmt.Sprintf("file://%s", patchFilePath),
+		"--service-name", "eksbeta")
+	// Run the command and capture output
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to apply patch: %v\nOutput: %s", err, string(output))
+	}
+
+	fmt.Printf("Successfully applied patch to AWS CLI: %s\n", patchFilePath)
+	return nil
+}

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -1,0 +1,211 @@
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+type ClusterConfig struct {
+	Session                  *session.Session
+	ClusterName              string
+	ClusterVpcCidr           string
+	ClusterPrivateSubnetCidr string
+	ClusterPublicSubnetCidr  string
+	ClusterRegion            string
+	PatchLocation            string
+	HybridNodeCidr           string
+	HybridPubicSubnetCidr    string
+	HybridPrivateSubnetCidr  string
+	HybridPodCidr            string
+	KubernetesVersions       []string
+	Networking               []string
+	RoleArn                  string
+	ClusterVpcID             string
+	ClusterSubnetIDs         []string
+	HybridVpcID              string
+	PeeringConnID            string
+}
+
+var awsNodePatchContent = `
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - "linux"
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - "amd64"
+                - "arm64"
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - "hybrid"
+`
+
+var authConfig = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-auth
+  namespace: kube-system
+data:
+  mapRoles: |
+`
+
+func CreateResources(config *ClusterConfig) error {
+	// Temporary code, remove this when AWS CLI supports creating hybrid EKS cluster
+	awsPatchLocation := "s3://eks-hybrid-beta/v0.0.0-beta.1/awscli/aws-eks-cli-beta.json"
+	localFilePath := "/tmp/awsclipatch"
+	err := patchEksServiceModel(awsPatchLocation, localFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to download aws cli patch that contains hybrid nodes API: %v", err)
+	}
+
+	// Create EKS cluster role
+	fmt.Println("Creating EKS cluster IAM Role...")
+	config.RoleArn, err = config.createEKSClusterRole()
+	if err != nil {
+		return fmt.Errorf("error creating IAM role: %v", err)
+	}
+
+	// Create EKS cluster VPC
+	clusterVpcParam := vpcSubnetParams{
+		vpcName:           fmt.Sprintf("%s-vpc", config.ClusterName),
+		vpcCidr:           config.ClusterVpcCidr,
+		publicSubnetCidr:  config.ClusterPublicSubnetCidr,
+		privateSubnetCidr: config.ClusterPrivateSubnetCidr,
+	}
+	fmt.Println("Creating EKS cluster VPC...")
+	clusterVpcConfig, err := config.createVPC(clusterVpcParam)
+	if err != nil {
+		return fmt.Errorf("error creating cluster VPC: %v", err)
+	}
+	config.ClusterVpcID = clusterVpcConfig.vpcID
+	config.ClusterSubnetIDs = clusterVpcConfig.subnetIDs
+
+	// Create hybrid nodes VPC
+	hybridNodesVpcParam := vpcSubnetParams{
+		vpcName:           fmt.Sprintf("%s-hybrid-node-vpc", config.ClusterName),
+		vpcCidr:           config.HybridNodeCidr,
+		publicSubnetCidr:  config.HybridPubicSubnetCidr,
+		privateSubnetCidr: config.HybridPrivateSubnetCidr,
+	}
+	fmt.Println("Creating EC2 hybrid nodes VPC...")
+	hybridNodesVpcConfig, err := config.createVPC(hybridNodesVpcParam)
+	if err != nil {
+		return fmt.Errorf("error creating EC2 hybrid nodes VPC: %v", err)
+	}
+	config.HybridVpcID = hybridNodesVpcConfig.vpcID
+
+	// Create VPC Peering Connection between the cluster VPC and EC2 hybrid nodes VPC
+	fmt.Println("Creating VPC peering connection...")
+	config.PeeringConnID, err = config.createVPCPeering()
+	if err != nil {
+		return fmt.Errorf("error creating VPC peering connection: %v", err)
+	}
+
+	// Update route tables for peering connection
+	fmt.Println("Updating route tables for VPC peering...")
+	err = config.updateRouteTablesForPeering()
+	if err != nil {
+		return fmt.Errorf("error updating route tables: %v", err)
+	}
+
+	// Create the EKS Cluster using the IAM role and VPC
+	for _, kubernetesVersion := range config.KubernetesVersions {
+		fmt.Printf("Creating EKS cluster with the kubernetes version %s..", kubernetesVersion)
+		clusterName := fmt.Sprintf("%s-%s", config.ClusterName, strings.Replace(kubernetesVersion, ".", "-", -1))
+		err := config.createEKSCluster(clusterName, kubernetesVersion)
+		if err != nil {
+			return fmt.Errorf("error creating %s EKS cluster: %v", kubernetesVersion, err)
+		}
+
+		fmt.Printf("Cluster creation of kubernetes version %s process started successfully..", kubernetesVersion)
+
+		// Wait for the cluster to be ready
+		err = config.waitForClusterCreation(clusterName)
+		if err != nil {
+			return fmt.Errorf("error while waiting for cluster creation: %v", err)
+		}
+
+		// Save kubeconfig file for the created cluster under /tmp/eks-hybrid/CULSTERNAME-kubeconfig dir to use it late in e2e test run
+		kubeconfigFilePath := filepath.Join("/tmp/eks-hybrid", fmt.Sprintf("%s.kubeconfig", clusterName))
+		err = saveKubeconfig(clusterName, config.ClusterRegion, kubeconfigFilePath)
+		if err != nil {
+			return fmt.Errorf("error saving kubeconfig for %s EKS cluster: %v", kubernetesVersion, err)
+		}
+
+		fmt.Printf("Kubeconfig saved at: %s\n", kubeconfigFilePath)
+
+		// Patch aws-node DaemonSet to update the VPC CNI with anti-affinity for nodes labeled with the default hybrid nodes label eks.amazonaws.com/compute-type: hybrid
+		fmt.Println("Patching aws-node DaemonSet...")
+		err = patchAwsNode(kubeconfigFilePath)
+		if err != nil {
+			return fmt.Errorf("error patching aws-node DaemonSet for %s EKS cluster: %v", kubernetesVersion, err)
+		}
+
+		// Apply aws-auth ConfigMap
+		fmt.Println("Applying aws-auth ConfigMap...")
+		err = applyAwsAuth(kubeconfigFilePath)
+		if err != nil {
+			return fmt.Errorf("error applying aws-auth ConfigMap for %s EKS cluster: %v", kubernetesVersion, err)
+		}
+	}
+
+	return nil
+}
+
+// saveKubeconfig saves the kubeconfig for the cluster
+func saveKubeconfig(clusterName, region, kubeconfigPath string) error {
+	cmd := exec.Command("aws", "eks", "update-kubeconfig", "--name", clusterName, "--region", region, "--kubeconfig", kubeconfigPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// patchAwsNode patches the aws-node DaemonSet
+func patchAwsNode(kubeconfig string) error {
+	// Patch aws-node using stdin
+	cmd := exec.Command("kubectl", "--kubeconfig", kubeconfig, "patch", "ds", "aws-node", "-n", "kube-system", "--type", "merge", "--patch-file=/dev/stdin")
+	cmd.Stdin = bytes.NewReader([]byte(awsNodePatchContent))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	fmt.Println(cmd)
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to patch aws-node DaemonSet: %v", err)
+	}
+
+	fmt.Println("Successfully patched aws-node DaemonSet")
+	return nil
+}
+
+// applyAwsAuth applies the aws-auth configmap
+func applyAwsAuth(kubeconfig string) error {
+	cmd := exec.Command("kubectl", "--kubeconfig", kubeconfig, "apply", "-f", "/dev/stdin")
+	cmd.Stdin = bytes.NewReader([]byte(authConfig))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to apply aws-auth ConfigMap: %v", err)
+	}
+
+	fmt.Println("Successfully applied aws-auth ConfigMap with empty mapRoles")
+	return nil
+}

--- a/internal/test/e2e/vpc.go
+++ b/internal/test/e2e/vpc.go
@@ -1,0 +1,200 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// vpcConfig holds information about the VPC and its subnets
+type vpcConfig struct {
+	vpcID     string
+	subnetIDs []string
+}
+
+// vpcSubnetParams holds information about the VPC params
+type vpcSubnetParams struct {
+	vpcName           string
+	vpcCidr           string
+	publicSubnetCidr  string
+	privateSubnetCidr string
+}
+
+// CreateVPC creates a VPC and the associated subnets (public and private)
+func (config *ClusterConfig) createVPC(vpcSubnetParams vpcSubnetParams) (*vpcConfig, error) {
+	svc := ec2.New(config.Session)
+
+	// Create VPC
+	vpcOutput, err := svc.CreateVpc(&ec2.CreateVpcInput{
+		CidrBlock: aws.String(vpcSubnetParams.vpcCidr),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VPC: %v", err)
+	}
+
+	vpcId := *vpcOutput.Vpc.VpcId
+
+	// Tag the VPC
+	_, err = svc.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{&vpcId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(vpcSubnetParams.vpcName),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to tag VPC: %v", err)
+	}
+
+	fmt.Printf("Successfully created VPC: %s\n", vpcId)
+
+	// Create a public subnet
+	publicSubnet, err := svc.CreateSubnet(&ec2.CreateSubnetInput{
+		VpcId:            aws.String(vpcId),
+		CidrBlock:        aws.String(vpcSubnetParams.publicSubnetCidr),
+		AvailabilityZone: aws.String(config.ClusterRegion + "a"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create public subnet: %v", err)
+	}
+
+	publicSubnetId := *publicSubnet.Subnet.SubnetId
+	fmt.Printf("Successfully created public subnet: %s\n", publicSubnetId)
+
+	// Tag the public subnet
+	_, err = svc.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{&publicSubnetId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(vpcSubnetParams.vpcName + "-public-subnet"),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to tag public subnet: %v", err)
+	}
+
+	// Create a private subnet
+	privateSubnet, err := svc.CreateSubnet(&ec2.CreateSubnetInput{
+		VpcId:            aws.String(vpcId),
+		CidrBlock:        aws.String(vpcSubnetParams.privateSubnetCidr),
+		AvailabilityZone: aws.String(config.ClusterRegion + "b"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create private subnet: %v", err)
+	}
+
+	privateSubnetId := *privateSubnet.Subnet.SubnetId
+	fmt.Printf("Successfully created private subnet: %s\n", privateSubnetId)
+
+	// Tag the private subnet
+	_, err = svc.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{&privateSubnetId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(vpcSubnetParams.vpcName + "-private-subnet"),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to tag private subnet: %v", err)
+	}
+
+	// Return VPC and subnet information
+	vpcConfig := &vpcConfig{
+		vpcID:     vpcId,
+		subnetIDs: []string{publicSubnetId, privateSubnetId},
+	}
+
+	return vpcConfig, nil
+}
+
+// CreateVPCPeering creates a VPC peering connection between two VPCs
+func (config *ClusterConfig) createVPCPeering() (string, error) {
+	svc := ec2.New(config.Session)
+
+	// Create VPC peering connection
+	result, err := svc.CreateVpcPeeringConnection(&ec2.CreateVpcPeeringConnectionInput{
+		VpcId:     aws.String(config.ClusterVpcID),
+		PeerVpcId: aws.String(config.HybridVpcID),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create VPC peering connection: %v", err)
+	}
+
+	peeringConnectionID := *result.VpcPeeringConnection.VpcPeeringConnectionId
+
+	fmt.Printf("VPC Peering Connection created: %s\n", peeringConnectionID)
+
+	// Accept the VPC peering request
+	_, err = svc.AcceptVpcPeeringConnection(&ec2.AcceptVpcPeeringConnectionInput{
+		VpcPeeringConnectionId: aws.String(peeringConnectionID),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to accept VPC peering connection: %v", err)
+	}
+
+	fmt.Printf("VPC Peering Connection accepted: %s\n", peeringConnectionID)
+	return peeringConnectionID, nil
+}
+
+// UpdateRouteTablesForPeering updates the route tables to allow traffic between peered VPCs
+func (config *ClusterConfig) updateRouteTablesForPeering() error {
+	svc := ec2.New(config.Session)
+
+	// Get the route tables for both VPCs
+	routeTables1, err := svc.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{aws.String(config.ClusterVpcID)},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to describe route tables for VPC %s: %v", config.ClusterVpcID, err)
+	}
+
+	routeTables2, err := svc.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{aws.String(config.HybridVpcID)},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to describe route tables for VPC %s: %v", config.HybridVpcID, err)
+	}
+
+	// Add routes to the route tables for both VPCs
+	for _, rt := range routeTables1.RouteTables {
+		_, err = svc.CreateRoute(&ec2.CreateRouteInput{
+			RouteTableId:           rt.RouteTableId,
+			DestinationCidrBlock:   aws.String(config.HybridNodeCidr),
+			VpcPeeringConnectionId: aws.String(config.PeeringConnID),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create route in VPC %s: %v", config.ClusterVpcID, err)
+		}
+	}
+
+	for _, rt := range routeTables2.RouteTables {
+		_, err = svc.CreateRoute(&ec2.CreateRouteInput{
+			RouteTableId:           rt.RouteTableId,
+			DestinationCidrBlock:   aws.String(config.ClusterVpcCidr),
+			VpcPeeringConnectionId: aws.String(config.PeeringConnID),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create route in VPC %s: %v", config.HybridVpcID, err)
+		}
+	}
+
+	fmt.Println("Routes updated for VPC peering connection")
+	return nil
+}


### PR DESCRIPTION
*Issue #, if available:*
This PR enables setting up e2e architecture for EKS-hybrid.

*Description of changes:*
`make e2e-setup` command creates `e2e-test-runner` binary under bin directory.

Running e2e-test-runner `./_bin/e2e-test-runner setup {flags}..` does the following things,
1. Takes kubernetes versions, cluster and EC2 hybrid VPC CIDRs, subnet as an input.
2. Patches the AWS CLI with hybrid nodes API fields.
3. Creates EKS cluster IAM role.
4. Creates VPC and subnets for EKS Cluster.
5. Creates VPC and subnets for EC2 hybrid node.
6. Creates VPC peering between 2 VPCs.
7. Updates route table for EKS and EC2 hybrid nodes VPCs.
8. Creates cluster based on provided Kubernetes version.
9. Waits for the cluster to get created before performing below steps.
10. Saves kubeconfig file for each cluster.
11. Patches the aws-node DaemonSet to update the VPC CNI with anti-affinity for nodes labeled with the default hybrid nodes label eks.amazonaws.com/compute-type: hybrid.
12. Applies aws-auth ConfigMap.

Installing CNI would be in the following PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
