### PR TITLE
adds invalid vpc as allowed retry error

### DIFF
--- a/test/e2e/vpc.go
+++ b/test/e2e/vpc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	ec2v2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2v2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go/aws"
@@ -315,6 +316,7 @@ func (t *TestRunner) createVPCPeering(ctx context.Context) (string, error) {
 	_, err = svc.AcceptVpcPeeringConnection(ctx, &ec2v2.AcceptVpcPeeringConnectionInput{
 		VpcPeeringConnectionId: aws.String(peeringConnectionID),
 	}, func(o *ec2v2.Options) {
+		o.Retryer = retry.AddWithErrorCodes(retry.NewStandard(), "InvalidVpcPeeringConnectionID.NotFound")
 		o.RetryMaxAttempts = 20
 		o.RetryMode = awsv2.RetryModeAdaptive
 	})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By default the sdk retries typical "retryable" errors like timeouts.

https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/aws/retry

In this case we know that the peering connection creation is async and may not be ready in time so adding it as a retryable error.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

