### PR TITLE
Add integration tests for nodeadm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cover.out
 coverage.out
 .idea
 .DS_Store
+vendor

--- a/test/integration/cases/install-containerd-source-none/expected-nodeadm-tracker
+++ b/test/integration/cases/install-containerd-source-none/expected-nodeadm-tracker
@@ -1,0 +1,10 @@
+Artifacts:
+  CniPlugins: true
+  Containerd: ""
+  IamAuthenticator: true
+  IamRolesAnywhere: true
+  ImageCredentialProvider: true
+  Iptables: true
+  Kubectl: true
+  Kubelet: true
+  Ssm: false

--- a/test/integration/cases/install-containerd-source-none/run.sh
+++ b/test/integration/cases/install-containerd-source-none/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+wait::dbus-ready
+
+# remove previously installed containerd to test installation via nodeadm
+dnf remove -y containerd
+
+nodeadm install 1.30  --credential-provider iam-ra --containerd-source none
+
+# /usr/bin/containerd not exists means nodeadm did not install containerd from any source
+assert::path-not-exist /usr/bin/containerd
+assert::path-exists /usr/sbin/iptables
+assert::path-exists /usr/bin/kubelet
+assert::path-exists /usr/local/bin/kubectl
+assert::path-exists /opt/cni/bin/
+assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
+assert::path-exists /usr/local/bin/aws-iam-authenticator
+
+assert::path-exists /usr/local/bin/aws_signing_helper
+
+assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker

--- a/test/integration/cases/install-with-iam/expected-nodeadm-tracker
+++ b/test/integration/cases/install-with-iam/expected-nodeadm-tracker
@@ -1,0 +1,10 @@
+Artifacts:
+  CniPlugins: true
+  Containerd: distro
+  IamAuthenticator: true
+  IamRolesAnywhere: true
+  ImageCredentialProvider: true
+  Iptables: true
+  Kubectl: true
+  Kubelet: true
+  Ssm: false

--- a/test/integration/cases/install-with-iam/run.sh
+++ b/test/integration/cases/install-with-iam/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+wait::dbus-ready
+
+# remove previously installed containerd to test installation via nodeadm
+dnf remove -y containerd
+
+nodeadm install 1.30  --credential-provider iam-ra
+
+assert::path-exists /usr/bin/containerd
+assert::path-exists /usr/sbin/iptables
+assert::path-exists /usr/bin/kubelet
+assert::path-exists /usr/local/bin/kubectl
+assert::path-exists /opt/cni/bin/
+assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
+assert::path-exists /usr/local/bin/aws-iam-authenticator
+
+assert::path-exists /usr/local/bin/aws_signing_helper
+
+assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker

--- a/test/integration/cases/install-with-ssm/expected-nodeadm-tracker
+++ b/test/integration/cases/install-with-ssm/expected-nodeadm-tracker
@@ -1,0 +1,10 @@
+Artifacts:
+  CniPlugins: true
+  Containerd: distro
+  IamAuthenticator: true
+  IamRolesAnywhere: false
+  ImageCredentialProvider: true
+  Iptables: true
+  Kubectl: true
+  Kubelet: true
+  Ssm: true

--- a/test/integration/cases/install-with-ssm/run.sh
+++ b/test/integration/cases/install-with-ssm/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+wait::dbus-ready
+
+# remove previously installed containerd to test installation via nodeadm
+dnf remove -y containerd
+
+nodeadm install 1.30  --credential-provider ssm
+
+assert::path-exists /usr/bin/containerd
+assert::path-exists /usr/sbin/iptables
+assert::path-exists /usr/bin/kubelet
+assert::path-exists /usr/local/bin/kubectl
+assert::path-exists /opt/cni/bin/
+assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
+assert::path-exists /usr/local/bin/aws-iam-authenticator
+
+assert::path-exists /opt/aws/ssm-setup-cli
+
+assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -47,6 +47,30 @@ function assert::file-contains() {
   fi
 }
 
+function assert::path-exists() {
+  if [ "$#" -ne 1 ]; then
+    echo "Usage: assert::path-exists INPUT_PATH"
+    exit 1
+  fi
+  local INPUT_PATH=$1
+  if ! [[ -e "$INPUT_PATH" ]]; then
+      echo "Path $INPUT_PATH does not exist"
+      exit 1
+  fi
+}
+
+function assert::path-not-exist() {
+  if [ "$#" -ne 1 ]; then
+    echo "Usage: assert::path-not-exist INPUT_PATH"
+    exit 1
+  fi
+  local INPUT_PATH=$1
+  if [ -e "$INPUT_PATH" ]; then
+      echo "Path $INPUT_PATH exists!"
+      exit 1
+  fi
+}
+
 function assert::file-not-contains() {
   if [ "$#" -ne 2 ]; then
     echo "Usage: assert::file-not-contains FILE PATTERN"

--- a/test/integration/infra/Dockerfile
+++ b/test/integration/infra/Dockerfile
@@ -14,7 +14,7 @@ RUN mv _bin/nodeadm /nodeadm
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN dnf -y update && \
-    dnf -y install systemd containerd jq python3 awscli && \
+    dnf -y install systemd containerd jq python3 awscli tar && \
     dnf clean all
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \


### PR DESCRIPTION
Add integration tests for nodeadm.

Test cases include:
1. Install
- install with IAM
- install with SSM
- install with containerd source set to none
