### PR TITLE
Validate nodeName can't be empty or longer than 64

### DIFF
--- a/internal/node/hybrid/validator.go
+++ b/internal/node/hybrid/validator.go
@@ -30,6 +30,12 @@ func (hnp *hybridNodeProvider) withHybridValidators() {
 			if cfg.Spec.Hybrid.IAMRolesAnywhere.TrustAnchorARN == "" {
 				return fmt.Errorf("TrustAnchorARN is missing in hybrid iam roles anywhere configuration")
 			}
+			if cfg.Spec.Hybrid.IAMRolesAnywhere.NodeName == "" {
+				return fmt.Errorf("NodeName can't be empty in hybrid iam roles anywhere configuration")
+			}
+			if len(cfg.Spec.Hybrid.IAMRolesAnywhere.NodeName) > 64 {
+				return fmt.Errorf("NodeName can't be longer than 64 characters in hybrid iam roles anywhere configuration")
+			}
 		}
 		if cfg.IsSSM() {
 			if cfg.Spec.Hybrid.SSM.ActivationCode == "" {

--- a/test/e2e/nodeadm_test.go
+++ b/test/e2e/nodeadm_test.go
@@ -50,6 +50,7 @@ type TestConfig struct {
 	NodeadmUrlAMD   string `yaml:"nodeadmUrlAMD"`
 	NodeadmUrlARM   string `yaml:"nodeadmUrlARM"`
 	SetRootPassword bool   `yaml:"setRootPassword"`
+	NodeK8sVersion  string `json:"nodeK8SVersion"`
 }
 
 type suiteConfiguration struct {
@@ -345,8 +346,13 @@ var _ = Describe("Hybrid Nodes", func() {
 								test.logger.Info(fmt.Sprintf("Instance Root Password: %s", rootPassword))
 							}
 
+							k8sVersion := test.cluster.kubernetesVersion
+							if suite.TestConfig.NodeK8sVersion != "" {
+								k8sVersion = suite.TestConfig.NodeK8sVersion
+							}
+
 							userdata, err := os.BuildUserData(UserDataInput{
-								KubernetesVersion: test.cluster.kubernetesVersion,
+								KubernetesVersion: k8sVersion,
 								NodeadmUrls:       test.nodeadmURLs,
 								NodeadmConfigYaml: string(nodeadmConfigYaml),
 								Provider:          string(provider.Name()),


### PR DESCRIPTION
*Description of changes:*
The roleSessionName we use to pass the node name has a limit of 64 chars. We validate to fail fast instead of having to debug why the init command fails getting credentials from IAM Roles Anywhere.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

