### PR TITLE
waits for ssm node to be deregistered

### DIFF
--- a/test/e2e/ec2.go
+++ b/test/e2e/ec2.go
@@ -199,3 +199,50 @@ func rebootEC2Instance(ctx context.Context, client *ec2.Client, instanceID strin
 	}
 	return nil
 }
+
+func waitForManagedInstanceUnregistered(ctx context.Context, ssmClient *ssm.SSM, instanceId string) error {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+
+	statusCh := make(chan struct{})
+	errCh := make(chan error)
+	consecutiveErrors := 0
+
+	go func() {
+		defer close(statusCh)
+		defer close(errCh)
+		for {
+			output, err := ssmClient.DescribeInstanceInformationWithContext(ctx, &ssm.DescribeInstanceInformationInput{
+				Filters: []*ssm.InstanceInformationStringFilter{
+					{
+						Key:    aws.String("InstanceIds"),
+						Values: []*string{aws.String(instanceId)},
+					},
+				},
+			})
+			if err != nil {
+				consecutiveErrors += 1
+				if consecutiveErrors > 3 || ctx.Err() != nil {
+					errCh <- fmt.Errorf("failed to describe instance information %s: %v", instanceId, err)
+					return
+				}
+			} else if len(output.InstanceInformationList) == 0 {
+				statusCh <- struct{}{}
+				return
+			} else {
+				consecutiveErrors = 0
+			}
+
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	select {
+	case <-statusCh:
+		return nil
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("timed out waiting for instance to unregister: %s", instanceId)
+	}
+}

--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -49,6 +49,7 @@ type NodeadmOS interface {
 type NodeadmCredentialsProvider interface {
 	Name() creds.CredentialProvider
 	NodeadmConfig(cluster *hybridCluster) (*api.NodeConfig, error)
+	VerifyUninstall(ctx context.Context, instanceId string) error
 }
 
 type SsmProvider struct {
@@ -88,6 +89,10 @@ func (s *SsmProvider) NodeadmConfig(cluster *hybridCluster) (*api.NodeConfig, er
 			},
 		},
 	}, nil
+}
+
+func (s *SsmProvider) VerifyUninstall(ctx context.Context, instanceId string) error {
+	return waitForManagedInstanceUnregistered(ctx, s.ssmClient, instanceId)
 }
 
 func parseS3URL(s3URL string) (bucket, key string, err error) {

--- a/test/e2e/nodeadm_test.go
+++ b/test/e2e/nodeadm_test.go
@@ -366,6 +366,7 @@ var _ = Describe("Hybrid Nodes", func() {
 								nodeIPAddress: ec2.ipAddress,
 								logger:        test.logger,
 								ssm:           test.ssmClient,
+								provider:      provider,
 							}
 							Expect(uninstallNodeTest.Run(ctx)).To(Succeed(), "node should have been reset sucessfully")
 
@@ -434,6 +435,7 @@ type uninstallNodeTest struct {
 	ssm           *ssm.SSM
 	nodeIPAddress string
 	logger        logr.Logger
+	provider      NodeadmCredentialsProvider
 }
 
 func (u uninstallNodeTest) Run(ctx context.Context) error {
@@ -463,6 +465,12 @@ func (u uninstallNodeTest) Run(ctx context.Context) error {
 		return err
 	}
 	u.logger.Info("Node deleted successfully", "node", nodeName)
+
+	u.logger.Info("Waiting for node to be unregistered", "node", nodeName)
+	if err = u.provider.VerifyUninstall(ctx, nodeName); err != nil {
+		return nil
+	}
+	u.logger.Info("Node unregistered successfully", "node", nodeName)
 
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds a wait after running nodeadm uninstall to ensure the ssm managed instance is properly removed.  

Added the method to the provider interface to avoid checking the provider type, tho is highly likely in the ira case this method will be a no-op.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

