### PR TITLE
Allow auto assign public IP in the subnet and create igw route for internet access

### DIFF
--- a/cmd/e2e-test-runner/cleanup/cleanup.go
+++ b/cmd/e2e-test-runner/cleanup/cleanup.go
@@ -37,7 +37,7 @@ func (c *command) Flaggy() *flaggy.Subcommand {
 }
 
 func (s *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
-	fmt.Println("cleaning up E2E resources...")
+	fmt.Println("Cleaning up E2E resources...")
 
 	file, err := os.ReadFile(s.resourcesFilePath)
 	if err != nil {

--- a/test/e2e/cleanup.go
+++ b/test/e2e/cleanup.go
@@ -37,6 +37,6 @@ func (t *TestRunner) CleanupE2EResources(ctx context.Context) error {
 		return fmt.Errorf("failed to clean up IAM roles: %v", err)
 	}
 
-	fmt.Println("cleanup completed successfully!")
+	fmt.Println("Cleanup completed successfully!")
 	return nil
 }


### PR DESCRIPTION
*Description of changes:*

Create route table and internet gateway for the public subnet by adding route 0.0.0.0/0 which allows hybrid nodes to reach the Public API EKS endpoint and allows ssh access to the hybrid nodes for troubleshooting.
Add port 443 inbound access for hybrid node pod and node cidr in the cluster's VPC.
Add port 10250 inbound access for kubernetes API server to kubelet access and port 22 to authorize ssh access to the ec2 instance. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

