### PR TITLE
adds log collector to e2e tests

### DIFF
--- a/buildspecs/test-nodeadm.yml
+++ b/buildspecs/test-nodeadm.yml
@@ -9,4 +9,4 @@ phases:
   build:
     commands:
     - SANITIZED_CODEBUILD_BUILD_ID=$(echo $CODEBUILD_BUILD_ID | tr ':' '-')
-    - ./hack/run-e2e.sh $SANITIZED_CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/latest-pre/linux/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest-pre/linux/arm64/nodeadm
+    - ./hack/run-e2e.sh $SANITIZED_CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/latest-pre/linux/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest-pre/linux/arm64/nodeadm $LOGS_BUCKET

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -27,6 +27,7 @@ KUBERNETES_VERSION="${3?Please specify the Kubernetes version}"
 CNI="${4?Please specify the cni}"
 NODEADM_AMD_URL="${5?Please specify the nodeadm amd url}"
 NODEADM_ARM_URL="${6?Please specify the nodeadm arm url}"
+LOGS_BUCKET="${7-}"
 
 CONFIG_DIR="$REPO_ROOT/e2e-config"
 BIN_DIR="$REPO_ROOT/_bin"
@@ -72,6 +73,7 @@ clusterRegion: "$REGION"
 hybridVpcID: "$VPC_ID"
 nodeadmUrlAMD: "$NODEADM_AMD_URL"
 nodeadmUrlARM: "$NODEADM_ARM_URL"
+logsBucket: "$LOGS_BUCKET"
 EOF
 
 

--- a/test/e2e/testdata/amazonlinux/2023/cloud-init.txt
+++ b/test/e2e/testdata/amazonlinux/2023/cloud-init.txt
@@ -8,20 +8,18 @@ users:
 package_update: true
 write_files:
   - content: |
-{{ .NodeadmConfig | indent 6 }}
+{{ .NodeadmConfigYaml | indent 6 }}
     path: nodeadm-config.yaml
 {{ range $file := .Files }}
   - content: |
 {{ $file.Content | indent 6 }}
     path: {{ $file.Path }}
+{{if $file.Permissions}}
+    permissions: '{{ $file.Permissions }}'
 {{- end }}
+{{- end }}
+
 runcmd:
-  - echo "Downloading nodeadm binary"
-  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
-  - chmod +x /tmp/nodeadm
-  - echo "Installing kubernetes components"
-  - /tmp/nodeadm install {{ .KubernetesVersion }} --credential-provider {{ .Provider }}
-  - echo "Initializing the node"
-  - /tmp/nodeadm init -c file:///nodeadm-config.yaml
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/testdata/log-collector.sh
+++ b/test/e2e/testdata/log-collector.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+LOGS_UPLOAD_NAME="$1"
+
+declare -A LOGS_UPLOAD_URLS=()
+{{ range $url := .LogsUploadUrls }}
+LOGS_UPLOAD_URLS["{{ $url.Name }}"]="{{ $url.Url }}"
+{{- end }}
+
+if [ ! ${LOGS_UPLOAD_URLS[$LOGS_UPLOAD_NAME]+1} ]; then
+    # no presigned url for name
+    exit
+fi
+
+LOG_SCRIPT_URL="https://raw.githubusercontent.com/jaxesn/amazon-eks-ami/refs/heads/jgw/hybrid-script/log-collector-script/linux/eks-log-collector.sh"
+
+curl -s --retry 5  $LOG_SCRIPT_URL -o /tmp/eks-log-collector.sh
+
+bash /tmp/eks-log-collector.sh
+# do not overwrite if the file is already there
+# s3 will return a 412 PreconditionFailed if the file already exists
+HTTP_CODE=$(curl --header 'If-None-Match: *' -w "%{http_code}" -s -o /dev/null --retry 5 --request PUT --upload-file /var/log/eks_* "${LOGS_UPLOAD_URLS[$LOGS_UPLOAD_NAME]}" )
+rm /var/log/eks_*
+
+if [[ ${HTTP_CODE} -lt 200 || ${HTTP_CODE} -gt 299 ]] ; then
+    exit 1
+fi

--- a/test/e2e/testdata/nodeadm-init.sh
+++ b/test/e2e/testdata/nodeadm-init.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NODEADM_URL="$1"
+KUBERNETES_VERSION="$2"
+PROVDER="$3"
+NODEADM_ADDITIONAL_ARGS="${4-}"
+
+function gather_logs(){
+    # Arbitrary wait to give enough time for logs to populated with potential errors
+    # if the node successfully joins and reboots in this, we wont get the logs
+    sleep 15
+    if ! /tmp/log-collector.sh "post-install"; then
+        /tmp/log-collector.sh "post-uninstall-install"
+    fi
+}
+
+trap "gather_logs" EXIT
+
+echo "Downloading nodeadm binary"
+curl -s --retry 5 -L "$NODEADM_URL" -o /tmp/nodeadm
+chmod +x /tmp/nodeadm
+
+echo "Installing kubernetes components"
+/tmp/nodeadm install $KUBERNETES_VERSION $NODEADM_ADDITIONAL_ARGS --credential-provider $PROVDER
+
+echo "Initializing the node"
+/tmp/nodeadm init -c file:///nodeadm-config.yaml

--- a/test/e2e/testdata/rhel/8/cloud-init.txt
+++ b/test/e2e/testdata/rhel/8/cloud-init.txt
@@ -11,20 +11,18 @@ rh_subscription:
 package_update: true
 write_files:
   - content: |
-{{ .NodeadmConfig | indent 6 }}
+{{ .NodeadmConfigYaml | indent 6 }}
     path: nodeadm-config.yaml
 {{ range $file := .Files }}
   - content: |
 {{ $file.Content | indent 6 }}
     path: {{ $file.Path }}
+{{if $file.Permissions}}
+    permissions: '{{ $file.Permissions }}'
 {{- end }}
+{{- end }}
+
 runcmd:
-  - echo "Downloading nodeadm binary"
-  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
-  - chmod +x /tmp/nodeadm
-  - echo "Installing kubernetes components"
-  - /tmp/nodeadm install {{ .KubernetesVersion }} --containerd-source docker --credential-provider {{ .Provider }}
-  - echo "Initializing the node"
-  - /tmp/nodeadm init -c file:///nodeadm-config.yaml
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "--containerd-source docker"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/testdata/rhel/9/cloud-init.txt
+++ b/test/e2e/testdata/rhel/9/cloud-init.txt
@@ -11,23 +11,21 @@ rh_subscription:
 package_update: true
 write_files:
   - content: |
-{{ .NodeadmConfig | indent 6 }}
+{{ .NodeadmConfigYaml | indent 6 }}
     path: nodeadm-config.yaml
 {{ range $file := .Files }}
   - content: |
 {{ $file.Content | indent 6 }}
     path: {{ $file.Path }}
+{{if $file.Permissions}}
+    permissions: '{{ $file.Permissions }}'
 {{- end }}
+{{- end }}
+
 runcmd:
   - sudo dnf install -y {{ .SSMAgentURL }}
   - sudo systemctl start amazon-ssm-agent
   - sudo systemctl enable amazon-ssm-agent
-  - echo "Downloading nodeadm binary"
-  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
-  - chmod +x /tmp/nodeadm
-  - echo "Installing kubernetes components"
-  - /tmp/nodeadm install {{ .KubernetesVersion }} --containerd-source docker --credential-provider {{ .Provider }}
-  - echo "Initializing the node"
-  - /tmp/nodeadm init -c file:///nodeadm-config.yaml
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "--containerd-source docker"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/testdata/ubuntu/2004/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2004/cloud-init.txt
@@ -8,20 +8,18 @@ users:
 package_update: true
 write_files:
   - content: |
-{{ .NodeadmConfig | indent 6 }}
+{{ .NodeadmConfigYaml | indent 6 }}
     path: nodeadm-config.yaml
 {{ range $file := .Files }}
   - content: |
 {{ $file.Content | indent 6 }}
     path: {{ $file.Path }}
+{{if $file.Permissions}}
+    permissions: '{{ $file.Permissions }}'
 {{- end }}
+{{- end }}
+
 runcmd:
-  - echo "Downloading nodeadm binary"
-  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
-  - chmod +x /tmp/nodeadm
-  - echo "Installing kubernetes components"
-  - /tmp/nodeadm install {{ .KubernetesVersion }} --credential-provider {{ .Provider }}
-  - echo "Initializing the node"
-  - /tmp/nodeadm init -c file:///nodeadm-config.yaml
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/testdata/ubuntu/2204/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2204/cloud-init.txt
@@ -8,20 +8,18 @@ users:
 package_update: true
 write_files:
   - content: |
-{{ .NodeadmConfig | indent 6 }}
+{{ .NodeadmConfigYaml | indent 6 }}
     path: nodeadm-config.yaml
 {{ range $file := .Files }}
   - content: |
 {{ $file.Content | indent 6 }}
     path: {{ $file.Path }}
+{{if $file.Permissions}}
+    permissions: '{{ $file.Permissions }}'
 {{- end }}
+{{- end }}
+
 runcmd:
-  - echo "Downloading nodeadm binary"
-  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
-  - chmod +x /tmp/nodeadm
-  - echo "Installing kubernetes components"
-  - /tmp/nodeadm install {{ .KubernetesVersion }} --credential-provider {{ .Provider }}
-  - echo "Initializing the node"
-  - /tmp/nodeadm init -c file:///nodeadm-config.yaml
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/testdata/ubuntu/2404/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2404/cloud-init.txt
@@ -57,21 +57,19 @@ write_files:
       }
     path: /etc/apparmor.d/cri-containerd.apparmor.d
   - content: |
-{{ .NodeadmConfig | indent 6 }}
+{{ .NodeadmConfigYaml | indent 6 }}
     path: nodeadm-config.yaml
 {{ range $file := .Files }}
   - content: |
 {{ $file.Content | indent 6 }}
     path: {{ $file.Path }}
+{{if $file.Permissions}}
+    permissions: '{{ $file.Permissions }}'
 {{- end }}
+{{- end }}
+
 runcmd:
   - systemctl restart apparmor.service
-  - echo "Downloading nodeadm binary"
-  - curl -s --retry 5 -L "{{ .NodeadmUrl }}" -o /tmp/nodeadm
-  - chmod +x /tmp/nodeadm
-  - echo "Installing kubernetes components"
-  - /tmp/nodeadm install {{ .KubernetesVersion }} --credential-provider {{ .Provider }}
-  - echo "Initializing the node"
-  - /tmp/nodeadm init -c file:///nodeadm-config.yaml
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds log collecting to the e2e suites.  If a logs bucket is supplied via the test spec, presigned urls will be generated for the ec2 instances to upload the tar of collected logs.  

There is only 1 upload url, but it will be written to 3 times during the simple test, after init, after uninstall and after the final init.  These will show up as versions in s3 and can be downloaded to be analyzed.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

