### PR TITLE
changes vpc peering setup to aws v2 for retries

### DIFF
--- a/cmd/e2e-test/setup/setup.go
+++ b/cmd/e2e-test/setup/setup.go
@@ -48,12 +48,14 @@ func (s *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return fmt.Errorf("failed to unmarshal configuration from YAML: %v", err)
 	}
 
+	ctx := context.Background()
+
 	// Create AWS session
 	testRunner.Session, err = testRunner.NewAWSSession()
+	testRunner.Config, err = testRunner.NewAWSConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create AWS session: %v", err)
 	}
-	ctx := context.Background()
 
 	// Create resources using TestRunner object
 	if err := testRunner.CreateResources(ctx); err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

On two different test runs i ran into the following error in one of the jobs:
```
{"level":"fatal","ts":1732410613.9173677,"caller":"e2e-test/main.go:34","msg":"Command failed","error":"failed to create resources: error creating VPC peering connection: failed to accept VPC peering connection: InvalidVpcPeeringConnectionID.NotFound: The vpcPeeringConnection ID 'pcx-0f640e36fbd803566' does not exist\n\tstatus code: 400, request id: f6bca5b8-d462-45a0-b3b6-f7c8ca4db0e9","stacktrace":"main.main\n\t/codebuild/output/src206145524/src/cmd/e2e-test/main.go:34\nruntime.main\n\t/root/sdk/go1.23.3/src/runtime/proc.go:272"}
```

This attempts to solve this by switching to the v2 sdk with builtin retries.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

