### PR TITLE
Make more obvious when imds mock fails to start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ CONVERSION_GEN ?= $(LOCALBIN)/conversion-gen
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT_CONFIG ?= .github/workflows/golangci-lint.yml
-GOLANGCI_LINT := $(LOCALBIN)/golangci-lint
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 GINKGO ?= $(LOCALBIN)/ginkgo
 
 ## Tool Versions
@@ -172,6 +172,7 @@ $(GINKGO): $(LOCALBIN)
 update-deps:
 	$(GO) get $(shell $(GO) list -f '{{if not (or .Main .Indirect)}}{{.Path}}{{end}}' -mod=mod -m all) && $(GO) mod tidy
 
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint.
 $(GOLANGCI_LINT): $(LOCALBIN) $(GOLANGCI_LINT_CONFIG)
 	$(eval GOLANGCI_LINT_VERSION?=$(shell cat .github/workflows/golangci-lint.yml | yq e '.jobs.golangci.steps[] | select(.name == "golangci-lint") .with.version' -))
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)

--- a/test/integration/.dockerignore
+++ b/test/integration/.dockerignore
@@ -1,2 +1,3 @@
 # we don't want to constantly invalidate the build cache while we're writing a new test case
 cases/
+run.sh

--- a/test/integration/infra/.dockerignore
+++ b/test/integration/infra/.dockerignore
@@ -1,1 +1,3 @@
 test/integration/cases/
+test/integration/run.sh
+_bin/


### PR DESCRIPTION
*Description of changes:*
There is a flaky test (`kubecofig-new-instance-type`) and I believe it fails because the imds mock fails to start due to the config file not being found. I'm not sure why that happens, but this should make more obvious if that is the case by failing early instead of letting the test continue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

