### PR TITLE
Ensure Go 1.21 is used to build nodeadm

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function get_go_path() {
+  local -r version=$1
+
+  # This is the path where the specific go binary versions reside in our builder-base image
+  local -r gorootbinarypath="/go/go${version}/bin"
+  # This is the path that will most likely be correct if running locally
+  local -r gopathbinarypath="$GOPATH/go${version}/bin"
+  if [ -d "$gorootbinarypath" ]; then
+    echo $gorootbinarypath
+  elif [ -d "$gopathbinarypath" ]; then
+    echo $gopathbinarypath
+  else
+    # not in builder-base, probably running in dev environment
+    # return default go installation
+    local -r which_go=$(which go)
+    echo "$(dirname $which_go)"
+  fi
+}
+
+function use_go_version() {
+  local -r version=$1
+
+  local -r gobinarypath=$(get_go_path $version)
+  echo "Adding $gobinarypath to PATH"
+  # Adding to the beginning of PATH to allow for builds on specific version if it exists
+  export PATH=${gobinarypath}:$PATH
+}


### PR DESCRIPTION
The default Go version in the builder-base image is Go 1.20, so simply invoking the `go` command will invoke the Go 1.20 binary. This PR makes the build explicitly use the full binary path which points to the correct Go binary corresponding to the input Go version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

