### PR TITLE
Add isof region for ECR support

### DIFF
--- a/internal/aws/ecr/ecr.go
+++ b/internal/aws/ecr/ecr.go
@@ -93,25 +93,29 @@ var accountsByRegion = map[string]string{
 	"us-east-2":      nonOptInRegionAccount,
 	"us-west-1":      nonOptInRegionAccount,
 	"us-west-2":      nonOptInRegionAccount,
-	"ap-east-1":      "800184023465",
-	"me-south-1":     "558608220178",
-	"cn-north-1":     "918309763551",
-	"cn-northwest-1": "961992271922",
-	"us-gov-west-1":  "013241004608",
-	"us-gov-east-1":  "151742754352",
-	"us-iso-west-1":  "608367168043",
-	"us-iso-east-1":  "725322719131",
-	"us-isob-east-1": "187977181151",
-	"af-south-1":     "877085696533",
-	"ap-southeast-3": "296578399912",
-	"me-central-1":   "759879836304",
-	"eu-south-1":     "590381155156",
-	"eu-south-2":     "455263428931",
-	"eu-central-2":   "900612956339",
-	"ap-south-2":     "900889452093",
-	"ap-southeast-4": "491585149902",
-	"il-central-1":   "066635153087",
-	"ca-west-1":      "761377655185",
+
+	"af-south-1":      "877085696533",
+	"ap-east-1":       "800184023465",
+	"ap-south-2":      "900889452093",
+	"ap-southeast-3":  "296578399912",
+	"ap-southeast-4":  "491585149902",
+	"ap-southeast-5":  "151610086707",
+	"ca-west-1":       "761377655185",
+	"cn-north-1":      "918309763551",
+	"cn-northwest-1":  "961992271922",
+	"eu-central-2":    "900612956339",
+	"eu-isoe-west-1":  "249663109785",
+	"eu-south-1":      "590381155156",
+	"eu-south-2":      "455263428931",
+	"il-central-1":    "066635153087",
+	"me-central-1":    "759879836304",
+	"me-south-1":      "558608220178",
+	"us-gov-east-1":   "151742754352",
+	"us-gov-west-1":   "013241004608",
+	"us-iso-east-1":   "725322719131",
+	"us-iso-west-1":   "608367168043",
+	"us-isob-east-1":  "187977181151",
+	"us-isof-south-1": "676585237158",
 }
 
 // getEKSRegistryCoordinates returns an AWS region and account ID for the default EKS ECR container image registry
@@ -128,6 +132,8 @@ func getEKSRegistryCoordinates(region string) (string, string) {
 		return "725322719131", "us-iso-east-1"
 	} else if strings.HasPrefix(region, "us-isob-") {
 		return "187977181151", "us-isob-east-1"
+	} else if strings.HasPrefix(region, "us-isof-") {
+		return "676585237158", "us-isof-south-1"
 	}
 	return "602401143452", "us-west-2"
 }


### PR DESCRIPTION
*Description of changes:*
Adding isof region for ECR support. This is primarily used to pull the pause image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

