### PR TITLE
changes nodeadmurl to two fields for arm and amd

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -61,7 +61,8 @@ cat <<EOF > $CONFIG_DIR/e2e-param.yaml
 clusterName: "$CLUSTER_NAME-${KUBERNETES_VERSION/./-}"
 clusterRegion: "$REGION"
 hybridVpcID: "$VPC_ID"
-nodeadmUrl: "$NODEADM_AMD_URL"
+nodeadmUrlAMD: "$NODEADM_AMD_URL"
+nodeadmUrlARM: "$NODEADM_ARM_URL"
 EOF
 
 $BIN_DIR/ginkgo -v -tags=e2e --label-filter='ssm' $BIN_DIR/e2e.test -- -filepath=$CONFIG_DIR/e2e-param.yaml

--- a/test/e2e/amazonlinux.go
+++ b/test/e2e/amazonlinux.go
@@ -56,12 +56,16 @@ func (a AmazonLinux2023) AMIName(ctx context.Context, awsSession *session.Sessio
 	return *amiId, err
 }
 
-func (a AmazonLinux2023) BuildUserData(nodeadmUrl, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (a AmazonLinux2023) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
 	data := amazonLinuxCloudInitData{
 		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrl,
+		NodeadmUrl:        nodeadmUrls.AMD,
 		KubernetesVersion: kubernetesVersion,
 		Provider:          provider,
+	}
+
+	if a.Architecture == arm64Arch {
+		data.NodeadmUrl = nodeadmUrls.ARM
 	}
 
 	return executeTemplate(al23CloudInit, data)

--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -30,7 +30,7 @@ const arm64Arch = "arm64"
 type NodeadmOS interface {
 	Name() string
 	AMIName(ctx context.Context, awsSession *session.Session) (string, error)
-	BuildUserData(nodeadmUrl, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error)
+	BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error)
 	InstanceType() string
 }
 
@@ -42,6 +42,11 @@ type NodeadmCredentialsProvider interface {
 type SsmProvider struct {
 	ssmClient *ssm.SSM
 	role      string
+}
+
+type NodeadmURLs struct {
+	AMD string
+	ARM string
 }
 
 func (s *SsmProvider) Name() creds.CredentialProvider {

--- a/test/e2e/rhel.go
+++ b/test/e2e/rhel.go
@@ -72,14 +72,18 @@ func (r RedHat8) AMIName(ctx context.Context, awsSession *session.Session) (stri
 	return findLatestImage(ec2.New(awsSession), "RHEL-8*", r.Architecture)
 }
 
-func (r RedHat8) BuildUserData(nodeadmUrl, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (r RedHat8) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
 	data := rhelCloudInitData{
 		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrl,
+		NodeadmUrl:        nodeadmUrls.AMD,
 		KubernetesVersion: kubernetesVersion,
 		Provider:          provider,
 		RhelUsername:      r.RhelUsername,
 		RhelPassword:      r.RhelPassword,
+	}
+
+	if r.Architecture == arm64Arch {
+		data.NodeadmUrl = nodeadmUrls.ARM
 	}
 
 	return executeTemplate(rhel8CloudInit, data)
@@ -126,14 +130,18 @@ func (r RedHat9) AMIName(ctx context.Context, awsSession *session.Session) (stri
 	return findLatestImage(ec2.New(awsSession), "RHEL-9*", r.Architecture)
 }
 
-func (r RedHat9) BuildUserData(nodeadmUrl, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (r RedHat9) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
 	data := rhelCloudInitData{
 		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrl,
+		NodeadmUrl:        nodeadmUrls.AMD,
 		KubernetesVersion: kubernetesVersion,
 		Provider:          provider,
 		RhelUsername:      r.RhelUsername,
 		RhelPassword:      r.RhelPassword,
+	}
+
+	if r.Architecture == arm64Arch {
+		data.NodeadmUrl = nodeadmUrls.ARM
 	}
 
 	return executeTemplate(rhel9CloudInit, data)

--- a/test/e2e/ubuntu.go
+++ b/test/e2e/ubuntu.go
@@ -71,12 +71,16 @@ func (u Ubuntu2004) AMIName(ctx context.Context, awsSession *session.Session) (s
 	return *amiId, err
 }
 
-func (u Ubuntu2004) BuildUserData(nodeadmUrl, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (u Ubuntu2004) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
 	data := ubuntuCloudInitData{
 		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrl,
+		NodeadmUrl:        nodeadmUrls.AMD,
 		KubernetesVersion: kubernetesVersion,
 		Provider:          provider,
+	}
+
+	if u.Architecture == arm64Arch {
+		data.NodeadmUrl = nodeadmUrls.ARM
 	}
 
 	return executeTemplate(ubuntu2004CloudInit, data)
@@ -114,12 +118,16 @@ func (u Ubuntu2204) AMIName(ctx context.Context, awsSession *session.Session) (s
 	return *amiId, err
 }
 
-func (u Ubuntu2204) BuildUserData(nodeadmUrl, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (u Ubuntu2204) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
 	data := ubuntuCloudInitData{
 		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrl,
+		NodeadmUrl:        nodeadmUrls.AMD,
 		KubernetesVersion: kubernetesVersion,
 		Provider:          provider,
+	}
+
+	if u.Architecture == arm64Arch {
+		data.NodeadmUrl = nodeadmUrls.ARM
 	}
 
 	return executeTemplate(ubuntu2204CloudInit, data)
@@ -157,12 +165,16 @@ func (u Ubuntu2404) AMIName(ctx context.Context, awsSession *session.Session) (s
 	return *amiId, err
 }
 
-func (u Ubuntu2404) BuildUserData(nodeadmUrl, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (u Ubuntu2404) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
 	data := ubuntuCloudInitData{
 		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrl,
+		NodeadmUrl:        nodeadmUrls.AMD,
 		KubernetesVersion: kubernetesVersion,
 		Provider:          provider,
+	}
+
+	if u.Architecture == arm64Arch {
+		data.NodeadmUrl = nodeadmUrls.ARM
 	}
 
 	return executeTemplate(ubuntu2404CloudInit, data)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds support for running arm and amd tests in the same run by introducing separate nodeadmurls in the test config.

*Testing (if applicable):*

```
Ran 12 of 12 Specs in 2155.233 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

