### PR TITLE
Revert "Make artifacts public on build release bucket"

### DIFF
--- a/buildspecs/dev-release-nodeadm.yml
+++ b/buildspecs/dev-release-nodeadm.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   build:
     commands:
-    - aws s3 cp _bin/amd64/nodeadm s3://$ARTIFACTS_BUCKET/${CODEBUILD_BUILD_NUMBER}/linux/amd64/nodeadm --acl public-read
-    - aws s3 cp _bin/arm64/nodeadm s3://$ARTIFACTS_BUCKET/${CODEBUILD_BUILD_NUMBER}/linux/arm64/nodeadm --acl public-read
-    - aws s3 cp _bin/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/amd64/nodeadm --acl public-read
-    - aws s3 cp _bin/arm64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/arm64/nodeadm --acl public-read
+    - aws s3 cp _bin/amd64/nodeadm s3://$ARTIFACTS_BUCKET/${CODEBUILD_BUILD_NUMBER}/linux/amd64/nodeadm
+    - aws s3 cp _bin/arm64/nodeadm s3://$ARTIFACTS_BUCKET/${CODEBUILD_BUILD_NUMBER}/linux/arm64/nodeadm
+    - aws s3 cp _bin/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/amd64/nodeadm
+    - aws s3 cp _bin/arm64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/arm64/nodeadm


### PR DESCRIPTION
*Description of changes:*
Upgrade to validate if user is changing credential providers.

This isnt needed anymore. ACL is not anymore the recommended way to make artifacts public. Artifacts are made public with bucket policy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

