### PR TITLE
Sanitize CodeBuild build ID for use in AWS resource names

### DIFF
--- a/buildspecs/test-nodeadm.yml
+++ b/buildspecs/test-nodeadm.yml
@@ -8,4 +8,5 @@ env:
 phases:
   build:
     commands:
-    - ./hack/run-e2e.sh hybrid-e2e-$CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/latest/linux/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/arm64/nodeadm
+    - SANITIZED_CODEBUILD_BUILD_ID=$(echo $CODEBUILD_BUILD_ID | tr ':' '-')
+    - ./hack/run-e2e.sh hybrid-e2e-$SANITIZED_CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/latest/linux/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/arm64/nodeadm


### PR DESCRIPTION
The CodeBuild build ID contains a colon (`:`) which causes IAM role creation to fail with the error
```console
error creating IAM role: failed to create role: ValidationError: The specified value for roleName is
invalid. It must contain only alphanumeric characters and/or the following: +=,.@_-
```
So we sanitize it before using it for IAM role name and EKS cluster name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

