### PR TITLE
Override file permission during installation if file already exists

### DIFF
--- a/internal/artifact/install.go
+++ b/internal/artifact/install.go
@@ -16,6 +16,9 @@ const DefaultDirPerms = fs.ModeDir | 0755
 // InstallFile installs src to dst with perms permissions. It ensures any base paths exist
 // before installing.
 func InstallFile(dst string, src io.Reader, perms fs.FileMode) error {
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(path.Dir(dst), DefaultDirPerms); err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently nodeadm is using os.OpenFile to create file with specific permission, but if the file already exists, os.OpenFile will not change its permission.

We fix this issue by manually removing the file at destination location before installation.

