### PR TITLE
Validate input yaml file to make sure only acceptable fields are allowed

### DIFF
--- a/cmd/nodeadm/config/check.go
+++ b/cmd/nodeadm/config/check.go
@@ -1,22 +1,24 @@
 package config
 
 import (
-	"github.com/aws/eks-hybrid/internal/cli"
-	"github.com/aws/eks-hybrid/internal/configprovider"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/cli"
+	"github.com/aws/eks-hybrid/internal/configprovider"
 )
 
 type fileCmd struct {
-	cmd *flaggy.Subcommand
+	cmd          *flaggy.Subcommand
+	configSource string
 }
 
 func NewCheckCommand() cli.Command {
-	cmd := flaggy.NewSubcommand("check")
-	cmd.Description = "Verify configuration"
-	return &fileCmd{
-		cmd: cmd,
-	}
+	file := fileCmd{}
+	file.cmd = flaggy.NewSubcommand("check")
+	file.cmd.Description = "Verify configuration"
+	file.cmd.String(&file.configSource, "c", "config-source", "Source of node configuration. The format is a URI with supported schemes: [file, imds].")
+	return &file
 }
 
 func (c *fileCmd) Flaggy() *flaggy.Subcommand {
@@ -24,8 +26,8 @@ func (c *fileCmd) Flaggy() *flaggy.Subcommand {
 }
 
 func (c *fileCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
-	log.Info("Checking configuration", zap.String("source", opts.ConfigSource))
-	provider, err := configprovider.BuildConfigProvider(opts.ConfigSource)
+	log.Info("Checking configuration", zap.String("source", c.configSource))
+	provider, err := configprovider.BuildConfigProvider(c.configSource)
 	if err != nil {
 		return err
 	}

--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -59,6 +59,10 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	if !root {
 		return cli.ErrMustRunAsRoot
 	}
+
+	if c.credentialProvider == "" {
+		flaggy.ShowHelpAndExit("--credential-provider is a required flag. Allowed values are ssm & iam-ra")
+	}
 	credentialProvider, err := creds.GetCredentialProvider(c.credentialProvider)
 	if err != nil {
 		return err

--- a/cmd/nodeadm/main.go
+++ b/cmd/nodeadm/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/eks-hybrid/cmd/nodeadm/install"
 	"github.com/aws/eks-hybrid/cmd/nodeadm/uninstall"
 	"github.com/aws/eks-hybrid/cmd/nodeadm/upgrade"
-	"github.com/aws/eks-hybrid/cmd/nodeadm/validate"
 	"github.com/aws/eks-hybrid/cmd/nodeadm/version"
 	"github.com/aws/eks-hybrid/internal/cli"
 )
@@ -29,7 +28,6 @@ func main() {
 		install.NewCommand(),
 		uninstall.NewCommand(),
 		upgrade.NewUpgradeCommand(),
-		validate.NewCommand(),
 	}
 
 	for _, cmd := range cmds {

--- a/cmd/nodeadm/validate/validate.go
+++ b/cmd/nodeadm/validate/validate.go
@@ -14,12 +14,14 @@ import (
 func NewCommand() cli.Command {
 	validate := validateCmd{}
 	validate.cmd = flaggy.NewSubcommand("validate")
+	validate.cmd.String(&validate.configSource, "c", "config-source", "Source of node configuration. The format is a URI with supported schemes: [file, imds].")
 	validate.cmd.Description = "Validate the node can join an EKS cluster"
 	return &validate
 }
 
 type validateCmd struct {
-	cmd *flaggy.Subcommand
+	cmd          *flaggy.Subcommand
+	configSource string
 }
 
 func (c *validateCmd) Flaggy() *flaggy.Subcommand {
@@ -29,8 +31,8 @@ func (c *validateCmd) Flaggy() *flaggy.Subcommand {
 func (c *validateCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	logger.Init()
 
-	logger.Info(fmt.Sprintf("Loading node configuration: %s", opts.ConfigSource))
-	provider, err := configprovider.BuildConfigProvider(opts.ConfigSource)
+	logger.Info(fmt.Sprintf("Loading node configuration: %s", c.configSource))
+	provider, err := configprovider.BuildConfigProvider(c.configSource)
 	if err != nil {
 		return err
 	}

--- a/internal/api/bridge/decode.go
+++ b/internal/api/bridge/decode.go
@@ -3,10 +3,12 @@ package bridge
 import (
 	"fmt"
 
-	api "github.com/aws/eks-hybrid/api"
+	"github.com/aws/eks-hybrid/api"
 	internalapi "github.com/aws/eks-hybrid/internal/api"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/yaml"
 )
 
 // DecodeNodeConfig unmarshals the given data into an internal NodeConfig object.
@@ -32,4 +34,15 @@ func DecodeNodeConfig(data []byte) (*internalapi.NodeConfig, error) {
 		return internalConfig, nil
 	}
 	return nil, fmt.Errorf("unable to convert %T to internal NodeConfig", obj)
+}
+
+// DecodeStrictNodeConfig unmarshals the given data into an internal NodeConfig object.
+// It attempts a struct unmarshalling. Will throw an error if unknown fields are present.
+func DecodeStrictNodeConfig(data []byte) (*internalapi.NodeConfig, error) {
+	var obj internalapi.NodeConfig
+	if err := yaml.UnmarshalStrict(data, &obj); err != nil {
+		return nil, err
+	}
+
+	return &obj, nil
 }

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -3,16 +3,13 @@ package cli
 import "github.com/integrii/flaggy"
 
 type GlobalOptions struct {
-	ConfigSource    string
 	DevelopmentMode bool
 }
 
 func NewGlobalOptions() *GlobalOptions {
 	opts := GlobalOptions{
-		ConfigSource:    "imds://user-data",
 		DevelopmentMode: false,
 	}
-	flaggy.String(&opts.ConfigSource, "c", "config-source", "Source of node configuration. The format is a URI with supported schemes: [imds, file].")
 	flaggy.Bool(&opts.DevelopmentMode, "d", "development", "Enable development mode for logging.")
 	return &opts
 }

--- a/internal/configprovider/file.go
+++ b/internal/configprovider/file.go
@@ -36,7 +36,7 @@ func (fcs *fileConfigProvider) Provide() (*internalapi.NodeConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	config, err := apibridge.DecodeNodeConfig(data)
+	config, err := apibridge.DecodeStrictNodeConfig(data)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -20,7 +20,9 @@ func NewNodeProvider(configSource string, logger *zap.Logger) (nodeprovider.Node
 		return nil, err
 	}
 	if nodeConfig.IsHybridNode() {
+		logger.Info("Setting up hybrid node provider...")
 		return hybrid.NewHybridNodeProvider(nodeConfig, logger)
 	}
+	logger.Info("Setting up EC2 node provider...")
 	return ec2.NewEc2NodeProvider(nodeConfig, logger)
 }

--- a/test/integration/cases/imds-timeouts/run.sh
+++ b/test/integration/cases/imds-timeouts/run.sh
@@ -12,7 +12,7 @@ mock::kubelet 1.29.0
 # configure without launching the imds mock service
 IMDS_MOCK_ONLY_CONFIGURE=true mock::aws
 
-if nodeadm init --skip run,install-validation; then
+if nodeadm init -c imds://user-data --skip run,install-validation; then
   echo "bootstrap should not succeed when EC2 IMDS APIs are not reachable."
   exit 1
 fi
@@ -20,4 +20,4 @@ fi
 # start the imds mock part way into the initialization to mimic
 # delayed availability of IMDS
 { sleep 10 && AWS_MOCK_ONLY_CONFIGURE=true mock::aws; } &
-nodeadm init --skip run,install-validation
+nodeadm init -c imds://user-data --skip run,install-validation


### PR DESCRIPTION
*Description of changes:*
Adding strict unmarshalling to the input config file to allow users to cleanly identify fields in wrong indentation. 

Also sets the --config-source as required command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

