### PR TITLE
adds cleanup/node reset test to simpleflow

### DIFF
--- a/test/e2e/cfn-templates/hybrid-cfn.yaml
+++ b/test/e2e/cfn-templates/hybrid-cfn.yaml
@@ -35,15 +35,22 @@ Resources:
           PolicyDocument: 
             Version: '2012-10-17'
             Statement: 
-              - Sid: AllowDeregisterAndDescribeOwnInstance
+              - Sid: AllowDeregisterOwnInstance
                 Effect: Allow
                 Action: 
                   - ssm:DeregisterManagedInstance
-                  - ssm:DescribeInstanceInformation
-                Resource: arn:aws:ec2:*:*:instance/${sts:RoleSessionName}
+                Resource: 'arn:aws:ssm:*:*:managed-instance/*'
                 Condition:
                   ArnLike:
-                    'aws:SourceArn': arn:aws:ec2:*:*:instance/${sts:RoleSessionName}
+                    'ssm:SourceInstanceARN': 'arn:aws:ssm:*:*:managed-instance/*'
+              - Sid: AllowDescribeInstances
+                Effect: Allow
+                Action: 
+                  - ssm:DescribeInstanceInformation
+                Resource: '*'
+                Condition:
+                  ArnLike:
+                    'ssm:SourceInstanceARN': 'arn:aws:ssm:*:*:managed-instance/*'
         - PolicyName: EKSDescribeCluster
           PolicyDocument: 
             Version: '2012-10-17'

--- a/test/e2e/ec2.go
+++ b/test/e2e/ec2.go
@@ -141,7 +141,6 @@ func deleteEC2Instance(ctx context.Context, client *ec2.Client, instanceID strin
 	if _, err := client.TerminateInstances(ctx, terminateInstanceInput); err != nil {
 		return err
 	}
-	fmt.Println("EC2 instance terminated successfully.")
 	return nil
 }
 
@@ -188,4 +187,15 @@ func (c runInstanceRetrier) MaxAttempts() int {
 
 func (c runInstanceRetrier) RetryDelay(attempt int, err error) (time.Duration, error) {
 	return c.backoff, nil
+}
+
+func rebootEC2Instance(ctx context.Context, client *ec2.Client, instanceID string) error {
+	rebootInstanceInput := &ec2.RebootInstancesInput{
+		InstanceIds: []string{instanceID},
+	}
+
+	if _, err := client.RebootInstances(ctx, rebootInstanceInput); err != nil {
+		return err
+	}
+	return nil
 }

--- a/test/e2e/testdata/amazonlinux/2023/cloud-init.txt
+++ b/test/e2e/testdata/amazonlinux/2023/cloud-init.txt
@@ -12,7 +12,7 @@ write_files:
     path: nodeadm-config.yaml
 runcmd:
   - echo "Downloading nodeadm binary"
-  - curl -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
+  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
   - chmod +x /tmp/nodeadm
   - echo "Installing kubernetes components"
   - /tmp/nodeadm install {{ .KubernetesVersion }} --credential-provider {{ .Provider }}

--- a/test/e2e/testdata/rhel/8/cloud-init.txt
+++ b/test/e2e/testdata/rhel/8/cloud-init.txt
@@ -15,7 +15,7 @@ write_files:
     path: nodeadm-config.yaml
 runcmd:
   - echo "Downloading nodeadm binary"
-  - curl -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
+  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
   - chmod +x /tmp/nodeadm
   - echo "Installing kubernetes components"
   - /tmp/nodeadm install {{ .KubernetesVersion }} --containerd-source docker --credential-provider {{ .Provider }}

--- a/test/e2e/testdata/rhel/9/cloud-init.txt
+++ b/test/e2e/testdata/rhel/9/cloud-init.txt
@@ -15,7 +15,7 @@ write_files:
     path: nodeadm-config.yaml
 runcmd:
   - echo "Downloading nodeadm binary"
-  - curl -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
+  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
   - chmod +x /tmp/nodeadm
   - echo "Installing kubernetes components"
   - /tmp/nodeadm install {{ .KubernetesVersion }} --containerd-source docker --credential-provider {{ .Provider }}

--- a/test/e2e/testdata/ubuntu/2004/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2004/cloud-init.txt
@@ -12,7 +12,7 @@ write_files:
     path: nodeadm-config.yaml
 runcmd:
   - echo "Downloading nodeadm binary"
-  - curl -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
+  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
   - chmod +x /tmp/nodeadm
   - echo "Installing kubernetes components"
   - /tmp/nodeadm install {{ .KubernetesVersion }} --credential-provider {{ .Provider }}

--- a/test/e2e/testdata/ubuntu/2204/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2204/cloud-init.txt
@@ -12,7 +12,7 @@ write_files:
     path: nodeadm-config.yaml
 runcmd:
   - echo "Downloading nodeadm binary"
-  - curl -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
+  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
   - chmod +x /tmp/nodeadm
   - echo "Installing kubernetes components"
   - /tmp/nodeadm install {{ .KubernetesVersion }} --credential-provider {{ .Provider }}

--- a/test/e2e/testdata/ubuntu/2404/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2404/cloud-init.txt
@@ -60,7 +60,7 @@ write_files:
 runcmd:
   - systemctl restart apparmor.service
   - echo "Downloading nodeadm binary"
-  - curl -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
+  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
   - chmod +x /tmp/nodeadm
   - echo "Installing kubernetes components"
   - /tmp/nodeadm install {{ .KubernetesVersion }} --credential-provider {{ .Provider }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes the ssm command for nodeadm uninstall to be "fire and forget" style so that it will return after the command starts.  After uninstall, cloud-init is reset and the node is rebooted.  On reboot it will re-join to the cluster to validate that the uninstall properly cleaned the state, at least to the point where the node could rejoin the same cluster.  Increased the hybrid-activations from 1 to 2, increase a few of the timeouts due to rhel taking longer than most and added an output to the ec2-instance-connect url to make it easier to debug/follow along with the boot process.

*Testing (if applicable):*

Ran tests locally for each OS and version. Couple times ran into issue downloading nodeadm from s3, added the retry flag to curl.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

