### PR TITLE
Add enableCredentialsFile field to enable writing AWS credentials

### DIFF
--- a/api/v1alpha1/nodeconfig_types.go
+++ b/api/v1alpha1/nodeconfig_types.go
@@ -109,6 +109,11 @@ type HybridOptions struct {
 	// NodeName is the name the node will adopt.
 	NodeName string `json:"nodeName,omitempty"`
 
+	// EnableCredentialsFile enables a shared credentials file on the host at /eks-hybrid/.aws/credentials
+	// For SSM, this means that nodeadm will not create symlink from `/root/.aws/credentials` to `/eks-hybrid/.aws/credentials`.
+	// For IAM Roles Anywhere, this means that nodeadm will not set up a systemd service to write and refresh the credentials to `/eks-hybrid/.aws/credentials`.
+	EnableCredentialsFile bool `json:"enableCredentialsFile,omitempty"`
+
 	// IAMRolesAnywhere includes IAM Roles Anywhere specific configuration and is mutually exclusive
 	// with SSM.
 	IAMRolesAnywhere *IAMRolesAnywhere `json:"iamRolesAnywhere,omitempty"`

--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -1,9 +1,10 @@
 package uninstall
 
 import (
+	"os"
+
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
-	"os"
 
 	"github.com/aws/eks-hybrid/internal/cli"
 	"github.com/aws/eks-hybrid/internal/cni"
@@ -92,6 +93,15 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		}
 		if err := ssm.Uninstall(packageManager); err != nil {
 			return err
+		}
+	}
+	if artifacts.IamRolesAnywhere {
+		log.Info("Removing aws_signing_helper_update daemon...")
+		if status, err := daemonManager.GetDaemonStatus(iamrolesanywhere.DaemonName); err == nil || status != daemon.DaemonStatusUnknown {
+			if err = daemonManager.StopDaemon(iamrolesanywhere.DaemonName); err != nil {
+				log.Info("Stopping aws_signing_helper_update daemon...")
+				return err
+			}
 		}
 	}
 	if artifacts.Containerd != string(containerd.ContainerdSourceNone) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -117,9 +117,10 @@ const (
 )
 
 type HybridOptions struct {
-	NodeName         string            `json:"nodeName,omitempty"`
-	IAMRolesAnywhere *IAMRolesAnywhere `json:"iamRolesAnywhere,omitempty"`
-	SSM              *SSM              `json:"ssm,omitempty"`
+	NodeName              string            `json:"nodeName,omitempty"`
+	EnableCredentialsFile bool              `json:"enableCredentialsFile,omitempty"`
+	IAMRolesAnywhere      *IAMRolesAnywhere `json:"iamRolesAnywhere,omitempty"`
+	SSM                   *SSM              `json:"ssm,omitempty"`
 }
 
 func (nc NodeConfig) IsHybridNode() bool {

--- a/internal/iamrolesanywhere/aws_config.go
+++ b/internal/iamrolesanywhere/aws_config.go
@@ -86,7 +86,7 @@ func validateAWSConfig(cfg AWSConfig) error {
 	}
 
 	if cfg.SigningHelperBinPath == "" {
-		errs = append(errs, errors.New("Singing helper path cannot be emtpyy"))
+		errs = append(errs, errors.New("Signing helper path cannot be empty"))
 	}
 
 	return errors.Join(errs...)

--- a/internal/iamrolesanywhere/aws_signing_helper_update_service.tpl
+++ b/internal/iamrolesanywhere/aws_signing_helper_update_service.tpl
@@ -1,0 +1,23 @@
+[Unit]
+Description=Service that runs aws_signing_helper update to keep the AWS credentials refreshed in {{ .SharedCredentialsFilePath }}.
+
+[Service]
+User=root
+Environment=AWS_SHARED_CREDENTIALS_FILE={{ .SharedCredentialsFilePath }}
+ExecStart={{ .SigningHelperBinPath }} update \
+        --certificate /etc/iam/pki/server.pem \
+        --private-key /etc/iam/pki/server.key \
+        --trust-anchor-arn {{ .TrustAnchorARN }} \
+        --profile-arn {{ .ProfileARN }} \
+        --role-arn {{ .RoleARN }} \
+        --role-session-name {{ .NodeName }} \
+        --region {{ .Region }}
+StandardOutput=journal
+StandardError=journal
+Restart=always
+RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/iamrolesanywhere/daemon.go
+++ b/internal/iamrolesanywhere/daemon.go
@@ -1,0 +1,82 @@
+package iamrolesanywhere
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"text/template"
+
+	"github.com/aws/eks-hybrid/internal/api"
+	"github.com/aws/eks-hybrid/internal/daemon"
+	"github.com/aws/eks-hybrid/internal/util"
+)
+
+const (
+	DaemonName                   = "aws_signing_helper_update"
+	EksHybridAwsCredentialsPath  = "/eks-hybrid/.aws/credentials"
+	SigningHelperServiceFilePath = "/etc/systemd/system/aws_signing_helper_update.service"
+)
+
+var (
+	//go:embed aws_signing_helper_update_service.tpl
+	rawSigningHelperServiceTemplate string
+
+	signingHelperServiceTemplate = template.Must(template.New("").Parse(rawSigningHelperServiceTemplate))
+)
+
+type SigningHelperDaemon struct {
+	daemonManager daemon.DaemonManager
+	spec          *api.NodeConfigSpec
+}
+
+func NewSigningHelperDaemon(daemonManager daemon.DaemonManager, spec *api.NodeConfigSpec) daemon.Daemon {
+	return &SigningHelperDaemon{
+		daemonManager: daemonManager,
+		spec:          spec,
+	}
+}
+
+func (s *SigningHelperDaemon) Configure() error {
+	var buf bytes.Buffer
+	if err := signingHelperServiceTemplate.Execute(&buf, map[string]string{
+		"SharedCredentialsFilePath": EksHybridAwsCredentialsPath,
+		"SigningHelperBinPath":      SigningHelperBinPath,
+		"TrustAnchorARN":            s.spec.Hybrid.IAMRolesAnywhere.TrustAnchorARN,
+		"ProfileARN":                s.spec.Hybrid.IAMRolesAnywhere.ProfileARN,
+		"RoleARN":                   s.spec.Hybrid.IAMRolesAnywhere.RoleARN,
+		"Region":                    s.spec.Cluster.Region,
+		"NodeName":                  s.spec.Hybrid.NodeName,
+	}); err != nil {
+		return fmt.Errorf("executing aws_signing_helper_update service template: %v", err)
+	}
+
+	if err := util.WriteFileWithDir(SigningHelperServiceFilePath, buf.Bytes(), 0644); err != nil {
+		return fmt.Errorf("writing aws_signing_helper_update service file %s: %v", EksHybridAwsCredentialsPath, err)
+	}
+	return nil
+}
+
+// EnsureRunning enables and starts the aws_signing_helper unit.
+func (s *SigningHelperDaemon) EnsureRunning() error {
+	err := s.daemonManager.EnableDaemon(s.Name())
+	if err != nil {
+		return err
+	}
+	return s.daemonManager.StartDaemon(s.Name())
+}
+
+// PostLaunch runs any additional step that needs to occur after the service
+// daemon as been started.
+func (s *SigningHelperDaemon) PostLaunch() error {
+	return nil
+}
+
+// Stop stops the aws_signing_helper unit only if it is loaded and running.
+func (s *SigningHelperDaemon) Stop() error {
+	return s.daemonManager.StopDaemon(s.Name())
+}
+
+// Name returns the name of the daemon.
+func (s *SigningHelperDaemon) Name() string {
+	return DaemonName
+}

--- a/internal/iamrolesanywhere/install.go
+++ b/internal/iamrolesanywhere/install.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/aws/eks-hybrid/internal/artifact"
 	"github.com/aws/eks-hybrid/internal/tracker"
@@ -39,5 +40,11 @@ func Install(ctx context.Context, tracker *tracker.Tracker, signingHelperSrc Sig
 }
 
 func Uninstall() error {
+	if err := os.RemoveAll(SigningHelperServiceFilePath); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(path.Dir(EksHybridAwsCredentialsPath)); err != nil {
+		return err
+	}
 	return os.RemoveAll(SigningHelperBinPath)
 }

--- a/internal/ssm/install.go
+++ b/internal/ssm/install.go
@@ -84,6 +84,11 @@ func Uninstall(pkgSource PkgSource) error {
 		return err
 	}
 
+	err = os.RemoveAll(symlinkedAWSConfigPath)
+	if err != nil {
+		return fmt.Errorf("removing directory %s: %v", symlinkedAWSConfigPath, err)
+	}
+
 	return os.RemoveAll(installerPath)
 }
 


### PR DESCRIPTION
*Description of changes:*
Add `EnableCredentialsFile` field under `HybridOptions` to enable writing an AWS credentials file under `/eks-hybrid/.aws/credentials`.
For SSM, this is being done by creating a symlink `/eks-hybrid/.aws -> /root/.aws`
For IAM RA, nodeadm will create a new systemd process `aws_signing_helper_update` that will run the `aws_signing_helper update` command to write the credentials directly to `/eks-hybrid/.aws/credentials`.

There is also support for uninstall which for SSM will just remove the symlink `/eks-hybrid/.aws` and for IAM RA, it will remove the systemd process `aws_signing_helper_update` and delete the `/eks-hybrid/.aws` path.

Example config:
```yaml
apiVersion: node.eks.aws/v1alpha1
kind: NodeConfig
spec:
  cluster:
    name: abhnvp-hybrid-pod-identity-test
    region: us-west-2
  hybrid:
    nodeName: "abhnvp-pod-identity-ira"
    enableHostCredentialsFile: true
    iamRolesAnywhere:
      ...
```

*Testing (if applicable):*
Tested this on hybrid node with both SSM and IAM roles anywhere with both `nodeadm init` and `nodeadm uninstall`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

