### PR TITLE
Add integration test for nodeadm upgrade

### DIFF
--- a/test/integration/cases/upgrade-with-iam/config.yaml
+++ b/test/integration/cases/upgrade-with-iam/config.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+    region: us-west-2
+  hybrid:
+    nodeName: mock-hybrid-node
+    iamRolesAnywhere:
+      awsConfigPath: /.aws/config
+      roleArn: arn:aws:iam::123456789010:role/mockHybridNodeRole
+      profileArn: arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole
+      trustAnchorArn: arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7

--- a/test/integration/cases/upgrade-with-iam/expected-nodeadm-tracker
+++ b/test/integration/cases/upgrade-with-iam/expected-nodeadm-tracker
@@ -1,0 +1,10 @@
+Artifacts:
+  CniPlugins: true
+  Containerd: distro
+  IamAuthenticator: true
+  IamRolesAnywhere: true
+  ImageCredentialProvider: true
+  Iptables: true
+  Kubectl: true
+  Kubelet: true
+  Ssm: false

--- a/test/integration/cases/upgrade-with-iam/run.sh
+++ b/test/integration/cases/upgrade-with-iam/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+wait::dbus-ready
+
+declare INITIAL_VERSION=1.26
+declare TARGET_VERSION=1.30
+
+# remove previously installed containerd to test installation via nodeadm
+dnf remove -y containerd
+
+# Test nodeadm upgrade with iam as credential provider
+# initial: version 1.26
+# target: version 1.30
+nodeadm install $INITIAL_VERSION --credential-provider iam-ra
+assert::path-exists /usr/bin/containerd
+assert::path-exists /usr/sbin/iptables
+assert::path-exists /usr/bin/kubelet
+assert::path-exists /usr/local/bin/kubectl
+VERSION_INFO=$(/usr/local/bin/kubectl version || true)
+assert::is-substring "$VERSION_INFO" "v$INITIAL_VERSION"
+assert::path-exists /opt/cni/bin/
+assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
+assert::path-exists /usr/local/bin/aws-iam-authenticator
+assert::path-exists /usr/local/bin/aws_signing_helper
+assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+
+nodeadm init --skip run,preprocess --config-source file://config.yaml
+
+nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation --config-source file://config.yaml
+assert::path-exists /usr/bin/containerd
+assert::path-exists /usr/sbin/iptables
+assert::path-exists /usr/local/bin/kubectl
+VERSION_INFO=$(/usr/local/bin/kubectl version || true)
+assert::is-substring "$VERSION_INFO" "v$TARGET_VERSION"
+assert::path-exists /opt/cni/bin/
+assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
+assert::path-exists /usr/local/bin/aws-iam-authenticator
+assert::path-exists /usr/local/bin/aws_signing_helper
+assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker

--- a/test/integration/cases/upgrade-with-ssm/config.yaml
+++ b/test/integration/cases/upgrade-with-ssm/config.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+    region: us-west-2
+  hybrid:
+    nodeName: mock-hybrid-node
+    ssm:
+      activationCode: ys25k3gpt8zzyl9jhn6gq8rj3519owjelyz7
+      activationId: 57be8cce-1137-32d4-ce32-ba044ea5df48

--- a/test/integration/cases/upgrade-with-ssm/expected-nodeadm-tracker
+++ b/test/integration/cases/upgrade-with-ssm/expected-nodeadm-tracker
@@ -1,0 +1,10 @@
+Artifacts:
+  CniPlugins: true
+  Containerd: distro
+  IamAuthenticator: true
+  IamRolesAnywhere: false
+  ImageCredentialProvider: true
+  Iptables: true
+  Kubectl: true
+  Kubelet: true
+  Ssm: true

--- a/test/integration/cases/upgrade-with-ssm/run.sh
+++ b/test/integration/cases/upgrade-with-ssm/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+wait::dbus-ready
+
+declare INITIAL_VERSION=1.26
+declare TARGET_VERSION=1.30
+
+# remove previously installed containerd to test installation via nodeadm
+dnf remove -y containerd
+
+# Test nodeadm upgrade with ssm as credential provider
+# initial: version 1.26
+# target: version 1.30
+nodeadm install $INITIAL_VERSION --credential-provider ssm
+assert::path-exists /usr/bin/containerd
+assert::path-exists /usr/sbin/iptables
+assert::path-exists /usr/bin/kubelet
+assert::path-exists /usr/local/bin/kubectl
+VERSION_INFO=$(/usr/local/bin/kubectl version || true)
+assert::is-substring "$VERSION_INFO" "v$INITIAL_VERSION"
+assert::path-exists /opt/cni/bin/
+assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
+assert::path-exists /usr/local/bin/aws-iam-authenticator
+assert::path-exists /opt/aws/ssm-setup-cli
+assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+
+nodeadm init --skip run,preprocess --config-source file://config.yaml
+
+nodeadm upgrade $TARGET_VERSION --skip run,preprocess,pod-validation,node-validation --config-source file://config.yaml
+assert::path-exists /usr/bin/containerd
+assert::path-exists /usr/sbin/iptables
+assert::path-exists /usr/local/bin/kubectl
+VERSION_INFO=$(/usr/local/bin/kubectl version || true)
+assert::is-substring "$VERSION_INFO" "v$TARGET_VERSION"
+assert::path-exists /opt/cni/bin/
+assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
+assert::path-exists /usr/local/bin/aws-iam-authenticator
+assert::path-exists /opt/aws/ssm-setup-cli
+assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker


### PR DESCRIPTION
Add integration test for nodeadm upgrade.

Test case will test upgrade hybrid node from 1.26 to 1.30 and change credential provider from ssm to iam, verify k8s version, the nodeadm tracker file and credential provider files are updated.
