### PR TITLE
Update CloudFormation template for SSM

### DIFF
--- a/example/hybrid-ssm-cfn.yaml
+++ b/example/hybrid-ssm-cfn.yaml
@@ -1,18 +1,28 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'v0.0.4: Hybrid Nodes SSM: Create the required resources for SSM connectivity to EKS cluster'
+Description: 'Creates the Systems Manager resources required for EKS Hybrid Nodes and the EKS Hybrid Nodes IAM role'
+
 Metadata:
   Version:
-    Number: "v0.0.4"
+    Number: "v0.0.5"
 
 Parameters:
-  EKSClusterArn:
+  RoleName:
     Type: String
+    Description: The role name for the EKS Hybrid Nodes IAM role
+    Default: 'AmazonEKSHybridNodesRole'
+  SSMDeregisterConditionTagKey:
+    Type: String
+    Description: The resource tag Key to use in the condition for the ssm:DeregisterManagedInstance action
+    Default: 'EKSClusterARN'
+  SSMDeregisterConditionTagValue:
+    Type: String
+    Description: The resource tag Value to use in the condition for the ssm:DeregisterManagedInstance action.
 
 Resources:
-  SSMRole:
+  EKSHybridNodesRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: HybridNodesSSMRole
+      RoleName: !Ref RoleName
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -20,43 +30,57 @@ Resources:
             Principal:
               Service: ssm.amazonaws.com
             Action: 'sts:AssumeRole'
+            Condition:
+              StringEquals: 
+                'aws:SourceAccount': !Sub '${AWS::AccountId}'
+              ArnEquals: 
+                'aws:SourceArn': !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:*'
       Policies:
-        - PolicyName: SSMRolePolicy
+        - PolicyName: EKSHybridSSMPolicy
+          PolicyDocument: !Sub
+            - |
+              {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                      {
+                          "Effect": "Allow",
+                          "Action": "ssm:DescribeInstanceInformation",
+                          "Resource": "*"
+                      },
+                      {
+                          "Effect": "Allow",
+                          "Action": "ssm:DeregisterManagedInstance",
+                          "Resource": "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:managed-instance/*",
+                          "Condition": {
+                              "StringEquals": {
+                                  "ssm:resourceTag/${SSMDeregisterConditionTagKey}": "${SSMDeregisterConditionTagValue}"
+                              }
+                          }
+                      }
+                  ]
+              }
+            - SSMDeregisterConditionTagKey: !Ref SSMDeregisterConditionTagKey
+              SSMDeregisterConditionTagValue: !Ref SSMDeregisterConditionTagValue
+        - PolicyName: EKSDescribeClusterPolicy
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
               - Effect: Allow
-                Action:
-                  - 'ssm:DeregisterManagedInstance'
-                  - 'ssm:DescribeInstanceInformation'
-                Resource: "arn:aws:ec2:*:*:instance/*",
-                Condition:
-                  ArnLike:
-                    'aws:ResourceArn': "arn:aws:ec2:*:*:instance/mi-*"
-        - PolicyName: EKSDescribeCluster
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - 'eks:DescribeCluster'                    
-                Resource: !Ref EKSClusterArn
+                Action: 'eks:DescribeCluster'                    
+                Resource: '*'
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
-      Tags:
-        - Key: Name
-          Value: !Sub '${AWS::StackName}-ssm-role'
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly
 
 Outputs:
-  SSMRoleName:
-    Description: Name of the EKS Hybrid SSM Role
-    Value: !Ref SSMRole
+  EKSHybridNodesRoleName:
+    Description: Name of the EKS Hybrid Nodes IAM role
+    Value: !Ref EKSHybridNodesRole
     Export:
-      Name: SSMRoleName
+      Name: EKSHybridNodesRoleSSM
   
-  SSMRoleARN:
-    Description: ARN of the EKS Hybrid SSM Role
-    Value: !GetAtt SSMRole.Arn
+  EKSHybridNodesRoleARN:
+    Description: ARN of the EKS Hybrid Nodes IAM role
+    Value: !GetAtt EKSHybridNodesRole.Arn
     Export:
-      Name: SSMRoleARN
+      Name: EKSHybridNodesRoleARNSSM


### PR DESCRIPTION
Updates to CloudFormation template for SSM hybrid activations.

The CloudFormation stack creates the Hybrid Nodes IAM role with scoped down permissions for `ssm:DescribeInstanceInformation` and `ssm:DeregisterManagedInstance`, adds permissions for `eks:DescribeCluster`, and allows SSM to assume the role based on source account and source arn.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

