### PR TITLE
allows e2e-test cleanup to be reran

### DIFF
--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -321,6 +321,11 @@ func (t *TestRunner) deleteEKSCluster(ctx context.Context, clusterName string) e
 	_, err := svc.DeleteCluster(&eks.DeleteClusterInput{
 		Name: aws.String(clusterName),
 	})
+	if err != nil && isErrCode(err, eks.ErrCodeResourceNotFoundException) {
+		fmt.Printf("Cluster %s already deleted\n", clusterName)
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to delete EKS hybrid cluster %s: %v", clusterName, err)
 	}

--- a/test/e2e/iam.go
+++ b/test/e2e/iam.go
@@ -64,16 +64,21 @@ func (t *TestRunner) deleteIamRole() error {
 		RoleName:  aws.String(roleName),
 		PolicyArn: aws.String(eksClusterPolicyArn),
 	})
-	if err != nil {
+	if err != nil && isErrCode(err, iam.ErrCodeNoSuchEntityException) {
+		fmt.Printf("AmazonEKSClusterPolicy already detached from role %s\n", roleName)
+	} else if err != nil {
 		return fmt.Errorf("failed to detach AmazonEKSClusterPolicy from role %s: %v", roleName, err)
+	} else {
+		fmt.Printf("Detached AmazonEKSClusterPolicy from role %s\n", roleName)
 	}
-
-	fmt.Printf("Detached AmazonEKSClusterPolicy from role %s\n", roleName)
 
 	_, err = svc.DeleteRole(&iam.DeleteRoleInput{
 		RoleName: aws.String(roleName),
 	})
-	if err != nil {
+	if err != nil && isErrCode(err, iam.ErrCodeNoSuchEntityException) {
+		fmt.Printf("role %s already deleted\n", roleName)
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("failed to delete role %s: %v", roleName, err)
 	}
 

--- a/test/e2e/vpc.go
+++ b/test/e2e/vpc.go
@@ -384,7 +384,10 @@ func (t *TestRunner) deleteVpc(vpc vpcConfig) error {
 	}
 
 	_, err := svc.DeleteVpc(input)
-	if err != nil {
+	if err != nil && isErrCode(err, "InvalidVpcID.NotFound") {
+		fmt.Printf("VPC %s already deleted\n", vpc.vpcID)
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("failed to delete VPC: %v", err)
 	}
 
@@ -401,6 +404,10 @@ func (t *TestRunner) deleteSubnet(subnetID string) error {
 	}
 
 	_, err := svc.DeleteSubnet(input)
+	if err != nil && isErrCode(err, "InvalidSubnetID.NotFound") {
+		fmt.Printf("subnet %s already deleted\n", subnetID)
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to delete subnet: %v", err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When running cleanup, it will sometimes fail and currently can not be reran due to erroring when resources cant be deleted, which are already deleted.  This adds exceptions for these specific errors before bailing out.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

