### PR TITLE
Require EC2 instances to strictly use IMDSv2

### DIFF
--- a/test/e2e/validate/setup.go
+++ b/test/e2e/validate/setup.go
@@ -105,6 +105,7 @@ func CreateEC2(sess *session.Session, instance EC2Instance) (*ec2.EC2, string, e
 			},
 		},
 		UserData: &userDataEncoded,
+		MetadataOptions: &ec2.InstanceMetadataOptionsRequest{HttpTokens: aws.String("required"), HttpPutResponseHopLimit: aws.Int64(int64(2))},
 	})
 
 	if err != nil {


### PR DESCRIPTION
Require EC2 instances to strictly use IMDSv2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

