### PR TITLE
Update format for default hybrid node providerID

### DIFF
--- a/internal/kubelet/config.go
+++ b/internal/kubelet/config.go
@@ -269,7 +269,7 @@ func (ksc *kubeletConfig) withCloudProvider(kubeletVersion string, cfg *api.Node
 func (ksc *kubeletConfig) withHybridCloudProvider(cfg *api.NodeConfig, flags map[string]string) {
 	flags["cloud-provider"] = ""
 	// provider ID needs to be specified when the cloud provider is external or empty string
-	ksc.ProviderID = ptr.String(getHybridProviderId(cfg.Spec.Hybrid.NodeName))
+	ksc.ProviderID = ptr.String(getHybridProviderId(cfg))
 	// hostname is overriden to the node name provided in the spec
 	flags["hostname-override"] = cfg.Spec.Hybrid.NodeName
 }
@@ -490,8 +490,8 @@ func getProviderId(availabilityZone, instanceId string) string {
 	return fmt.Sprintf("aws:///%s/%s", availabilityZone, instanceId)
 }
 
-func getHybridProviderId(nodeName string) string {
-	return fmt.Sprintf("aws-external:///%s", nodeName)
+func getHybridProviderId(cfg *api.NodeConfig) string {
+	return fmt.Sprintf("eks-hybrid:///%s/%s/%s", cfg.Spec.Cluster.Region, cfg.Spec.Cluster.Name, cfg.Spec.Hybrid.NodeName)
 }
 
 // Get the IP of the node depending on the ipFamily configured for the cluster

--- a/internal/kubelet/config_test.go
+++ b/internal/kubelet/config_test.go
@@ -120,8 +120,12 @@ func TestProviderID(t *testing.T) {
 func TestHybridCloudProvider(t *testing.T) {
 	nodeConfig := api.NodeConfig{
 		Spec: api.NodeConfigSpec{
+			Cluster: api.ClusterDetails{
+				Name:   "my-cluster",
+				Region: "us-west-2",
+			},
 			Hybrid: &api.HybridOptions{
-				NodeName: "dummy-hybrid",
+				NodeName: "my-node",
 				IAMRolesAnywhere: &api.IAMRolesAnywhere{
 					TrustAnchorARN: "arn:aws:iam::222211113333:role/AmazonEKSConnectorAgentRole",
 					ProfileARN:     "dummy-profile-arn",
@@ -130,7 +134,7 @@ func TestHybridCloudProvider(t *testing.T) {
 			},
 		},
 	}
-	expectedProviderId := getHybridProviderId(nodeConfig.Spec.Hybrid.NodeName)
+	expectedProviderId := "eks-hybrid:///us-west-2/my-cluster/my-node"
 	kubeletArgs := make(map[string]string)
 	kubeletConfig := defaultKubeletSubConfig()
 	kubeletConfig.withHybridCloudProvider(&nodeConfig, kubeletArgs)


### PR DESCRIPTION
*Description of changes:*
ProviderID now follows `eks-hybrid:///<region>/<cluster-name>/<node-name>`
This should unequivocally identify a node by the providerID at the account level.
The change in scheme is to make more evident this is for eks hybrid nodes and not just any external aws compute.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

