### PR TITLE
Add e2e-test-runner binary to nodeadm release output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,8 @@ $(GOLANGCI_LINT): $(LOCALBIN) $(GOLANGCI_LINT_CONFIG)
 
 .PHONY: e2e-tests-binary
 e2e-tests-binary:
-	GOMAXPROCS=10 go test ./test/e2e/validate -c -o "./_bin/e2e.test" -tags "e2e"
+	GOMAXPROCS=10 go test ./test/e2e/validate -c -o "./_bin/e2e-validate.test" -tags "e2e_validate"
+	go test -c ./test/e2e -o ./_bin/e2e.test -tags "e2e"
 
 .PHONY: e2e-setup
 e2e-setup:

--- a/buildspecs/build-nodeadm.yml
+++ b/buildspecs/build-nodeadm.yml
@@ -3,9 +3,7 @@ version: 0.2
 phases:
   build:
     commands:
-    - make build-cross-platform e2e-tests-binary
-    - aws s3 cp _bin/ s3://$ARTIFACTS_BUCKET --recursive
-    - aws s3 cp testdata/nodeconfig.yaml s3://$ARTIFACTS_BUCKET
+    - make build-cross-platform e2e-tests-binary e2e-setup
 
 cache:
   paths:
@@ -15,4 +13,7 @@ cache:
 artifacts:
   files:
   - "_bin/**/*"
+  - "_bin/e2e.test"
+  - "_bin/e2e-test-runner"
   - "buildspecs/*"
+  - "testdata/nodeconfig.yaml"

--- a/buildspecs/dev-release-nodeadm.yml
+++ b/buildspecs/dev-release-nodeadm.yml
@@ -7,3 +7,7 @@ phases:
     - aws s3 cp _bin/arm64/nodeadm s3://$ARTIFACTS_BUCKET/${CODEBUILD_BUILD_NUMBER}/linux/arm64/nodeadm --acl public-read
     - aws s3 cp _bin/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/amd64/nodeadm --acl public-read
     - aws s3 cp _bin/arm64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/arm64/nodeadm --acl public-read
+    - aws s3 cp _bin/e2e-test-runner s3://$ARTIFACTS_BUCKET/${CODEBUILD_BUILD_NUMBER}/e2e-test-runnner --acl public-read
+    - aws s3 cp _bin/e2e.test s3://$ARTIFACTS_BUCKET/${CODEBUILD_BUILD_NUMBER}/e2e.test --acl public-read
+    - aws s3 cp _bin/e2e-test-runner s3://$ARTIFACTS_BUCKET/latest/e2e-test-runnner --acl public-read
+    - aws s3 cp _bin/e2e.test s3://$ARTIFACTS_BUCKET/latest/e2e.test --acl public-read

--- a/buildspecs/test-nodeadm.yml
+++ b/buildspecs/test-nodeadm.yml
@@ -3,4 +3,4 @@ version: 0.2
 phases:
   build:
     commands:
-    - ${CODEBUILD_SRC_DIR}/_bin/e2e.test -test.parallel 10
+    - ${CODEBUILD_SRC_DIR}/_bin/e2e-validate.test -test.parallel 10

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/pprof v0.0.0-20240618054019-d3b898a103f8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,7 +69,6 @@ github.com/go-openapi/jsonreference v0.20.2 h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2Kv
 github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
-github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/test/e2e/validate/validate_test.go
+++ b/test/e2e/validate/validate_test.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e_validate
 
 package validate
 


### PR DESCRIPTION
Add both e2e-test-runner binary and the e2e.test binary to nodeadm-build artifact and copy them to s3 bucket to be consumed by nodeadm canary test.

