### PR TITLE
Adding new node label for credential provider

### DIFF
--- a/internal/kubelet/config.go
+++ b/internal/kubelet/config.go
@@ -41,7 +41,8 @@ const (
 	kubeletConfigDir  = "config.json.d"
 	kubeletConfigPerm = 0644
 
-	hybridNodeLabel = "eks.amazonaws.com/compute-type=hybrid"
+	hybridNodeLabel            = "eks.amazonaws.com/compute-type=hybrid"
+	credentialProviderLabelKey = "eks.amazonaws.com/hybrid-credential-provider"
 
 	hybridProviderIdPrefix = "eks-hybrid"
 )
@@ -282,7 +283,10 @@ func (ksc *kubeletConfig) withHybridCloudProvider(cfg *api.NodeConfig, flags map
 }
 
 func (ksc *kubeletConfig) withHybridNodeLabels(cfg *api.NodeConfig, flags map[string]string) {
-	flags["node-labels"] = hybridNodeLabel
+	var labels []string
+	labels = append(labels, hybridNodeLabel)
+	labels = append(labels, fmt.Sprintf("%s=%s", credentialProviderLabelKey, cfg.GetNodeType()))
+	flags["node-labels"] = strings.Join(labels, ",")
 }
 
 // When the DefaultReservedResources flag is enabled, override the kubelet

--- a/internal/kubelet/config_test.go
+++ b/internal/kubelet/config_test.go
@@ -143,6 +143,30 @@ func TestHybridCloudProvider(t *testing.T) {
 	assert.Equal(t, *kubeletConfig.ProviderID, expectedProviderId)
 }
 
+func TestHybridLabels(t *testing.T) {
+	nodeConfig := api.NodeConfig{
+		Spec: api.NodeConfigSpec{
+			Cluster: api.ClusterDetails{
+				Name:   "my-cluster",
+				Region: "us-west-2",
+			},
+			Hybrid: &api.HybridOptions{
+				NodeName: "my-node",
+				IAMRolesAnywhere: &api.IAMRolesAnywhere{
+					TrustAnchorARN: "arn:aws:iam::222211113333:role/AmazonEKSConnectorAgentRole",
+					ProfileARN:     "dummy-profile-arn",
+					RoleARN:        "dummy-assume-role-arn",
+				},
+			},
+		},
+	}
+	expectedLabels := "eks.amazonaws.com/compute-type=hybrid,eks.amazonaws.com/hybrid-credential-provider=iam-ra"
+	kubeletArgs := make(map[string]string)
+	kubeletConfig := defaultKubeletSubConfig()
+	kubeletConfig.withHybridNodeLabels(&nodeConfig, kubeletArgs)
+	assert.Equal(t, kubeletArgs["node-labels"], expectedLabels)
+}
+
 func TestResolvConf(t *testing.T) {
 	resolvConfPath := "/dummy/path/to/resolv.conf"
 	kubeletConfig := defaultKubeletSubConfig()


### PR DESCRIPTION
*Description of changes:*
We want to add a new label to nodes to track what credential provider was used when running nodeadm.

*Testing (if applicable):*
Build nodeadm and ran install and init. Saw new label `eks.amazonaws.com/hybrid-credential-provider: ssm` on the nodes.

```
root@ip-10-0-59-81:/home/ubuntu# k get node mi-05c1e85888a3cd9b6 -oyaml
apiVersion: v1
kind: Node
metadata:
  annotations:
    node.alpha.kubernetes.io/ttl: "0"
    volumes.kubernetes.io/controller-managed-attach-detach: "true"
  creationTimestamp: "2024-10-30T21:22:30Z"
  labels:
    beta.kubernetes.io/arch: amd64
    beta.kubernetes.io/os: linux
    eks.amazonaws.com/compute-type: hybrid
    eks.amazonaws.com/hybrid-credential-provider: ssm
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

