### PR TITLE
Install ssm agent during install phase

### DIFF
--- a/test/integration/cases/install-with-ssm/run.sh
+++ b/test/integration/cases/install-with-ssm/run.sh
@@ -16,7 +16,7 @@ declare SUPPORTED_VERSIONS=(1.26 1.27 1.28 1.29 1.30)
 
 for VERSION in ${SUPPORTED_VERSIONS}
 do
-    nodeadm install $VERSION   --credential-provider ssm
+    nodeadm install $VERSION --credential-provider ssm
 
     assert::path-exists /usr/bin/containerd
     assert::path-exists /usr/sbin/iptables
@@ -29,6 +29,7 @@ do
     assert::path-exists /usr/local/bin/aws-iam-authenticator
 
     assert::path-exists /opt/ssm/ssm-setup-cli
+    assert::path-exists /usr/bin/amazon-ssm-agent
 
     assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 
@@ -43,5 +44,6 @@ do
     assert::path-not-exist /usr/local/bin/aws-iam-authenticator
     assert::path-not-exist /usr/bin/containerd
     assert::path-not-exist /opt/ssm/ssm-setup-cli
+    assert::path-not-exist /usr/bin/amazon-ssm-agent
     assert::path-not-exist /opt/nodeadm/tracker
 done

--- a/test/integration/cases/upgrade-with-ssm/run.sh
+++ b/test/integration/cases/upgrade-with-ssm/run.sh
@@ -31,6 +31,7 @@ assert::path-exists /opt/cni/bin/
 assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
 assert::path-exists /usr/local/bin/aws-iam-authenticator
 assert::path-exists /opt/ssm/ssm-setup-cli
+assert::path-exists /usr/bin/amazon-ssm-agent
 assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 assert::path-exists /etc/systemd/system/kubelet.service
 assert::files-equal /etc/systemd/system/kubelet.service expected-kubelet-systemd-unit
@@ -67,6 +68,7 @@ assert::path-exists /opt/cni/bin/
 assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
 assert::path-exists /usr/local/bin/aws-iam-authenticator
 assert::path-exists /opt/ssm/ssm-setup-cli
+assert::path-exists /usr/bin/amazon-ssm-agent
 assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 assert::path-exists /etc/systemd/system/kubelet.service
 assert::files-equal /etc/systemd/system/kubelet.service expected-kubelet-systemd-unit


### PR DESCRIPTION
*Description of changes:*
We use ssm-setup-cli binary which only supported the `-register` command before. This would both install and register the agent with a hybrid activation. With the newer `-install` flag, this change makes sure to install the agent during the install phase, which would be used during the init phase by running the `-register` flag. 

If there is a newer version of ssm agent available for the `stable` channel while running init command, the setup binary will update the agent to the newest.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

