### PR TITLE
adds e2e cleanup for periodic

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Short-circuit if script has already been sourced
+[[ $(type -t build::common::loaded) == function ]] && return 0
+
+function build::common::echo_and_run() {
+    >&2 echo "($(pwd)) \$ $*"
+    "$@"
+}
+
+function retry() {
+    local n=1
+    local max=20
+    local delay=5
+    while true; do
+        "$@" && break || {
+            if [[ $n -lt $max ]]; then
+                ((n++))
+                >&2 echo "Command failed. Attempt $n/$max:"
+                sleep $delay;
+            else
+                fail "The command has failed after $n attempts."
+            fi
+        }
+    done
+}
+
+# Marker function to indicate script has been fully sourced
+function build::common::loaded() {
+  return 0
+}

--- a/hack/e2e-cleanup.sh
+++ b/hack/e2e-cleanup.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source $REPO_ROOT/hack/common.sh
+
+DATE=date
+if [ "$(uname -s)" = "Darwin" ]; then
+    DATE=gdate
+fi
+
+TEST_CLUSTER_TAG_KEY="Nodeadm-E2E-Tests-Cluster"
+
+CLUSTER_NAME=${1:-}
+
+TEST_CLUSTER_TAG_KEY_FILTER="Name=tag-key,Values=$TEST_CLUSTER_TAG_KEY"
+if [ -n "$CLUSTER_NAME" ]; then
+    TEST_CLUSTER_TAG_KEY_FILTER+=" Name=tag:$TEST_CLUSTER_TAG_KEY,Values=$CLUSTER_NAME"
+fi
+
+
+function aws() {
+    retry build::common::echo_and_run command aws "$@"    
+}
+
+function older_than_one_day(){
+    created="$1"
+
+    createDate=$($DATE -d"$created" +%s)
+    olderThan=$($DATE --date "1 second ago" +%s)
+    if [[ $createDate -lt $olderThan ]]; then       
+        return 0  # 0 = true
+    else       
+        return 1  # 1 = false
+    fi
+}
+
+declare -A CLUSTER_STATUSES=()
+function is_eks_cluster_deleted(){
+    name="$1"
+
+    # +1 means to return 1 if the key exists, otherwise return nothing
+    if [ ! ${CLUSTER_STATUSES[$name]+1} ]; then
+        cluster_status="$(command aws eks describe-cluster --name $name --query 'cluster.status' --output text)"
+        if [ $? != 0 ]; then
+            # 1 = false
+            CLUSTER_STATUSES[$name]="DELETING"
+        else
+            CLUSTER_STATUSES[$name]=$cluster_status
+        fi
+    fi
+    if [ "DELETING" == ${CLUSTER_STATUSES[$name]} ]; then
+        # 0 = true
+        return 0
+    else   
+        # 1 = false   
+        return 1
+    fi
+}
+
+function delete_cluster(){
+    eks_cluster="$1"
+ 
+     aws eks delete-cluster --name $eks_cluster
+} 
+
+function delete_instance(){
+    instance_id="$1"
+    cluster_name="$2"
+   
+    aws ec2 terminate-instances --instance-ids $instance_id
+}
+
+function delete_peering_connection(){
+    peering_connection_id="$1"
+    cluster_name="$2"
+    
+    aws ec2 delete-vpc-peering-connection --vpc-peering-connection-id $peering_connection_id  
+}
+
+function delete_role(){
+    role="$1"
+
+    if [ ! -z "$(aws iam list-attached-role-policies --role-name $role --query "AttachedPolicies[*]" --output text)" ]; then
+        aws iam detach-role-policy --role-name $role --policy-arn "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+    fi
+    aws iam delete-role --role-name $role
+}
+
+function delete_vpc(){
+    vpc="$1"
+    cluster_name="$2"
+
+    for internet_gateway in $(aws ec2 describe-internet-gateways --filters "Name=attachment.vpc-id,Values=$vpc" --query "InternetGateways[*].InternetGatewayId"  --output text); do 
+        aws ec2 detach-internet-gateway --internet-gateway-id $internet_gateway --vpc-id $vpc
+        aws ec2 delete-internet-gateway --internet-gateway-id $internet_gateway
+    done
+
+    for subnet in $(aws ec2 describe-subnets --filters "Name=vpc-id,Values=$vpc" --query "Subnets[*].SubnetId" --output text); do 
+        aws ec2 delete-subnet --subnet-id $subnet
+    done
+
+    main_route_table=$(aws ec2  describe-route-tables --filters "Name=vpc-id,Values=$vpc" "Name=association.main,Values=true" --query "RouteTables[*].RouteTableId" --output text)
+    for rt in $(aws ec2 describe-route-tables --filters "Name=vpc-id,Values=$vpc" --query "RouteTables[*].RouteTableId" --output text); do
+        if [[ "$rt" != "$main_route_table" ]]; then
+            aws ec2 delete-route-table --route-table-id $rt
+        fi
+    done
+
+    aws ec2 delete-vpc --vpc-id $vpc
+}
+
+for eks_cluster in $(aws eks list-clusters --query "clusters" --output text); do
+    if [ -n "$CLUSTER_NAME" ] && [ "$eks_cluster" == "$CLUSTER_NAME" ]; then
+        delete_cluster $eks_cluster
+        break
+    fi    
+    describe=$(aws eks describe-cluster --name $eks_cluster --query 'cluster.{tags:tags,createdAt:createdAt}')
+    if older_than_one_day "$(echo $describe | jq -r ".createdAt")"; then
+        if [ "true" == $(echo $describe | jq ".tags | has(\"$TEST_CLUSTER_TAG_KEY\")") ]; then
+            delete_cluster $eks_cluster
+        fi 
+    fi
+    
+done
+
+# Loop through role names and get tags
+for role in $(aws iam list-roles --query 'Roles[*].RoleName' --no-paginate --output text); do
+    if [[ $role == *-hybrid-node ]]; then
+        cluster_name="$(aws iam list-role-tags --query "Tags[*]" --role-name $role --output json | jq -r "map(select(.Key == \"$TEST_CLUSTER_TAG_KEY\"))[0].Value")"
+        if [ -z "$cluster_name" ] || ! is_eks_cluster_deleted $cluster_name; then
+            continue
+        fi
+        if [ -z "$CLUSTER_NAME" ] || [ "$cluster_name" == "$CLUSTER_NAME" ]; then        
+            delete_role $role
+        fi
+    fi
+done
+
+for reservations in $(aws ec2 describe-instances --filters $TEST_CLUSTER_TAG_KEY_FILTER --query "Reservations[*].Instances[*].{InstanceId:InstanceId,Tags:Tags,State:State.Name}" --output json | jq -c '.[]'); do
+    for ec2 in $(echo $reservations | jq -c '.[]'); do
+        if [ "terminated" == "$(echo "$ec2" | jq -r '.State')" ]; then
+            continue
+        fi
+        cluster_name=$(echo $ec2 | jq -r ".Tags | map(select(.Key == \"$TEST_CLUSTER_TAG_KEY\"))[0].Value")
+        instance_id=$(echo $ec2 | jq -r ".InstanceId")
+        if ! is_eks_cluster_deleted $cluster_name; then
+            continue
+        fi
+        delete_instance $instance_id $cluster_name
+    done
+done
+
+for peering_connection in $(aws ec2 describe-vpc-peering-connections --filters $TEST_CLUSTER_TAG_KEY_FILTER --query "VpcPeeringConnections[*].{VpcPeeringConnectionId:VpcPeeringConnectionId,Tags:Tags,StatusCode:Status.Code}" --output json | jq -c '.[]'); do     
+    if [ "deleted" == "$(echo "$peering_connection" | jq -r '.StatusCode')" ]; then
+        continue
+    fi
+    cluster_name=$(echo "$peering_connection" | jq -r ".Tags | map(select(.Key == \"$TEST_CLUSTER_TAG_KEY\"))[0].Value")
+    peering_connection_id=$(echo "$peering_connection" | jq -r ".VpcPeeringConnectionId")
+    if ! is_eks_cluster_deleted $cluster_name; then
+        continue
+    fi
+    delete_peering_connection $peering_connection_id $cluster_name
+done
+
+for vpc in $(aws ec2 describe-vpcs --filters $TEST_CLUSTER_TAG_KEY_FILTER --query "Vpcs[*].{VpcId:VpcId,Tags:Tags}"| jq -c '.[]'); do
+    cluster_name=$(echo $vpc | jq -r ".Tags | map(select(.Key == \"$TEST_CLUSTER_TAG_KEY\"))[0].Value")
+    vpc=$(echo $vpc | jq -r ".VpcId")
+    if ! is_eks_cluster_deleted $cluster_name; then
+        continue
+    fi
+    delete_vpc $vpc $cluster_name
+done
+
+
+
+# TODO:
+#  hybrid activations
+#  registered managed instances

--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -238,7 +238,8 @@ func (t *TestRunner) createEKSCluster(ctx context.Context, clusterName, kubernet
 		},
 		RoleArn: aws.String(t.Status.RoleArn),
 		Tags: map[string]*string{
-			"Name": aws.String(fmt.Sprintf("%s-%s", clusterName, kubernetesVersion)),
+			"Name":            aws.String(fmt.Sprintf("%s-%s", clusterName, kubernetesVersion)),
+			TestClusterTagKey: aws.String(clusterName),
 		},
 		AccessConfig: &eks.CreateAccessConfigRequest{
 			AuthenticationMode: aws.String("API_AND_CONFIG_MAP"),

--- a/test/e2e/ec2.go
+++ b/test/e2e/ec2.go
@@ -21,6 +21,7 @@ import (
 
 // instanceConfig holds the configuration for the EC2 instance.
 type ec2InstanceConfig struct {
+	clusterName        string
 	instanceName       string
 	amiID              string
 	instanceType       string
@@ -101,6 +102,10 @@ func (e *ec2InstanceConfig) create(ctx context.Context, ec2Client *ec2.Client, s
 					{
 						Key:   aws.String("Name"),
 						Value: aws.String(e.instanceName),
+					},
+					{
+						Key:   aws.String(TestClusterTagKey),
+						Value: aws.String(e.clusterName),
 					},
 				},
 			},

--- a/test/e2e/iam.go
+++ b/test/e2e/iam.go
@@ -30,6 +30,10 @@ func (t *TestRunner) createEKSClusterRole() error {
 	_, err := svc.CreateRole(&iam.CreateRoleInput{
 		RoleName:                 aws.String(roleName),
 		AssumeRolePolicyDocument: aws.String(assumeRolePolicyDocument),
+		Tags: []*iam.Tag{{
+			Key:   aws.String(TestClusterTagKey),
+			Value: aws.String(t.Spec.ClusterName),
+		}},
 	})
 	if err != nil && !isErrCode(err, iam.ErrCodeEntityAlreadyExistsException) {
 		return fmt.Errorf("failed to create role: %w", err)

--- a/test/e2e/nodeadm_test.go
+++ b/test/e2e/nodeadm_test.go
@@ -335,6 +335,7 @@ var _ = Describe("Hybrid Nodes", func() {
 							Expect(err).NotTo(HaveOccurred(), "expected to successfully retrieve ami id")
 
 							ec2Input := ec2InstanceConfig{
+								clusterName:        test.cluster.clusterName,
 								instanceName:       instanceName,
 								amiID:              amiId,
 								instanceType:       os.InstanceType(),

--- a/test/e2e/run.go
+++ b/test/e2e/run.go
@@ -20,6 +20,8 @@ import (
 	sigyaml "sigs.k8s.io/yaml"
 )
 
+const TestClusterTagKey = "Nodeadm-E2E-Tests-Cluster"
+
 type TestRunner struct {
 	Session *session.Session   `yaml:"-"`
 	Spec    TestResourceSpec   `yaml:"spec"`
@@ -109,6 +111,7 @@ func (t *TestRunner) CreateResources(ctx context.Context) error {
 
 	// Create EKS cluster VPC
 	clusterVpcParam := vpcSubnetParams{
+		clusterName:       t.Spec.ClusterName,
 		vpcName:           fmt.Sprintf("%s-vpc", t.Spec.ClusterName),
 		vpcCidr:           t.Spec.ClusterNetwork.VpcCidr,
 		publicSubnetCidr:  t.Spec.ClusterNetwork.PublicSubnetCidr,
@@ -149,6 +152,7 @@ func (t *TestRunner) CreateResources(ctx context.Context) error {
 
 	// Create hybrid nodes VPC
 	hybridNodesVpcParam := vpcSubnetParams{
+		clusterName:       t.Spec.ClusterName,
 		vpcName:           fmt.Sprintf("%s-hybrid-node-vpc", t.Spec.ClusterName),
 		vpcCidr:           t.Spec.HybridNetwork.VpcCidr,
 		publicSubnetCidr:  t.Spec.HybridNetwork.PublicSubnetCidr,
@@ -218,9 +222,9 @@ func (t *TestRunner) CreateResources(ctx context.Context) error {
 	}
 
 	clientConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath(t.Spec.ClusterName))
-    if err != nil {
-        return fmt.Errorf("loading kubeconfig: %v", err)
-    }
+	if err != nil {
+		return fmt.Errorf("loading kubeconfig: %v", err)
+	}
 
 	k8sClient, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds a script to brute force cleanup of potential leaky e2e test objects.  This approach goes through each of the potential resource types, looking for a hybrid tag, which represents the cluster/e2e test it was associated with.  Based on this tag, it is determined if the cluster is still active, or gone, if not these resources are deleted.  Clusters are deleted after 1 day.  Each resource is given a tag so we do not need rely on the cluster existing to find all the resources in case we have runs where resources are half deleted.  

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

