### PR TITLE
Shorten EKS Cluster name and role prefix to pass resource name validations

### DIFF
--- a/buildspecs/test-nodeadm.yml
+++ b/buildspecs/test-nodeadm.yml
@@ -9,4 +9,4 @@ phases:
   build:
     commands:
     - SANITIZED_CODEBUILD_BUILD_ID=$(echo $CODEBUILD_BUILD_ID | tr ':' '-')
-    - ./hack/run-e2e.sh hybrid-e2e-$SANITIZED_CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/latest/linux/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/arm64/nodeadm
+    - ./hack/run-e2e.sh $SANITIZED_CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/latest/linux/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/arm64/nodeadm

--- a/test/e2e/iam.go
+++ b/test/e2e/iam.go
@@ -76,5 +76,5 @@ func (t *TestRunner) deleteIamRole() error {
 }
 
 func getRoleName(name string) string {
-	return fmt.Sprintf("%s-eks-hybrid-role", name)
+	return fmt.Sprintf("%s-hybrid-node", name)
 }


### PR DESCRIPTION
Fixes the error
```
error creating IAM role: failed to create role: ValidationError: 1 validation error detected: Value at 
'roleName' failed to satisfy constraint: Member must have length less than or equal to 64
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

