### PR TITLE
allows setting root password on new instances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
+	github.com/tredoe/osutil v1.5.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/mod v0.18.0
 	k8s.io/apimachinery v0.29.5

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tredoe/osutil v1.5.0 h1:UGVxbbHRoZi8xXVmbNZ2vgG6XoJ15ndE4LniiQ3rJKg=
+github.com/tredoe/osutil v1.5.0/go.mod h1:TEzphzUUunysbdDRfdOgqkg10POQbnfIPV50ynqOfIg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/test/e2e/amazonlinux.go
+++ b/test/e2e/amazonlinux.go
@@ -14,11 +14,16 @@ import (
 //go:embed testdata/amazonlinux/2023/cloud-init.txt
 var al23CloudInit []byte
 
+//go:embed testdata/eks-log-collector.sh
+var logCollector []byte
+
 type amazonLinuxCloudInitData struct {
-	NodeadmConfig     string
-	NodeadmUrl        string
-	KubernetesVersion string
-	Provider          string
+	LogCollectorScript string
+	NodeadmConfig      string
+	NodeadmUrl         string
+	KubernetesVersion  string
+	Provider           string
+	RootPasswordHash   string
 }
 
 type AmazonLinux2023 struct {
@@ -56,16 +61,18 @@ func (a AmazonLinux2023) AMIName(ctx context.Context, awsSession *session.Sessio
 	return *amiId, err
 }
 
-func (a AmazonLinux2023) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (a AmazonLinux2023) BuildUserData(UserDataInput UserDataInput) ([]byte, error) {
 	data := amazonLinuxCloudInitData{
-		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrls.AMD,
-		KubernetesVersion: kubernetesVersion,
-		Provider:          provider,
+		LogCollectorScript: string(logCollector),
+		KubernetesVersion:  UserDataInput.KubernetesVersion,
+		NodeadmConfig:      UserDataInput.NodeadmConfigYaml,
+		NodeadmUrl:         UserDataInput.NodeadmUrls.AMD,
+		Provider:           UserDataInput.Provider,
+		RootPasswordHash:   UserDataInput.RootPasswordHash,
 	}
 
 	if a.Architecture == arm64Arch {
-		data.NodeadmUrl = nodeadmUrls.ARM
+		data.NodeadmUrl = UserDataInput.NodeadmUrls.ARM
 	}
 
 	return executeTemplate(al23CloudInit, data)

--- a/test/e2e/rhel.go
+++ b/test/e2e/rhel.go
@@ -28,6 +28,7 @@ type rhelCloudInitData struct {
 	Provider          string
 	RhelUsername      string
 	RhelPassword      string
+	RootPasswordHash  string
 }
 
 type RedHat8 struct {
@@ -72,18 +73,19 @@ func (r RedHat8) AMIName(ctx context.Context, awsSession *session.Session) (stri
 	return findLatestImage(ec2.New(awsSession), "RHEL-8*", r.Architecture)
 }
 
-func (r RedHat8) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (r RedHat8) BuildUserData(UserDataInput UserDataInput) ([]byte, error) {
 	data := rhelCloudInitData{
-		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrls.AMD,
-		KubernetesVersion: kubernetesVersion,
-		Provider:          provider,
+		KubernetesVersion: UserDataInput.KubernetesVersion,
+		NodeadmConfig:     UserDataInput.NodeadmConfigYaml,
+		NodeadmUrl:        UserDataInput.NodeadmUrls.AMD,
+		Provider:          UserDataInput.Provider,
 		RhelUsername:      r.RhelUsername,
 		RhelPassword:      r.RhelPassword,
+		RootPasswordHash:  UserDataInput.RootPasswordHash,
 	}
 
 	if r.Architecture == arm64Arch {
-		data.NodeadmUrl = nodeadmUrls.ARM
+		data.NodeadmUrl = UserDataInput.NodeadmUrls.ARM
 	}
 
 	return executeTemplate(rhel8CloudInit, data)
@@ -130,18 +132,19 @@ func (r RedHat9) AMIName(ctx context.Context, awsSession *session.Session) (stri
 	return findLatestImage(ec2.New(awsSession), "RHEL-9*", r.Architecture)
 }
 
-func (r RedHat9) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (r RedHat9) BuildUserData(UserDataInput UserDataInput) ([]byte, error) {
 	data := rhelCloudInitData{
-		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrls.AMD,
-		KubernetesVersion: kubernetesVersion,
-		Provider:          provider,
+		KubernetesVersion: UserDataInput.KubernetesVersion,
+		NodeadmConfig:     UserDataInput.NodeadmConfigYaml,
+		NodeadmUrl:        UserDataInput.NodeadmUrls.AMD,
+		Provider:          UserDataInput.Provider,
 		RhelUsername:      r.RhelUsername,
 		RhelPassword:      r.RhelPassword,
+		RootPasswordHash:  UserDataInput.RootPasswordHash,
 	}
 
 	if r.Architecture == arm64Arch {
-		data.NodeadmUrl = nodeadmUrls.ARM
+		data.NodeadmUrl = UserDataInput.NodeadmUrls.ARM
 	}
 
 	return executeTemplate(rhel9CloudInit, data)

--- a/test/e2e/testdata/amazonlinux/2023/cloud-init.txt
+++ b/test/e2e/testdata/amazonlinux/2023/cloud-init.txt
@@ -1,4 +1,10 @@
 #cloud-config
+{{- if .RootPasswordHash }}
+users:
+  - name: root
+    lock_passwd: false
+    hashed_passwd: {{ .RootPasswordHash }}
+{{- end }}
 package_update: true
 write_files:
   - content: |

--- a/test/e2e/testdata/rhel/8/cloud-init.txt
+++ b/test/e2e/testdata/rhel/8/cloud-init.txt
@@ -1,4 +1,10 @@
 #cloud-config
+{{- if .RootPasswordHash }}
+users:
+  - name: root
+    lock_passwd: false
+    hashed_passwd: {{ .RootPasswordHash }}
+{{- end }}
 rh_subscription:
   username: {{ .RhelUsername }}
   password: {{ .RhelPassword }}

--- a/test/e2e/testdata/rhel/9/cloud-init.txt
+++ b/test/e2e/testdata/rhel/9/cloud-init.txt
@@ -1,4 +1,10 @@
 #cloud-config
+{{- if .RootPasswordHash }}
+users:
+  - name: root
+    lock_passwd: false
+    hashed_passwd: {{ .RootPasswordHash }}
+{{- end }}
 rh_subscription:
   username: {{ .RhelUsername }}
   password: {{ .RhelPassword }}

--- a/test/e2e/testdata/ubuntu/2004/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2004/cloud-init.txt
@@ -1,4 +1,10 @@
 #cloud-config
+{{- if .RootPasswordHash }}
+users:
+  - name: root
+    lock_passwd: false
+    hashed_passwd: {{ .RootPasswordHash }}
+{{- end }}
 package_update: true
 write_files:
   - content: |

--- a/test/e2e/testdata/ubuntu/2204/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2204/cloud-init.txt
@@ -1,4 +1,10 @@
 #cloud-config
+{{- if .RootPasswordHash }}
+users:
+  - name: root
+    lock_passwd: false
+    hashed_passwd: {{ .RootPasswordHash }}
+{{- end }}
 package_update: true
 write_files:
   - content: |

--- a/test/e2e/testdata/ubuntu/2404/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2404/cloud-init.txt
@@ -1,4 +1,10 @@
 #cloud-config
+{{- if .RootPasswordHash }}
+users:
+  - name: root
+    lock_passwd: false
+    hashed_passwd: {{ .RootPasswordHash }}
+{{- end }}
 package_update: true
 write_files:
   - content: |

--- a/test/e2e/ubuntu.go
+++ b/test/e2e/ubuntu.go
@@ -28,6 +28,7 @@ type ubuntuCloudInitData struct {
 	NodeadmUrl        string
 	KubernetesVersion string
 	Provider          string
+	RootPasswordHash  string
 }
 
 func templateFuncMap() map[string]interface{} {
@@ -71,16 +72,17 @@ func (u Ubuntu2004) AMIName(ctx context.Context, awsSession *session.Session) (s
 	return *amiId, err
 }
 
-func (u Ubuntu2004) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (u Ubuntu2004) BuildUserData(UserDataInput UserDataInput) ([]byte, error) {
 	data := ubuntuCloudInitData{
-		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrls.AMD,
-		KubernetesVersion: kubernetesVersion,
-		Provider:          provider,
+		KubernetesVersion: UserDataInput.KubernetesVersion,
+		NodeadmConfig:     UserDataInput.NodeadmConfigYaml,
+		NodeadmUrl:        UserDataInput.NodeadmUrls.AMD,
+		Provider:          UserDataInput.Provider,
+		RootPasswordHash:  UserDataInput.RootPasswordHash,
 	}
 
 	if u.Architecture == arm64Arch {
-		data.NodeadmUrl = nodeadmUrls.ARM
+		data.NodeadmUrl = UserDataInput.NodeadmUrls.ARM
 	}
 
 	return executeTemplate(ubuntu2004CloudInit, data)
@@ -118,16 +120,17 @@ func (u Ubuntu2204) AMIName(ctx context.Context, awsSession *session.Session) (s
 	return *amiId, err
 }
 
-func (u Ubuntu2204) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (u Ubuntu2204) BuildUserData(UserDataInput UserDataInput) ([]byte, error) {
 	data := ubuntuCloudInitData{
-		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrls.AMD,
-		KubernetesVersion: kubernetesVersion,
-		Provider:          provider,
+		KubernetesVersion: UserDataInput.KubernetesVersion,
+		NodeadmConfig:     UserDataInput.NodeadmConfigYaml,
+		NodeadmUrl:        UserDataInput.NodeadmUrls.AMD,
+		Provider:          UserDataInput.Provider,
+		RootPasswordHash:  UserDataInput.RootPasswordHash,
 	}
 
 	if u.Architecture == arm64Arch {
-		data.NodeadmUrl = nodeadmUrls.ARM
+		data.NodeadmUrl = UserDataInput.NodeadmUrls.ARM
 	}
 
 	return executeTemplate(ubuntu2204CloudInit, data)
@@ -165,16 +168,17 @@ func (u Ubuntu2404) AMIName(ctx context.Context, awsSession *session.Session) (s
 	return *amiId, err
 }
 
-func (u Ubuntu2404) BuildUserData(nodeadmUrls NodeadmURLs, nodeadmConfigYaml, kubernetesVersion, provider string) ([]byte, error) {
+func (u Ubuntu2404) BuildUserData(UserDataInput UserDataInput) ([]byte, error) {
 	data := ubuntuCloudInitData{
-		NodeadmConfig:     nodeadmConfigYaml,
-		NodeadmUrl:        nodeadmUrls.AMD,
-		KubernetesVersion: kubernetesVersion,
-		Provider:          provider,
+		KubernetesVersion: UserDataInput.KubernetesVersion,
+		NodeadmConfig:     UserDataInput.NodeadmConfigYaml,
+		NodeadmUrl:        UserDataInput.NodeadmUrls.AMD,
+		Provider:          UserDataInput.Provider,
+		RootPasswordHash:  UserDataInput.RootPasswordHash,
 	}
 
 	if u.Architecture == arm64Arch {
-		data.NodeadmUrl = nodeadmUrls.ARM
+		data.NodeadmUrl = UserDataInput.NodeadmUrls.ARM
 	}
 
 	return executeTemplate(ubuntu2404CloudInit, data)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds a new field to the TestConfig to allow setting the root password on the newly created instance to a random password.  This allows logging in via the `EC2 Instance Connect` as the root user. Each cloud-init has been updated to support adding the users block.  The password is a 8 char random string, hashed using sha-512, roughly equivalent `mkpasswd --method=SHA-512 --rounds=4096 `.

Questions:

- Added a field on the config, would we rather an env var?
- For the buildUserData method, should we turn these params into a struct instead?


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

