### PR TITLE
Statically compile e2e-test-runner and e2e.test binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,8 +185,8 @@ $(GOLANGCI_LINT): $(LOCALBIN) $(GOLANGCI_LINT_CONFIG)
 
 .PHONY: e2e-tests-binary
 e2e-tests-binary:
-	$(GO) test -c ./test/e2e -o ./_bin/e2e.test -tags "e2e"
+	CGO_ENABLED=0 $(GO) test -ldflags "-s -w -buildid='' -extldflags -static" -c ./test/e2e -o ./_bin/e2e.test -tags "e2e"
 
 .PHONY: e2e-setup
 e2e-setup:
-	$(GO) build -o _bin/e2e-test-runner ./cmd/e2e-test-runner/main.go 
+	CGO_ENABLED=0 $(GO) build -ldflags "-s -w -buildid='' -extldflags -static" -o _bin/e2e-test-runner ./cmd/e2e-test-runner/main.go


### PR DESCRIPTION
Need to statically compile e2e-test-runner and e2e.test binary to prevent issues such as glibc version difference

> /tmp/eks-hybrid/e2e-test-runner: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /tmp/eks-hybrid/e2e-test-runner)
