### PR TITLE
Fix logger undefined syntax error

### DIFF
--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -149,7 +149,7 @@ func runNodeadmUninstall(ctx context.Context, client *ssm.SSM, instanceID string
 		instanceID: instanceID,
 		commands:   commands,
 	}
-	outputs, err := ssmConfig.runCommandsOnInstance(ctx)
+	outputs, err := ssmConfig.runCommandsOnInstance(ctx, logger)
 	if err != nil {
 		return fmt.Errorf("running SSM command: %w", err)
 	}

--- a/test/e2e/nodeadm_test.go
+++ b/test/e2e/nodeadm_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Hybrid Nodes", Ordered, func() {
 				cfn:                 test.cfnClient,
 				iam:                 test.iamClient,
 			}
-			test.stackOut, err = test.stackIn.deployResourcesStack(ctx)
+			test.stackOut, err = test.stackIn.deployResourcesStack(ctx, logger)
 			Expect(err).NotTo(HaveOccurred(), "e2e resrouce stack should have been deployed")
 
 			for _, provider := range credentialProviders {
@@ -246,7 +246,7 @@ var _ = Describe("Hybrid Nodes", Ordered, func() {
 
 		AfterAll(func(ctx context.Context) {
 			logger.Info("Deleting e2e resources stack", "stackName", test.stackIn.stackName)
-			err := test.stackIn.deleteResourceStack(ctx)
+			err := test.stackIn.deleteResourceStack(ctx, logger)
 			Expect(err).NotTo(HaveOccurred(), "failed to delete stack")
 		})
 	})

--- a/test/e2e/ssm.go
+++ b/test/e2e/ssm.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/go-logr/logr"
 )
 
 func createSSMActivation(client *ssm.SSM, iamRole string, ssmActivationName string) (*ssm.CreateActivationOutput, error) {
@@ -35,7 +36,7 @@ type ssmConfig struct {
 	commands   []string
 }
 
-func (s *ssmConfig) runCommandsOnInstance(ctx context.Context) ([]ssm.GetCommandInvocationOutput, error) {
+func (s *ssmConfig) runCommandsOnInstance(ctx context.Context, logger logr.Logger) ([]ssm.GetCommandInvocationOutput, error) {
 	outputs := []ssm.GetCommandInvocationOutput{}
 	for _, command := range s.commands {
 		logger.Info("Running command: ", "command", command)


### PR DESCRIPTION
Logger definition is missing in several files under e2e package and will cause syntax error, added logger to package import list and function signatures to fix this issue.
