### PR TITLE
Restart credential daemons with init

### DIFF
--- a/internal/iamrolesanywhere/daemon.go
+++ b/internal/iamrolesanywhere/daemon.go
@@ -62,7 +62,7 @@ func (s *SigningHelperDaemon) EnsureRunning() error {
 	if err != nil {
 		return err
 	}
-	return s.daemonManager.StartDaemon(s.Name())
+	return s.daemonManager.RestartDaemon(s.Name())
 }
 
 // PostLaunch runs any additional step that needs to occur after the service

--- a/internal/ssm/daemon.go
+++ b/internal/ssm/daemon.go
@@ -79,7 +79,7 @@ func (s *ssm) EnsureRunning() error {
 	if err != nil {
 		return err
 	}
-	return s.daemonManager.StartDaemon(SsmDaemonName)
+	return s.daemonManager.RestartDaemon(SsmDaemonName)
 }
 
 func (s *ssm) PostLaunch() error {


### PR DESCRIPTION
*Description of changes:*
If the aws credentials file is deleted by mistake, and user attempts an init flow, to re-populate the credentials file, it fails since ssm will skip initialization as there is an existing registration. With this change, ssm will restart forcing it to populate the creds file, while using the same old registration.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

