### PR TITLE
E2E framework implementation for EKS-hybrid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/golang/mock v1.6.0
 	github.com/integrii/flaggy v1.5.2
+	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pkg/errors v0.9.1
@@ -44,7 +45,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/onsi/ginkgo/v2 v2.19.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,0 +1,43 @@
+// nolint
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/eks"
+)
+
+type TestConfig struct {
+	ClusterName   string `yaml:"clusterName"`
+	ClusterRegion string `yaml:"clusterRegion"`
+	HybridVpcID   string `yaml:"hybridVpcID"`
+	NodeadmUrl    string `yaml:"nodeadmUrl"`
+}
+
+// newE2EAWSSession constructs AWS session for E2E tests.
+func newE2EAWSSession(region string) (*session.Session, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(region),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AWS session: %w", err)
+	}
+	return sess, nil
+}
+
+// getKubernetesVersion returns kubernetes version of the cluster.
+func getKubernetesVersion(ctx context.Context, eksClient *eks.EKS, clusterName string) (string, error) {
+	input := &eks.DescribeClusterInput{
+		Name: aws.String(clusterName),
+	}
+
+	result, err := eksClient.DescribeClusterWithContext(ctx, input)
+	if err != nil {
+		return "", fmt.Errorf("failed to describe cluster: %v", err)
+	}
+
+	return *result.Cluster.Version, nil
+}

--- a/test/e2e/nodeadm_test.go
+++ b/test/e2e/nodeadm_test.go
@@ -1,0 +1,104 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/eks-hybrid/internal/creds"
+	"github.com/aws/eks-hybrid/internal/system"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	filePath    string
+	eksClient   *eks.EKS
+	ec2Client   *ec2.EC2
+	config      *TestConfig = &TestConfig{}
+	testEntries []TableEntry
+	kubeVersion string
+)
+
+func init() {
+	flag.StringVar(&filePath, "filepath", "", "Path to configuration")
+}
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	g := NewGomegaWithT(t)
+
+	g.Expect(filePath).NotTo(BeEmpty(), "-filePath flag is required") // Fail the test if the filepath flag is not provided
+	g.Expect(loadTestConfig(config)).NotTo(HaveOccurred())
+	g.Expect(generateTestEntries()).NotTo(BeEmpty())
+
+	RunSpecs(t, "E2E Suite")
+}
+
+// loadTestConfig reads the configuration from the specified file path and unmarshals it into the TestConfig struct.
+func loadTestConfig(config *TestConfig) error {
+	file, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open configuration file: %v", err)
+	}
+
+	if err = yaml.Unmarshal(file, config); err != nil {
+		return fmt.Errorf("failed to unmarshal configuration from YAML: %v", err)
+	}
+
+	return nil
+}
+
+var (
+	osList              = []string{system.UbuntuOsName, system.AmazonOsName, system.RhelOsName}
+	credentialProviders = []creds.CredentialProvider{creds.SsmCredentialProvider, creds.IamRolesAnywhereCredentialProvider}
+)
+
+func generateTestEntries() []TableEntry {
+	for _, os := range osList {
+		for _, provider := range credentialProviders {
+			testEntries = append(testEntries, Entry(
+				fmt.Sprintf("With OS %s and with Credential Provider %s", os, string(provider)),
+				os,
+				provider,
+				Label(os, string(provider)),
+			))
+		}
+	}
+	return testEntries
+}
+
+var _ = BeforeSuite(func() {
+	ctx := context.Background()
+	awsSession, err := newE2EAWSSession(config.ClusterRegion)
+	Expect(err).NotTo(HaveOccurred())
+
+	eksClient = eks.New(awsSession)
+	ec2Client = ec2.New(awsSession)
+
+	// Get Kubernetes version for the given cluster name
+	kubeVersion, err = getKubernetesVersion(ctx, eksClient, config.ClusterName)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = Describe("Hybrid Nodes", func() {
+	When("using peered VPC", func() {
+		DescribeTable("Joining a node",
+			func(os string, provider creds.CredentialProvider) {
+				Expect(os).NotTo(BeEmpty())
+				Expect(provider).NotTo(BeEmpty())
+				Expect(kubeVersion).NotTo(BeEmpty())
+
+				fmt.Printf("Running test for OS: %s, Credential Provider: %s, Kubernetes Version: %s\n", os, string(provider), kubeVersion)
+			}, testEntries)
+	})
+})


### PR DESCRIPTION
*Description of changes:*

This PR enables running e2e tests for EKS-hybrid. 

To run e2e tests on an existing infrastructure, run the following command,
`ginkgo -tags=e2e  ./test/e2e -- -filepath=e2e-param.yaml`

It is easier to filter tests based on label using ginkgo. To run all the test only related to Ubuntu, run command like
`ginkgo -tags=e2e --label-filter='ubuntu'  ./test/e2e -- -filepath=e2e-param.yaml`

The command takes configuration file as an input which looks like below,

```
clusterName: 
clusterRegion: 
hybridVpcID: 
nodeadmUrl:
```

Get Ginkgo CLI using `go install github.com/onsi/ginkgo/v2@v2.19.0` command.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

