### PR TITLE
Add retries for Node and Pod wait operations

### DIFF
--- a/test/e2e/nodeadm_test.go
+++ b/test/e2e/nodeadm_test.go
@@ -449,7 +449,7 @@ func (t joinNodeTest) Run(ctx context.Context) error {
 
 	t.logger.Info("Creating a test pod on the hybrid node...")
 	podName := getNginxPodName(nodeName)
-	if err = createNginxPodInNode(ctx, t.k8s, nodeName); err != nil {
+	if err = createNginxPodInNode(ctx, t.k8s, nodeName, t.logger); err != nil {
 		return err
 	}
 	t.logger.Info(fmt.Sprintf("Pod %s created and running on node %s", podName, nodeName))


### PR DESCRIPTION
This PR adds retries for Node and Pod wait operations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

