### PR TITLE
Uninstall to clean up leftover config files and artifacts

### DIFF
--- a/internal/cni/install.go
+++ b/internal/cni/install.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	rootDir = "/opt/cni"
 	// BinPath is the path to the cni plugins binary.
 	BinPath = "/opt/cni/bin"
 
@@ -48,5 +49,5 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 }
 
 func Uninstall() error {
-	return os.RemoveAll(BinPath)
+	return os.RemoveAll(rootDir)
 }

--- a/internal/imagecredentialprovider/install.go
+++ b/internal/imagecredentialprovider/install.go
@@ -3,6 +3,7 @@ package imagecredentialprovider
 import (
 	"context"
 	"os"
+	"path"
 
 	"github.com/pkg/errors"
 
@@ -41,5 +42,5 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 }
 
 func Uninstall() error {
-	return os.RemoveAll(BinPath)
+	return os.RemoveAll(path.Dir(BinPath))
 }

--- a/internal/kubelet/install.go
+++ b/internal/kubelet/install.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"os"
+	"path"
 
 	"github.com/pkg/errors"
 
@@ -62,7 +63,7 @@ func Uninstall() error {
 		BinPath,
 		UnitPath,
 		kubeconfigPath,
-		kubeletConfigRoot,
+		path.Dir(kubeletConfigRoot),
 	}
 
 	for _, path := range pathsToRemove {

--- a/internal/node/hybrid/hybrid.go
+++ b/internal/node/hybrid/hybrid.go
@@ -1,9 +1,9 @@
 package hybrid
 
 import (
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.uber.org/zap"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/nodeprovider"

--- a/internal/tracker/artifacts.go
+++ b/internal/tracker/artifacts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
@@ -12,7 +13,7 @@ import (
 	"github.com/aws/eks-hybrid/internal/util"
 )
 
-const trackerFile = "/opt/aws/nodeadm-tracker"
+const trackerFile = "/opt/nodeadm/tracker"
 
 type Tracker struct {
 	Artifacts *InstalledArtifacts
@@ -70,7 +71,7 @@ func (tracker *Tracker) Save() error {
 }
 
 func Clear() error {
-	return os.RemoveAll(trackerFile)
+	return os.RemoveAll(path.Dir(trackerFile))
 }
 
 // GetInstalledArtifacts reads the tracker file and returns the current

--- a/test/integration/cases/install-containerd-source-none/run.sh
+++ b/test/integration/cases/install-containerd-source-none/run.sh
@@ -31,7 +31,7 @@ do
 
     assert::path-exists /usr/local/bin/aws_signing_helper
 
-    assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+    assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 
     nodeadm uninstall --skip node-validation,pod-validation
 
@@ -42,5 +42,5 @@ do
     assert::path-not-exist /etc/eks/image-credential-provider/ecr-credential-provider
     assert::path-not-exist /usr/local/bin/aws-iam-authenticator
     assert::path-not-exist /usr/local/bin/aws_signing_helper
-    assert::path-not-exist /opt/aws/nodeadm-tracker
+    assert::path-not-exist /opt/nodeadm/tracker
 done

--- a/test/integration/cases/install-with-iam/run.sh
+++ b/test/integration/cases/install-with-iam/run.sh
@@ -30,7 +30,7 @@ do
 
     assert::path-exists /usr/local/bin/aws_signing_helper
 
-    assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+    assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 
     nodeadm uninstall --skip node-validation,pod-validation
 
@@ -43,5 +43,5 @@ do
     assert::path-not-exist /usr/local/bin/aws-iam-authenticator
     assert::path-not-exist /usr/local/bin/aws_signing_helper
     assert::path-not-exist /usr/bin/containerd
-    assert::path-not-exist /opt/aws/nodeadm-tracker
+    assert::path-not-exist /opt/nodeadm/tracker
 done

--- a/test/integration/cases/install-with-ssm/run.sh
+++ b/test/integration/cases/install-with-ssm/run.sh
@@ -28,9 +28,9 @@ do
     assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
     assert::path-exists /usr/local/bin/aws-iam-authenticator
 
-    assert::path-exists /opt/aws/ssm-setup-cli
+    assert::path-exists /opt/ssm/ssm-setup-cli
 
-    assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+    assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 
     nodeadm uninstall --skip node-validation,pod-validation
 
@@ -42,6 +42,6 @@ do
     assert::path-not-exist /etc/eks/image-credential-provider/ecr-credential-provider
     assert::path-not-exist /usr/local/bin/aws-iam-authenticator
     assert::path-not-exist /usr/bin/containerd
-    assert::path-not-exist /opt/aws/ssm-setup-cli
-    assert::path-not-exist /opt/aws/nodeadm-tracker
+    assert::path-not-exist /opt/ssm/ssm-setup-cli
+    assert::path-not-exist /opt/nodeadm/tracker
 done

--- a/test/integration/cases/upgrade-with-iam/run.sh
+++ b/test/integration/cases/upgrade-with-iam/run.sh
@@ -32,7 +32,7 @@ assert::path-exists /opt/cni/bin/
 assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
 assert::path-exists /usr/local/bin/aws-iam-authenticator
 assert::path-exists /usr/local/bin/aws_signing_helper
-assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 assert::path-exists /etc/systemd/system/kubelet.service
 assert::files-equal /etc/systemd/system/kubelet.service expected-kubelet-systemd-unit
 # Verify installed binaries have the correct permission as we specified in code
@@ -65,7 +65,7 @@ systemctl disable aws_signing_helper_update.service
 systemctl daemon-reload
 systemctl reset-failed
 
-nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation --config-source file://config.yaml
+nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation,init-validation --config-source file://config.yaml
 
 assert::path-exists /usr/bin/containerd
 assert::path-exists /usr/sbin/iptables
@@ -76,7 +76,7 @@ assert::path-exists /opt/cni/bin/
 assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
 assert::path-exists /usr/local/bin/aws-iam-authenticator
 assert::path-exists /usr/local/bin/aws_signing_helper
-assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 assert::path-exists /etc/systemd/system/kubelet.service
 assert::files-equal /etc/systemd/system/kubelet.service expected-kubelet-systemd-unit
 

--- a/test/integration/cases/upgrade-with-ssm/run.sh
+++ b/test/integration/cases/upgrade-with-ssm/run.sh
@@ -30,8 +30,8 @@ assert::is-substring "$VERSION_INFO" "v$INITIAL_VERSION"
 assert::path-exists /opt/cni/bin/
 assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
 assert::path-exists /usr/local/bin/aws-iam-authenticator
-assert::path-exists /opt/aws/ssm-setup-cli
-assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+assert::path-exists /opt/ssm/ssm-setup-cli
+assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 assert::path-exists /etc/systemd/system/kubelet.service
 assert::files-equal /etc/systemd/system/kubelet.service expected-kubelet-systemd-unit
 # Verify installed binaries have the correct permission as we specified in code
@@ -41,7 +41,7 @@ assert::file-permission-matches /etc/systemd/system/kubelet.service 644
 assert::file-permission-matches /usr/local/bin/kubectl 755
 assert::file-permission-matches /etc/eks/image-credential-provider/ecr-credential-provider 755
 assert::file-permission-matches /usr/local/bin/aws-iam-authenticator 755
-assert::file-permission-matches /opt/aws/ssm-setup-cli 755
+assert::file-permission-matches /opt/ssm/ssm-setup-cli 755
 
 # It's very difficult to simulate amazon-ssm-agent daemon in the integration test environment,
 # skip the preprocess stage of init for now.
@@ -57,7 +57,7 @@ validate-file /etc/kubernetes/pki/ca.crt 644 expected-ca-crt
 # Order of items in this file is random, skip checking content of /etc/eks/kubelet/environment
 validate-file /etc/eks/kubelet/environment 644
 
-nodeadm upgrade $TARGET_VERSION --skip run,preprocess,pod-validation,node-validation --config-source file://config.yaml
+nodeadm upgrade $TARGET_VERSION --skip run,preprocess,pod-validation,node-validation,init-validation --config-source file://config.yaml
 assert::path-exists /usr/bin/containerd
 assert::path-exists /usr/sbin/iptables
 assert::path-exists /usr/local/bin/kubectl
@@ -66,8 +66,8 @@ assert::is-substring "$VERSION_INFO" "v$TARGET_VERSION"
 assert::path-exists /opt/cni/bin/
 assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
 assert::path-exists /usr/local/bin/aws-iam-authenticator
-assert::path-exists /opt/aws/ssm-setup-cli
-assert::files-equal /opt/aws/nodeadm-tracker expected-nodeadm-tracker
+assert::path-exists /opt/ssm/ssm-setup-cli
+assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 assert::path-exists /etc/systemd/system/kubelet.service
 assert::files-equal /etc/systemd/system/kubelet.service expected-kubelet-systemd-unit
 
@@ -76,7 +76,7 @@ assert::file-permission-matches /etc/systemd/system/kubelet.service 644
 assert::file-permission-matches /usr/local/bin/kubectl 755
 assert::file-permission-matches /etc/eks/image-credential-provider/ecr-credential-provider 755
 assert::file-permission-matches /usr/local/bin/aws-iam-authenticator 755
-assert::file-permission-matches /opt/aws/ssm-setup-cli 755
+assert::file-permission-matches /opt/ssm/ssm-setup-cli 755
 
 cat <<< $(jq 'del(.kubeReserved)' /etc/kubernetes/kubelet/config.json) > /etc/kubernetes/kubelet/config.json
 validate-json-file /etc/kubernetes/kubelet/config.json 644 expected-kubelet-config-upgraded


### PR DESCRIPTION
*Description of changes:*
- Uninstall command to cleanup leftover resources at /opt/ as well as /etc directories
- Uninstall command should only validate node and pod status only if node has initialized and joined the cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

