### PR TITLE
Add ssm agent on RHEL9 os for ira provider and skip Ubuntu2004, RHEL8 IRA tests

### DIFF
--- a/hack/SKIPPED_TESTS.yaml
+++ b/hack/SKIPPED_TESTS.yaml
@@ -1,0 +1,5 @@
+skipped_tests:
+  - "(ubuntu2004-amd64 && iam-ra)"
+  - "(rhel8-amd64 && iam-ra)"
+  - "(ubuntu2004-arm64 && iam-ra)"
+  - "(rhel8-arm64 && iam-ra)"

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -74,9 +74,14 @@ nodeadmUrlAMD: "$NODEADM_AMD_URL"
 nodeadmUrlARM: "$NODEADM_ARM_URL"
 EOF
 
+
+SKIP_FILE=SKIPPED_TESTS.yaml
+# Extract skipped_tests field from SKIP_FILE file and join entries with ' || '
+skip=$(yq '.skipped_tests | join(" || ")' ${SKIP_FILE})
+
 # We expliclty specify procs instead of letting ginkgo decide (with -p) because in if not
 # ginkgo will use all available CPUs, which could be a small number depending
 # on how the CI runner has been configured. However, even if only one CPU is avaialble,
 # there is still value in running the tests in multiple processes, since most of the work is
 # "waiting" for infra to be created and nodes to join the cluster.
-$BIN_DIR/ginkgo --procs 64 -v -tags=e2e --label-filter='ssm' $BIN_DIR/e2e.test -- -filepath=$CONFIG_DIR/e2e-param.yaml
+$BIN_DIR/ginkgo --procs 64 -v -tags=e2e --label-filter='!(${skip})' $BIN_DIR/e2e.test -- -filepath=$CONFIG_DIR/e2e-param.yaml

--- a/test/e2e/rhel.go
+++ b/test/e2e/rhel.go
@@ -30,6 +30,7 @@ type rhelCloudInitData struct {
 	RhelPassword      string
 	RootPasswordHash  string
 	Files             []File
+	SSMAgentURL       string
 }
 
 type RedHat8 struct {
@@ -37,6 +38,11 @@ type RedHat8 struct {
 	RhelPassword string
 	Architecture string
 }
+
+const (
+	rhelSsmAgentAMD = "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm"
+	rhelSsmAgentARM = "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm"
+)
 
 func NewRedHat8AMD(rhelUsername string, rhelPassword string) *RedHat8 {
 	rh8 := new(RedHat8)
@@ -145,10 +151,12 @@ func (r RedHat9) BuildUserData(UserDataInput UserDataInput) ([]byte, error) {
 		RhelPassword:      r.RhelPassword,
 		RootPasswordHash:  UserDataInput.RootPasswordHash,
 		Files:             UserDataInput.Files,
+		SSMAgentURL:       rhelSsmAgentAMD,
 	}
 
 	if r.Architecture == arm64Arch {
 		data.NodeadmUrl = UserDataInput.NodeadmUrls.ARM
+		data.SSMAgentURL = rhelSsmAgentARM
 	}
 
 	return executeTemplate(rhel9CloudInit, data)

--- a/test/e2e/testdata/rhel/9/cloud-init.txt
+++ b/test/e2e/testdata/rhel/9/cloud-init.txt
@@ -19,6 +19,9 @@ write_files:
     path: {{ $file.Path }}
 {{- end }}
 runcmd:
+  - sudo dnf install -y {{ .SSMAgentURL }}
+  - sudo systemctl start amazon-ssm-agent
+  - sudo systemctl enable amazon-ssm-agent
   - echo "Downloading nodeadm binary"
   - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
   - chmod +x /tmp/nodeadm


### PR DESCRIPTION
*Description of changes:*
- Install aws ssm agent on RHEL9 os for IRA provider.
- Skip Ubuntu2004 and RHEL8 IRA tests.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

