### PR TITLE
Add retries, download-timeouts to network downloads and installs

### DIFF
--- a/crds/node.eks.aws_nodeconfigs.yaml
+++ b/crds/node.eks.aws_nodeconfigs.yaml
@@ -81,6 +81,14 @@ spec:
                 description: HybridOptions defines the options specific to hybrid
                   node enrollment.
                 properties:
+                  enableCredentialsFile:
+                    description: EnableCredentialsFile enables a shared credentials
+                      file on the host at /eks-hybrid/.aws/credentials For SSM, this
+                      means that nodeadm will not create symlink from `/root/.aws/credentials`
+                      to `/eks-hybrid/.aws/credentials`. For IAM Roles Anywhere, this
+                      means that nodeadm will not set up a systemd service to write
+                      and refresh the credentials to `/eks-hybrid/.aws/credentials`.
+                    type: boolean
                   iamRolesAnywhere:
                     description: IAMRolesAnywhere includes IAM Roles Anywhere specific
                       configuration and is mutually exclusive with SSM.

--- a/internal/containerd/install.go
+++ b/internal/containerd/install.go
@@ -1,6 +1,7 @@
 package containerd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -26,15 +27,15 @@ const (
 
 // Source represents a source that serves a containerd binary.
 type Source interface {
-	GetContainerd() artifact.Package
+	GetContainerd(ctx context.Context) artifact.Package
 }
 
-func Install(tracker *tracker.Tracker, source Source, containerdSource SourceName) error {
+func Install(ctx context.Context, tracker *tracker.Tracker, source Source, containerdSource SourceName) error {
 	if containerdSource == ContainerdSourceNone {
 		return nil
 	}
 	if isContainerdNotInstalled() {
-		containerd := source.GetContainerd()
+		containerd := source.GetContainerd(ctx)
 		if err := artifact.InstallPackage(containerd); err != nil {
 			return errors.Wrap(err, "failed to install containerd")
 		}
@@ -43,9 +44,9 @@ func Install(tracker *tracker.Tracker, source Source, containerdSource SourceNam
 	return nil
 }
 
-func Uninstall(source Source) error {
+func Uninstall(ctx context.Context, source Source) error {
 	if isContainerdInstalled() {
-		containerd := source.GetContainerd()
+		containerd := source.GetContainerd(ctx)
 		if err := artifact.UninstallPackage(containerd); err != nil {
 			return errors.Wrap(err, "failed to uninstall containerd")
 		}

--- a/internal/iptables/iptables.go
+++ b/internal/iptables/iptables.go
@@ -1,6 +1,7 @@
 package iptables
 
 import (
+	"context"
 	"github.com/pkg/errors"
 	"os/exec"
 
@@ -12,13 +13,13 @@ const iptablesBinName = "iptables"
 
 // Source interface for iptables package
 type Source interface {
-	GetIptables() artifact.Package
+	GetIptables(ctx context.Context) artifact.Package
 }
 
 // Install iptables package required for kubelet
-func Install(tracker *tracker.Tracker, source Source) error {
+func Install(ctx context.Context, tracker *tracker.Tracker, source Source) error {
 	if !isIptablesInstalled() {
-		iptablesSrc := source.GetIptables()
+		iptablesSrc := source.GetIptables(ctx)
 		if err := artifact.InstallPackage(iptablesSrc); err != nil {
 			return errors.Wrap(err, "failed to install iptables")
 		}
@@ -28,9 +29,9 @@ func Install(tracker *tracker.Tracker, source Source) error {
 }
 
 // Uninstall iptables package
-func Uninstall(source Source) error {
+func Uninstall(ctx context.Context, source Source) error {
 	if isIptablesInstalled() {
-		iptablesSrc := source.GetIptables()
+		iptablesSrc := source.GetIptables(ctx)
 		if err := artifact.UninstallPackage(iptablesSrc); err != nil {
 			return errors.Wrap(err, "failed to uninstall iptables")
 		}

--- a/internal/ssm/install.go
+++ b/internal/ssm/install.go
@@ -18,12 +18,12 @@ const installerPath = "/opt/aws/ssm-setup-cli"
 
 // Source serves an SSM installer binary for the target platform.
 type Source interface {
-	GetSSMInstaller(context.Context) (io.ReadCloser, error)
+	GetSSMInstaller(ctx context.Context) (io.ReadCloser, error)
 }
 
 // PkgSource serves and defines the package for target platform
 type PkgSource interface {
-	GetSSMPackage() artifact.Package
+	GetSSMPackage(ctx context.Context) artifact.Package
 }
 
 func Install(ctx context.Context, tracker *tracker.Tracker, source Source) error {
@@ -42,7 +42,7 @@ func Install(ctx context.Context, tracker *tracker.Tracker, source Source) error
 
 // Uninstall de-registers the managed instance and removes all files and components that
 // make up the ssm agent component.
-func Uninstall(pkgSource PkgSource) error {
+func Uninstall(ctx context.Context, pkgSource PkgSource) error {
 	instanceId, region, err := GetManagedHybridInstanceIdAndRegion()
 
 	// If uninstall is being run just after running install and before running init
@@ -73,7 +73,7 @@ func Uninstall(pkgSource PkgSource) error {
 		}
 	}
 
-	ssmPkg := pkgSource.GetSSMPackage()
+	ssmPkg := pkgSource.GetSSMPackage(ctx)
 	if err := artifact.UninstallPackage(ssmPkg); err != nil {
 		return errors.Wrapf(err, "failed to uninstall ssm")
 	}

--- a/test/integration/cases/install-with-timeout/run.sh
+++ b/test/integration/cases/install-with-timeout/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+declare SUPPORTED_VERSIONS=(1.27 1.28 1.29 1.30 1.31)
+
+for VERSION in ${SUPPORTED_VERSIONS}
+do
+  if nodeadm install $VERSION --credential-provider ssm --download-timeout 1s; then
+    echo "install should not succeed in 1 second"
+    exit 1
+  fi
+done


### PR DESCRIPTION
*Description of changes:*
Adding retries with backoff to network http get calls. Also added `--download-timeout` that will take a custom timeout for all download and install commands including yum/apt package installs. Install and uninstall default timeout will be 5 mins, upgrade default timeout will be 10 mins.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

