### PR TITLE
Provide concise actionable error message if SSM activation expires

### DIFF
--- a/internal/ssm/daemon.go
+++ b/internal/ssm/daemon.go
@@ -1,6 +1,7 @@
 package ssm
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 
@@ -16,6 +17,7 @@ var (
 	SsmDaemonName               = "amazon-ssm-agent"
 
 	checksumMismatchErrorRegex = regexp.MustCompile(`.*checksum mismatch with latest ssm-setup-cli*`)
+	activationErrorRegex       = regexp.MustCompile(`.*ActivationExpired*`)
 )
 
 type ssm struct {
@@ -57,6 +59,8 @@ func (s *ssm) Configure() error {
 				return err
 			}
 			return s.registerMachine(s.nodeConfig, registerOverride)
+		} else if match := activationErrorRegex.MatchString(err.Error()); match {
+			return fmt.Errorf("SSM activation expired. Please use a valid activation")
 		}
 		return err
 	}


### PR DESCRIPTION
*Description of changes:*
If SSM activation expires and user trying to init with the activation, nodeadm threw a page long error message the contains entire stderr/stdout of the ssm-setup-cli run. With this change, nodeadm will throw a small actionable error that informs user to use a valid activation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

