### PR TITLE
Improvements for nodeadm integration tests

### DIFF
--- a/test/integration/cases/upgrade-with-iam/config.yaml
+++ b/test/integration/cases/upgrade-with-iam/config.yaml
@@ -10,6 +10,7 @@ spec:
     region: us-west-2
   hybrid:
     nodeName: mock-hybrid-node
+    enableCredentialsFile: true
     iamRolesAnywhere:
       awsConfigPath: /.aws/config
       roleArn: arn:aws:iam::123456789010:role/mockHybridNodeRole

--- a/test/integration/cases/upgrade-with-iam/expected-aws-config
+++ b/test/integration/cases/upgrade-with-iam/expected-aws-config
@@ -1,0 +1,3 @@
+[profile hybrid]
+region = us-west-2
+credential_process = /usr/local/bin/aws_signing_helper credential-process --certificate /etc/iam/pki/server.pem --private-key /etc/iam/pki/server.key --trust-anchor-arn arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7 --profile-arn arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole --role-arn arn:aws:iam::123456789010:role/mockHybridNodeRole --role-session-name mock-hybrid-node

--- a/test/integration/cases/upgrade-with-iam/expected-aws-signing-helper-systemd-unit
+++ b/test/integration/cases/upgrade-with-iam/expected-aws-signing-helper-systemd-unit
@@ -1,0 +1,23 @@
+[Unit]
+Description=Service that runs aws_signing_helper update to keep the AWS credentials refreshed in /eks-hybrid/.aws/credentials.
+
+[Service]
+User=root
+Environment=AWS_SHARED_CREDENTIALS_FILE=/eks-hybrid/.aws/credentials
+ExecStart=/usr/local/bin/aws_signing_helper update \
+        --certificate /etc/iam/pki/server.pem \
+        --private-key /etc/iam/pki/server.key \
+        --trust-anchor-arn arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7 \
+        --profile-arn arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole \
+        --role-arn arn:aws:iam::123456789010:role/mockHybridNodeRole \
+        --role-session-name mock-hybrid-node \
+        --region us-west-2
+StandardOutput=journal
+StandardError=journal
+Restart=always
+RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
+
+[Install]
+WantedBy=multi-user.target

--- a/test/integration/cases/upgrade-with-iam/expected-ca-crt
+++ b/test/integration/cases/upgrade-with-iam/expected-ca-crt
@@ -1,0 +1,1 @@
+certificateAuthority

--- a/test/integration/cases/upgrade-with-iam/expected-containerd-config
+++ b/test/integration/cases/upgrade-with-iam/expected-containerd-config
@@ -1,0 +1,26 @@
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+# Users can use the following import directory to add additional
+# configuration to containerd. The imports do not behave exactly like overrides.
+# see: https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md#format
+imports = ["/etc/containerd/config.d/*.toml"]
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri".containerd]
+    default_runtime_name = "runc"
+    discard_unpacked_layers = true
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5"
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+    runtime_type = "io.containerd.runc.v2"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+    SystemdCgroup = true
+  [plugins."io.containerd.grpc.v1.cri".cni]
+    bin_dir = "/opt/cni/bin"
+    conf_dir = "/etc/cni/net.d"

--- a/test/integration/cases/upgrade-with-iam/expected-image-credential-provider-config-initial
+++ b/test/integration/cases/upgrade-with-iam/expected-image-credential-provider-config-initial
@@ -1,0 +1,28 @@
+{
+  "apiVersion": "kubelet.config.k8s.io/v1alpha1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "ecr-credential-provider",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1alpha1",
+      "env": [
+        {
+          "name": "AWS_CONFIG_FILE",
+          "value": "/.aws/config"
+        },
+        {
+          "name": "AWS_PROFILE",
+          "value": "hybrid"
+        }
+      ]
+    }
+  ]
+}

--- a/test/integration/cases/upgrade-with-iam/expected-image-credential-provider-config-upgraded
+++ b/test/integration/cases/upgrade-with-iam/expected-image-credential-provider-config-upgraded
@@ -1,0 +1,28 @@
+{
+  "apiVersion": "kubelet.config.k8s.io/v1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "ecr-credential-provider",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1",
+      "env": [
+        {
+          "name": "AWS_CONFIG_FILE",
+          "value": "/.aws/config"
+        },
+        {
+          "name": "AWS_PROFILE",
+          "value": "hybrid"
+        }
+      ]
+    }
+  ]
+}

--- a/test/integration/cases/upgrade-with-iam/expected-kubeconfig
+++ b/test/integration/cases/upgrade-with-iam/expected-kubeconfig
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Config
+clusters:
+  - name: kubernetes
+    cluster:
+      certificate-authority: /etc/kubernetes/pki/ca.crt
+      server: https://example.com
+current-context: kubelet
+contexts:
+  - name: kubelet
+    context:
+      cluster: kubernetes
+      user: kubelet
+users:
+  - name: kubelet
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: "/usr/local/bin/aws-iam-authenticator"
+        env:
+          - name: "AWS_PROFILE"
+            value: "hybrid"
+          - name: "AWS_CONFIG_FILE"
+            value: "/.aws/config"
+        args:
+          - "token"
+          - "--cluster-id"
+          - "my-cluster"
+          - "--region"
+          - "us-west-2"

--- a/test/integration/cases/upgrade-with-iam/expected-kubelet-config-initial
+++ b/test/integration/cases/upgrade-with-iam/expected-kubelet-config-initial
@@ -1,0 +1,63 @@
+{
+  "address": "0.0.0.0",
+  "authentication": {
+    "x509": {
+      "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+    },
+    "webhook": {
+      "enabled": true,
+      "cacheTTL": "2m0s"
+    },
+    "anonymous": {
+      "enabled": false
+    }
+  },
+  "authorization": {
+    "mode": "Webhook",
+    "webhook": {
+      "cacheAuthorizedTTL": "5m0s",
+      "cacheUnauthorizedTTL": "30s"
+    }
+  },
+  "cgroupDriver": "systemd",
+  "cgroupRoot": "/",
+  "clusterDNS": [
+    "10.100.0.10"
+  ],
+  "clusterDomain": "cluster.local",
+  "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
+  "evictionHard": {
+    "memory.available": "100Mi",
+    "nodefs.available": "10%",
+    "nodefs.inodesFree": "5%"
+  },
+  "featureGates": {
+    "KubeletCredentialProviders": true,
+    "RotateKubeletServerCertificate": true
+  },
+  "hairpinMode": "hairpin-veth",
+  "kubeAPIBurst": 20,
+  "kubeAPIQPS": 10,
+  "kubeReservedCgroup": "/runtime",
+  "logging": {
+    "verbosity": 2
+  },
+  "protectKernelDefaults": true,
+  "providerID": "eks-hybrid:///us-west-2/my-cluster/mock-hybrid-node",
+  "readOnlyPort": 0,
+  "serializeImagePulls": false,
+  "serverTLSBootstrap": true,
+  "systemReservedCgroup": "/system",
+  "tlsCipherSuites": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+    "TLS_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_RSA_WITH_AES_256_GCM_SHA384"
+  ],
+  "kind": "KubeletConfiguration",
+  "apiVersion": "kubelet.config.k8s.io/v1beta1"
+}

--- a/test/integration/cases/upgrade-with-iam/expected-kubelet-config-upgraded
+++ b/test/integration/cases/upgrade-with-iam/expected-kubelet-config-upgraded
@@ -1,0 +1,60 @@
+{
+    "address": "0.0.0.0",
+    "authentication": {
+        "x509": {
+            "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+        },
+        "webhook": {
+            "enabled": true,
+            "cacheTTL": "2m0s"
+        },
+        "anonymous": {
+            "enabled": false
+        }
+    },
+    "authorization": {
+        "mode": "Webhook",
+        "webhook": {
+            "cacheAuthorizedTTL": "5m0s",
+            "cacheUnauthorizedTTL": "30s"
+        }
+    },
+    "cgroupDriver": "systemd",
+    "cgroupRoot": "/",
+    "clusterDNS": [
+        "10.100.0.10"
+    ],
+    "clusterDomain": "cluster.local",
+    "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
+    "evictionHard": {
+        "memory.available": "100Mi",
+        "nodefs.available": "10%",
+        "nodefs.inodesFree": "5%"
+    },
+    "featureGates": {
+        "RotateKubeletServerCertificate": true
+    },
+    "hairpinMode": "hairpin-veth",
+    "kubeReservedCgroup": "/runtime",
+    "logging": {
+        "verbosity": 2
+    },
+    "protectKernelDefaults": true,
+    "providerID": "eks-hybrid:///us-west-2/my-cluster/mock-hybrid-node",
+    "readOnlyPort": 0,
+    "serializeImagePulls": false,
+    "serverTLSBootstrap": true,
+    "systemReservedCgroup": "/system",
+    "tlsCipherSuites": [
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_GCM_SHA384"
+    ],
+    "kind": "KubeletConfiguration",
+    "apiVersion": "kubelet.config.k8s.io/v1beta1"
+}

--- a/test/integration/cases/upgrade-with-iam/expected-kubelet-systemd-unit
+++ b/test/integration/cases/upgrade-with-iam/expected-kubelet-systemd-unit
@@ -1,0 +1,26 @@
+[Unit]
+Description=Kubernetes Kubelet
+Documentation=https://github.com/kubernetes/kubernetes
+After=containerd.service
+Requires=containerd.service
+
+[Service]
+Slice=runtime.slice
+EnvironmentFile=/etc/eks/kubelet/environment
+ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
+ExecStart=/usr/bin/kubelet \
+    --config /etc/kubernetes/kubelet/config.json \
+    --kubeconfig /var/lib/kubelet/kubeconfig \
+    --container-runtime-endpoint unix:///run/containerd/containerd.sock \
+    $NODEADM_KUBELET_ARGS\
+    $KUBELET_EXTRA_ARGS
+
+Restart=on-failure
+RestartForceExitStatus=SIGPIPE
+RestartSec=5
+KillMode=process
+CPUAccounting=true
+MemoryAccounting=true
+
+[Install]
+WantedBy=multi-user.target

--- a/test/integration/cases/upgrade-with-iam/run.sh
+++ b/test/integration/cases/upgrade-with-iam/run.sh
@@ -19,6 +19,9 @@ dnf remove -y containerd
 # initial: version 1.26
 # target: version 1.30
 nodeadm install $INITIAL_VERSION --credential-provider iam-ra
+
+# Verify all binaries are installed at correct location
+# and all generated config files have desired content
 assert::path-exists /usr/bin/containerd
 assert::path-exists /usr/sbin/iptables
 assert::path-exists /usr/bin/kubelet
@@ -30,10 +33,40 @@ assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
 assert::path-exists /usr/local/bin/aws-iam-authenticator
 assert::path-exists /usr/local/bin/aws_signing_helper
 assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+assert::path-exists /etc/systemd/system/kubelet.service
+assert::files-equal /etc/systemd/system/kubelet.service expected-kubelet-systemd-unit
+# Verify installed binaries have the correct permission as we specified in code
+# Only verify the files whose permission we specified in code
+assert::file-permission-matches /usr/bin/kubelet 755
+assert::file-permission-matches /etc/systemd/system/kubelet.service 644
+assert::file-permission-matches /usr/local/bin/kubectl 755
+assert::file-permission-matches /etc/eks/image-credential-provider/ecr-credential-provider 755
+assert::file-permission-matches /usr/local/bin/aws-iam-authenticator 755
 
-nodeadm init --skip run,preprocess --config-source file://config.yaml
+nodeadm init --skip run --config-source file://config.yaml
+validate-file /etc/systemd/system/aws_signing_helper_update.service 644 expected-aws-signing-helper-systemd-unit
+validate-file /.aws/config 644 expected-aws-config
+# The memory reserved by kubelet is dynamic depending on the host that builts the docker image
+# Remove kubeReserved field before checking its content
+cat <<< $(jq 'del(.kubeReserved)' /etc/kubernetes/kubelet/config.json) > /etc/kubernetes/kubelet/config.json
+validate-json-file /etc/kubernetes/kubelet/config.json 644 expected-kubelet-config-initial
+validate-file /etc/containerd/config.toml 644 expected-containerd-config
+validate-file /var/lib/kubelet/kubeconfig 644 expected-kubeconfig
+validate-json-file /etc/eks/image-credential-provider/config.json 644 expected-image-credential-provider-config-initial
+validate-file /etc/kubernetes/pki/ca.crt 644 expected-ca-crt
+# Order of items in this file is random, skip checking content of /etc/eks/kubelet/environment
+validate-file /etc/eks/kubelet/environment 644
+
+# In integration test environment, the aws_signing_helper_update will run
+# but stuck in a loop of failure which prevents the next nodeadm init call
+# from starting it, we manually stop and reset the service to work around it.
+systemctl stop aws_signing_helper_update.service
+systemctl disable aws_signing_helper_update.service
+systemctl daemon-reload
+systemctl reset-failed
 
 nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation --config-source file://config.yaml
+
 assert::path-exists /usr/bin/containerd
 assert::path-exists /usr/sbin/iptables
 assert::path-exists /usr/local/bin/kubectl
@@ -44,3 +77,22 @@ assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
 assert::path-exists /usr/local/bin/aws-iam-authenticator
 assert::path-exists /usr/local/bin/aws_signing_helper
 assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+assert::path-exists /etc/systemd/system/kubelet.service
+assert::files-equal /etc/systemd/system/kubelet.service expected-kubelet-systemd-unit
+
+assert::file-permission-matches /usr/local/bin/aws_signing_helper 755
+assert::file-permission-matches /usr/bin/kubelet 755
+assert::file-permission-matches /etc/systemd/system/kubelet.service 644
+assert::file-permission-matches /usr/local/bin/kubectl 755
+assert::file-permission-matches /etc/eks/image-credential-provider/ecr-credential-provider 755
+assert::file-permission-matches /usr/local/bin/aws-iam-authenticator 755
+
+validate-file /etc/systemd/system/aws_signing_helper_update.service 644 expected-aws-signing-helper-systemd-unit
+validate-file /.aws/config 644 expected-aws-config
+cat <<< $(jq 'del(.kubeReserved)' /etc/kubernetes/kubelet/config.json) > /etc/kubernetes/kubelet/config.json
+validate-json-file /etc/kubernetes/kubelet/config.json 644 expected-kubelet-config-upgraded
+validate-file /etc/containerd/config.toml 644 expected-containerd-config
+validate-file /var/lib/kubelet/kubeconfig 644 expected-kubeconfig
+validate-json-file /etc/eks/image-credential-provider/config.json 644 expected-image-credential-provider-config-upgraded
+validate-file /etc/kubernetes/pki/ca.crt 644 expected-ca-crt
+validate-file /etc/eks/kubelet/environment 644

--- a/test/integration/cases/upgrade-with-ssm/expected-ca-crt
+++ b/test/integration/cases/upgrade-with-ssm/expected-ca-crt
@@ -1,0 +1,1 @@
+certificateAuthority

--- a/test/integration/cases/upgrade-with-ssm/expected-containerd-config
+++ b/test/integration/cases/upgrade-with-ssm/expected-containerd-config
@@ -1,0 +1,26 @@
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+# Users can use the following import directory to add additional
+# configuration to containerd. The imports do not behave exactly like overrides.
+# see: https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md#format
+imports = ["/etc/containerd/config.d/*.toml"]
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri".containerd]
+    default_runtime_name = "runc"
+    discard_unpacked_layers = true
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5"
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+    runtime_type = "io.containerd.runc.v2"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+    SystemdCgroup = true
+  [plugins."io.containerd.grpc.v1.cri".cni]
+    bin_dir = "/opt/cni/bin"
+    conf_dir = "/etc/cni/net.d"

--- a/test/integration/cases/upgrade-with-ssm/expected-image-credential-provider-config-initial
+++ b/test/integration/cases/upgrade-with-ssm/expected-image-credential-provider-config-initial
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "kubelet.config.k8s.io/v1alpha1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "ecr-credential-provider",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1alpha1"
+    }
+  ]
+}

--- a/test/integration/cases/upgrade-with-ssm/expected-image-credential-provider-config-upgraded
+++ b/test/integration/cases/upgrade-with-ssm/expected-image-credential-provider-config-upgraded
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "kubelet.config.k8s.io/v1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "ecr-credential-provider",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1"
+    }
+  ]
+}

--- a/test/integration/cases/upgrade-with-ssm/expected-kubeconfig
+++ b/test/integration/cases/upgrade-with-ssm/expected-kubeconfig
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Config
+clusters:
+  - name: kubernetes
+    cluster:
+      certificate-authority: /etc/kubernetes/pki/ca.crt
+      server: https://example.com
+current-context: kubelet
+contexts:
+  - name: kubelet
+    context:
+      cluster: kubernetes
+      user: kubelet
+users:
+  - name: kubelet
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: "/usr/local/bin/aws-iam-authenticator"
+        args:
+          - "token"
+          - "--cluster-id"
+          - "my-cluster"
+          - "--region"
+          - "us-west-2"

--- a/test/integration/cases/upgrade-with-ssm/expected-kubelet-config-initial
+++ b/test/integration/cases/upgrade-with-ssm/expected-kubelet-config-initial
@@ -1,0 +1,63 @@
+{
+  "address": "0.0.0.0",
+  "authentication": {
+    "x509": {
+      "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+    },
+    "webhook": {
+      "enabled": true,
+      "cacheTTL": "2m0s"
+    },
+    "anonymous": {
+      "enabled": false
+    }
+  },
+  "authorization": {
+    "mode": "Webhook",
+    "webhook": {
+      "cacheAuthorizedTTL": "5m0s",
+      "cacheUnauthorizedTTL": "30s"
+    }
+  },
+  "cgroupDriver": "systemd",
+  "cgroupRoot": "/",
+  "clusterDNS": [
+    "10.100.0.10"
+  ],
+  "clusterDomain": "cluster.local",
+  "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
+  "evictionHard": {
+    "memory.available": "100Mi",
+    "nodefs.available": "10%",
+    "nodefs.inodesFree": "5%"
+  },
+  "featureGates": {
+    "KubeletCredentialProviders": true,
+    "RotateKubeletServerCertificate": true
+  },
+  "hairpinMode": "hairpin-veth",
+  "kubeAPIBurst": 20,
+  "kubeAPIQPS": 10,
+  "kubeReservedCgroup": "/runtime",
+  "logging": {
+    "verbosity": 2
+  },
+  "protectKernelDefaults": true,
+  "providerID": "eks-hybrid:///us-west-2/my-cluster/mock-hybrid-node",
+  "readOnlyPort": 0,
+  "serializeImagePulls": false,
+  "serverTLSBootstrap": true,
+  "systemReservedCgroup": "/system",
+  "tlsCipherSuites": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+    "TLS_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_RSA_WITH_AES_256_GCM_SHA384"
+  ],
+  "kind": "KubeletConfiguration",
+  "apiVersion": "kubelet.config.k8s.io/v1beta1"
+}

--- a/test/integration/cases/upgrade-with-ssm/expected-kubelet-config-upgraded
+++ b/test/integration/cases/upgrade-with-ssm/expected-kubelet-config-upgraded
@@ -1,0 +1,60 @@
+{
+    "address": "0.0.0.0",
+    "authentication": {
+        "x509": {
+            "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+        },
+        "webhook": {
+            "enabled": true,
+            "cacheTTL": "2m0s"
+        },
+        "anonymous": {
+            "enabled": false
+        }
+    },
+    "authorization": {
+        "mode": "Webhook",
+        "webhook": {
+            "cacheAuthorizedTTL": "5m0s",
+            "cacheUnauthorizedTTL": "30s"
+        }
+    },
+    "cgroupDriver": "systemd",
+    "cgroupRoot": "/",
+    "clusterDNS": [
+        "10.100.0.10"
+    ],
+    "clusterDomain": "cluster.local",
+    "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
+    "evictionHard": {
+        "memory.available": "100Mi",
+        "nodefs.available": "10%",
+        "nodefs.inodesFree": "5%"
+    },
+    "featureGates": {
+        "RotateKubeletServerCertificate": true
+    },
+    "hairpinMode": "hairpin-veth",
+    "kubeReservedCgroup": "/runtime",
+    "logging": {
+        "verbosity": 2
+    },
+    "protectKernelDefaults": true,
+    "providerID": "eks-hybrid:///us-west-2/my-cluster/mock-hybrid-node",
+    "readOnlyPort": 0,
+    "serializeImagePulls": false,
+    "serverTLSBootstrap": true,
+    "systemReservedCgroup": "/system",
+    "tlsCipherSuites": [
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_GCM_SHA384"
+    ],
+    "kind": "KubeletConfiguration",
+    "apiVersion": "kubelet.config.k8s.io/v1beta1"
+}

--- a/test/integration/cases/upgrade-with-ssm/expected-kubelet-systemd-unit
+++ b/test/integration/cases/upgrade-with-ssm/expected-kubelet-systemd-unit
@@ -1,0 +1,26 @@
+[Unit]
+Description=Kubernetes Kubelet
+Documentation=https://github.com/kubernetes/kubernetes
+After=containerd.service
+Requires=containerd.service
+
+[Service]
+Slice=runtime.slice
+EnvironmentFile=/etc/eks/kubelet/environment
+ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
+ExecStart=/usr/bin/kubelet \
+    --config /etc/kubernetes/kubelet/config.json \
+    --kubeconfig /var/lib/kubelet/kubeconfig \
+    --container-runtime-endpoint unix:///run/containerd/containerd.sock \
+    $NODEADM_KUBELET_ARGS\
+    $KUBELET_EXTRA_ARGS
+
+Restart=on-failure
+RestartForceExitStatus=SIGPIPE
+RestartSec=5
+KillMode=process
+CPUAccounting=true
+MemoryAccounting=true
+
+[Install]
+WantedBy=multi-user.target

--- a/test/integration/cases/upgrade-with-ssm/run.sh
+++ b/test/integration/cases/upgrade-with-ssm/run.sh
@@ -19,6 +19,8 @@ dnf remove -y containerd
 # initial: version 1.26
 # target: version 1.30
 nodeadm install $INITIAL_VERSION --credential-provider ssm
+# Verify all binaries are installed at correct location
+# and all generated config files have desired content
 assert::path-exists /usr/bin/containerd
 assert::path-exists /usr/sbin/iptables
 assert::path-exists /usr/bin/kubelet
@@ -30,8 +32,30 @@ assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
 assert::path-exists /usr/local/bin/aws-iam-authenticator
 assert::path-exists /opt/aws/ssm-setup-cli
 assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+assert::path-exists /etc/systemd/system/kubelet.service
+assert::files-equal /etc/systemd/system/kubelet.service expected-kubelet-systemd-unit
+# Verify installed binaries have the correct permission as we specified in code
+# Only verify the files whose permission we specified in code
+assert::file-permission-matches /usr/bin/kubelet 755
+assert::file-permission-matches /etc/systemd/system/kubelet.service 644
+assert::file-permission-matches /usr/local/bin/kubectl 755
+assert::file-permission-matches /etc/eks/image-credential-provider/ecr-credential-provider 755
+assert::file-permission-matches /usr/local/bin/aws-iam-authenticator 755
+assert::file-permission-matches /opt/aws/ssm-setup-cli 755
 
+# It's very difficult to simulate amazon-ssm-agent daemon in the integration test environment,
+# skip the preprocess stage of init for now.
 nodeadm init --skip run,preprocess --config-source file://config.yaml
+# The memory reserved by kubelet is dynamic depending on the host that builts the docker image
+# Remove kubeReserved field before checking its content
+cat <<< $(jq 'del(.kubeReserved)' /etc/kubernetes/kubelet/config.json) > /etc/kubernetes/kubelet/config.json
+validate-json-file /etc/kubernetes/kubelet/config.json 644 expected-kubelet-config-initial
+validate-file /var/lib/kubelet/kubeconfig 644 expected-kubeconfig
+validate-file /etc/containerd/config.toml 644 expected-containerd-config
+validate-json-file /etc/eks/image-credential-provider/config.json 644 expected-image-credential-provider-config-initial
+validate-file /etc/kubernetes/pki/ca.crt 644 expected-ca-crt
+# Order of items in this file is random, skip checking content of /etc/eks/kubelet/environment
+validate-file /etc/eks/kubelet/environment 644
 
 nodeadm upgrade $TARGET_VERSION --skip run,preprocess,pod-validation,node-validation --config-source file://config.yaml
 assert::path-exists /usr/bin/containerd
@@ -44,3 +68,21 @@ assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
 assert::path-exists /usr/local/bin/aws-iam-authenticator
 assert::path-exists /opt/aws/ssm-setup-cli
 assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+assert::path-exists /etc/systemd/system/kubelet.service
+assert::files-equal /etc/systemd/system/kubelet.service expected-kubelet-systemd-unit
+
+assert::file-permission-matches /usr/bin/kubelet 755
+assert::file-permission-matches /etc/systemd/system/kubelet.service 644
+assert::file-permission-matches /usr/local/bin/kubectl 755
+assert::file-permission-matches /etc/eks/image-credential-provider/ecr-credential-provider 755
+assert::file-permission-matches /usr/local/bin/aws-iam-authenticator 755
+assert::file-permission-matches /opt/aws/ssm-setup-cli 755
+
+cat <<< $(jq 'del(.kubeReserved)' /etc/kubernetes/kubelet/config.json) > /etc/kubernetes/kubelet/config.json
+validate-json-file /etc/kubernetes/kubelet/config.json 644 expected-kubelet-config-upgraded
+validate-file /var/lib/kubelet/kubeconfig 644 expected-kubeconfig
+validate-file /etc/containerd/config.toml 644 expected-containerd-config
+validate-json-file /etc/eks/image-credential-provider/config.json 644 expected-image-credential-provider-config-upgraded
+validate-file /etc/kubernetes/pki/ca.crt 644 expected-ca-crt
+# Order of items in this file is random, skip checking content of /etc/eks/kubelet/environment
+validate-file /etc/eks/kubelet/environment 644


### PR DESCRIPTION
Improve coverage of nodeadm integration tests.
Testing steps added to existing test cases include:

- Verify the existence of config files generated during install/init and verify their content
- Verify the permission of binaries and config files.