### PR TITLE
adds cfn cleanup

### DIFF
--- a/buildspecs/cleanup-nodeadm.yml
+++ b/buildspecs/cleanup-nodeadm.yml
@@ -1,0 +1,6 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+    - ./hack/e2e-cleanup.sh

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -28,8 +28,8 @@ function fail() {
 
 function retry() {
     local n=1
-    local max=20
-    local delay=5
+    local max=40
+    local delay=10
     while true; do
         "$@" && break || {
             if [[ $n -lt $max ]]; then

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -52,7 +52,7 @@ EOF
 
 function cleanup(){
   if [ -f $RESOURCES_YAML ]; then
-    retry $BIN_DIR/e2e-test cleanup -f $RESOURCES_YAML
+    $BIN_DIR/e2e-test cleanup -f $RESOURCES_YAML || true
   fi
   $REPO_ROOT/hack/e2e-cleanup.sh $CLUSTER_NAME
 }

--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -103,7 +103,7 @@ func (s *SsmProvider) InstanceID(node HybridEC2dNode) string {
 }
 
 func (s *SsmProvider) NodeadmConfig(ctx context.Context, node NodeSpec) (*api.NodeConfig, error) {
-	ssmActivationDetails, err := createSSMActivation(ctx, s.ssmClientV2, s.role, ssmActivationName)
+	ssmActivationDetails, err := createSSMActivation(ctx, s.ssmClientV2, s.role, ssmActivationName, node.Cluster.clusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/ssm.go
+++ b/test/e2e/ssm.go
@@ -9,6 +9,7 @@ import (
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	ssmv2 "github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmv2Types "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -16,12 +17,18 @@ import (
 	"github.com/go-logr/logr"
 )
 
-func createSSMActivation(ctx context.Context, client *ssmv2.Client, iamRole string, ssmActivationName string) (*ssmv2.CreateActivationOutput, error) {
+func createSSMActivation(ctx context.Context, client *ssmv2.Client, iamRole string, ssmActivationName string, clusterName string) (*ssmv2.CreateActivationOutput, error) {
 	// Define the input for the CreateActivation API
 	input := &ssmv2.CreateActivationInput{
 		IamRole:             aws.String(iamRole),
 		RegistrationLimit:   aws.Int32(2),
 		DefaultInstanceName: aws.String(ssmActivationName),
+		Tags: []ssmv2Types.Tag{
+			{
+				Key:   aws.String(TestClusterTagKey),
+				Value: aws.String(clusterName),
+			},
+		},
 	}
 
 	// Call CreateActivation to create the SSM activation

--- a/test/e2e/stack.go
+++ b/test/e2e/stack.go
@@ -109,6 +109,10 @@ func (e *e2eCfnStack) deployStack(ctx context.Context, logger logr.Logger) error
 			Capabilities: []*string{
 				aws.String("CAPABILITY_NAMED_IAM"),
 			},
+			Tags: []*cloudformation.Tag{{
+				Key:   aws.String(TestClusterTagKey),
+				Value: aws.String(e.clusterName),
+			}},
 		})
 		if err != nil {
 			return fmt.Errorf("creating hybrid nodes cfn stack: %w", err)
@@ -164,6 +168,10 @@ func (s *e2eCfnStack) createInstanceProfile(ctx context.Context, logger logr.Log
 		instanceProfileArnOut, err := s.iam.CreateInstanceProfileWithContext(ctx, &iam.CreateInstanceProfileInput{
 			InstanceProfileName: aws.String(instanceProfileName),
 			Path:                aws.String("/"),
+			Tags: []*iam.Tag{{
+				Key:   aws.String(TestClusterTagKey),
+				Value: aws.String(s.clusterName),
+			}},
 		})
 		if err != nil {
 			return "", err


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds clean up for the cloud formation stacks in case tests fail/crash before cleaning them up.  

- To be sure we dont delete stacks we do not intend to delete, went through and added tag restrictions to as many of resources iam policies as i could.  
- Added requestTag restrictions to the same resources to ensure that the test code can only create these resources with the proper tag key.  
- Added the missing perms for the iam-ra newly added tests
- Added tags to instance profile roles
- Improved role deletion in cleanup script
- Added instance profile deletion in cleanup script

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

