### PR TITLE
Switch to prod manifest for eks releases

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
       - main
   pull_request:
     paths:
-      - '**.go'
+      - '**'
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,7 +7,7 @@ on:
       - main
   pull_request:
     paths:
-      - '**.go'
+      - '**'
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,7 +7,7 @@ on:
       - main
   pull_request:
     paths:
-      - '**.go'
+      - '**'
 permissions:
   contents: read
   pull-requests: read

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 GIT_VERSION?=0.0.0
-HYBRID_MANIFEST_URL?=https://do-not-delete-temp-hybrid-manifest.s3.amazonaws.com/manifest.yaml
+MANIFEST_HOST?=hybrid-assets.eks.amazonaws.com
+HYBRID_MANIFEST_URL=https://$(MANIFEST_HOST)/manifest.yaml
 
 .PHONY: all
 all: crds generate fmt vet build


### PR DESCRIPTION
*Description of changes:*
Switching nodeadm to use prod eks release manifest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
