### PR TITLE
Change the rolename for SSM role

### DIFF
--- a/test/e2e/cfn-templates/hybrid-cfn.yaml
+++ b/test/e2e/cfn-templates/hybrid-cfn.yaml
@@ -22,7 +22,7 @@ Resources:
     Condition: CreateSSMRole
     Type: AWS::IAM::Role
     Properties: 
-      RoleName: !Sub "HybridNodesIAMRoleSSM-${AWS::StackName}"
+      RoleName: !Sub "${AWS::StackName}-ssm"
       AssumeRolePolicyDocument: 
         Version: '2012-10-17'
         Statement: 
@@ -64,13 +64,13 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly
       Tags: 
         - Key: Name
-          Value: !Sub '${AWS::StackName}-ssm-role'
+          Value: !Sub '${AWS::StackName}'
 
   # Create IAM Role for EC2
   EC2Role:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "HybridNodesEC2Role-${AWS::StackName}"
+      RoleName: !Sub "${AWS::StackName}-ec2"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/test/e2e/nodeadm_test.go
+++ b/test/e2e/nodeadm_test.go
@@ -105,6 +105,13 @@ func getCredentialProviderNames(providers []NodeadmCredentialsProvider) string {
 	return strings.Join(names, ", ")
 }
 
+func getTruncatedName(name string, limit int) string {
+	if len(name) > limit {
+		name = name[:limit]
+	}
+	return name
+}
+
 type peeredVPCTest struct {
 	aws         awsconfig.Config // TODO: move everything to aws sdk v2
 	awsSession  *session.Session
@@ -159,11 +166,12 @@ var _ = SynchronizedBeforeSuite(
 			providerFilter = credentialProviders
 		}
 
+		stackName := fmt.Sprintf("EKSHybridCI-%s-%s", removeSpecialChars(config.ClusterName), getCredentialProviderNames(providerFilter))
 		stack := &e2eCfnStack{
 			clusterName:         cluster.clusterName,
 			clusterArn:          cluster.clusterArn,
 			credentialProviders: providerFilter,
-			stackName:           fmt.Sprintf("EKSHybridCI-%s-%s", removeSpecialChars(config.ClusterName), getCredentialProviderNames(providerFilter)),
+			stackName:           getTruncatedName(stackName, 60),
 			cfn:                 cfnClient,
 			iam:                 iamClient,
 		}


### PR DESCRIPTION
*Description of changes:*
Change the SSM role name from `HybridNodesIAMRoleSSM-${AWS::StackName}` to `${AWS::StackName}-ssm` to avoid running into character count constraints in creating the role.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

