### PR TITLE
Build Ginkgo binary in the build stage and pass it to test stage

### DIFF
--- a/buildspecs/build-nodeadm.yml
+++ b/buildspecs/build-nodeadm.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   build:
     commands:
-    - make build-cross-platform e2e-tests-binary e2e-setup
+    - make build-cross-platform e2e-tests-binary e2e-setup ginkgo
 
 cache:
   paths:

--- a/buildspecs/test-nodeadm.yml
+++ b/buildspecs/test-nodeadm.yml
@@ -6,10 +6,6 @@ env:
     RHEL_PASSWORD: "redhat-credentials:password"
 
 phases:
-  pre_build:
-    commands:
-    - make ginkgo
-
   build:
     commands:
     - ./hack/run-e2e.sh hybrid-e2e-$CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/latest/linux/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/arm64/nodeadm


### PR DESCRIPTION
The test stage doesn't have any source and we aren't passing the Makefile from the build stage, so the test stage just fails with the following error:
```console
make: *** No rule to make target 'ginkgo'.  Stop.
```
This PR has changes to build the `ginkgo` binary in the build stage and pass it to test stage (similar to other Go binaries).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

