### PR TITLE
Fix create dir for EnableCredentialsFile with SSM

### DIFF
--- a/internal/ssm/daemon.go
+++ b/internal/ssm/daemon.go
@@ -82,7 +82,7 @@ func (s *ssm) EnsureRunning() error {
 func (s *ssm) PostLaunch() error {
 	if s.nodeConfig.Spec.Hybrid.EnableCredentialsFile {
 		s.logger.Info("Creating symlink for AWS credentials", zap.String("Symbolic link path", symlinkedAWSConfigPath))
-		err := os.MkdirAll(filepath.Dir(eksHybridPath), 0755)
+		err := os.MkdirAll(eksHybridPath, 0755)
 		if err != nil {
 			return fmt.Errorf("creating path: %v", err)
 		}


### PR DESCRIPTION
*Description of changes:*
There was a bug in the `EnableCredentialsFile` flow with SSM where instead of creating `/eks-hybrid` directory, it was instead trying to create `filepath.Dir("/eks-hybrid")` which equates to just creating `/`.

This PR fixes it to just create `/eks-hybrid`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

