### PR TITLE
Add integration test case for nodeadm init aspects

### DIFF
--- a/internal/system/ports.go
+++ b/internal/system/ports.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"fmt"
+
 	"go.uber.org/zap"
 
 	"github.com/aws/eks-hybrid/internal/api"
@@ -58,7 +59,7 @@ func (s *portsAspect) Setup() error {
 			return err
 		}
 		s.logger.Info("Allowing port on firewall", zap.Reflect("node-port-services",
-			fmt.Sprintf("%s-%s", nodePortStartRangePort, nodePortStartRangePort)))
+			fmt.Sprintf("%s-%s", nodePortStartRangePort, nodePortEndRangePort)))
 		if err = s.firewallManager.AllowTcpPortRange(nodePortStartRangePort, nodePortEndRangePort); err != nil {
 			return err
 		}

--- a/test/integration/cases/hybrid-node-system-aspects/config.yaml
+++ b/test/integration/cases/hybrid-node-system-aspects/config.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+    region: us-west-2
+  hybrid:
+    nodeName: mock-hybrid-node
+    iamRolesAnywhere:
+      awsConfigPath: /.aws/config
+      roleArn: arn:aws:iam::123456789010:role/mockHybridNodeRole
+      profileArn: arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole
+      trustAnchorArn: arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7

--- a/test/integration/cases/hybrid-node-system-aspects/expected-99-nodeadm.conf
+++ b/test/integration/cases/hybrid-node-system-aspects/expected-99-nodeadm.conf
@@ -1,0 +1,4 @@
+vm.overcommit_memory=1
+kernel.panic=10
+kernel.panic_on_oops=1
+net.ipv4.ip_forward=1

--- a/test/integration/cases/hybrid-node-system-aspects/expected-aws-config
+++ b/test/integration/cases/hybrid-node-system-aspects/expected-aws-config
@@ -1,0 +1,3 @@
+[profile hybrid]
+region = us-west-2
+credential_process = /usr/local/bin/aws_signing_helper credential-process --certificate /etc/iam/pki/server.pem --private-key /etc/iam/pki/server.key --trust-anchor-arn arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7 --profile-arn arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole --role-arn arn:aws:iam::123456789010:role/mockHybridNodeRole --role-session-name mock-hybrid-node

--- a/test/integration/cases/hybrid-node-system-aspects/run.sh
+++ b/test/integration/cases/hybrid-node-system-aspects/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+mock::kubelet 1.30.0
+wait::dbus-ready
+
+# install, enable and start firewalld to test ports aspect
+dnf install -y firewalld
+systemctl enable firewalld
+systemctl start firewalld
+
+nodeadm init --skip run,install-validation --config-source file://config.yaml
+
+# Check if aws config file has been created as specifed in NodeConfig
+assert::files-equal /.aws/config expected-aws-config
+
+# Check if sysctl aspect has been setup
+assert::files-equal /etc/sysctl.d/99-nodeadm.conf expected-99-nodeadm.conf
+
+# Check if swap has been disabled and partition removed from /etc/fstab
+assert::file-not-contains /etc/fstab "swap"
+assert::swap-disabled-validate-path
+
+# Check if port has been allowed by firewalld
+assert::allowed-by-firewalld "10250" "tcp"
+assert::allowed-by-firewalld "10256" "tcp"
+assert::allowed-by-firewalld "30000-32767" "tcp"

--- a/test/integration/infra/Dockerfile
+++ b/test/integration/infra/Dockerfile
@@ -14,7 +14,7 @@ RUN mv _bin/nodeadm /nodeadm
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN dnf -y update && \
-    dnf -y install systemd containerd jq python3 awscli tar && \
+    dnf -y install systemd containerd jq python3 awscli tar procps && \
     dnf clean all
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \


### PR DESCRIPTION
Add integration test cases to test nodeadm init process, tests include:

- Test if sysctl aspect has been setup
- Test if swap has been disabled
- Test specific ports has been allowed by firewall
