### PR TITLE
Validate if cluster is active before pulling cidr and apiserverendpoint

### DIFF
--- a/internal/kubelet/cluster.go
+++ b/internal/kubelet/cluster.go
@@ -3,9 +3,11 @@ package kubelet
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 )
 
 func (k *kubelet) ensureClusterDetails() error {
@@ -16,6 +18,9 @@ func (k *kubelet) ensureClusterDetails() error {
 		})
 		if err != nil {
 			return err
+		}
+		if cluster.Cluster.Status != types.ClusterStatusActive {
+			return fmt.Errorf("eks cluster is not active")
 		}
 		if k.nodeConfig.Spec.Cluster.APIServerEndpoint == "" {
 			k.nodeConfig.Spec.Cluster.APIServerEndpoint = *cluster.Cluster.Endpoint


### PR DESCRIPTION
*Description of changes:*
Make sure EKS-cluster is active before proceeding to pull cluster details like CIDR and api server endpoint from the describe cluster api call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

