### PR TITLE
Don't de-register SSM instance during upgrade

### DIFF
--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/eks-hybrid/internal/kubelet"
 	"github.com/aws/eks-hybrid/internal/node"
 	"github.com/aws/eks-hybrid/internal/packagemanager"
+	"github.com/aws/eks-hybrid/internal/ssm"
 	"github.com/aws/eks-hybrid/internal/tracker"
 )
 
@@ -104,6 +105,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		Artifacts:      installed.Artifacts,
 		DaemonManager:  daemonManager,
 		PackageManager: packageManager,
+		SSMUninstall:   ssm.DeregisterAndUninstall,
 		Logger:         log,
 	}
 

--- a/cmd/nodeadm/upgrade/upgrade.go
+++ b/cmd/nodeadm/upgrade/upgrade.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/eks-hybrid/internal/kubelet"
 	"github.com/aws/eks-hybrid/internal/node"
 	"github.com/aws/eks-hybrid/internal/packagemanager"
+	"github.com/aws/eks-hybrid/internal/ssm"
 	"github.com/aws/eks-hybrid/internal/tracker"
 )
 
@@ -163,6 +164,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		Artifacts:      installed.Artifacts,
 		DaemonManager:  daemonManager,
 		PackageManager: packageManager,
+		SSMUninstall:   ssm.Uninstall,
 		Logger:         log,
 	}
 


### PR DESCRIPTION
## Description of changes
The upgrade seems like it just runs a uninstall + install + init blindly

This works great with iam roles anywhere. However, for SSM, this de-registers the managed instance. Init should re-register it again. However, this presents two problems:
- The node name changes bc the managed instance id changes
- If the activation code was limited to one registration or the activation has already been used the max number of times by other machines, init will fail when trying to re-register the machine

With this change we try to make de-register optional. So when uninstall is run by the upgrade flow, it only removes the package and ssm-cli-setup binary, but it doesn't de-register the instance. When run by the `uninstall` command, it also de-registers the instance. This also opens the possibility to make de-registration option during uninstall by adding a flag.

## Testing
Need to test this more with e2e. However, we don't have e2e tests yet for upgrade.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

