### PR TITLE
temporarily pin containerd on ubuntu 2404

### DIFF
--- a/test/e2e/testdata/ubuntu/2404/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2404/cloud-init.txt
@@ -6,6 +6,8 @@ users:
     hashed_passwd: {{ .RootPasswordHash }}
 {{- end }}
 package_update: true
+packages:
+  - [containerd,1.7.12-0ubuntu4]
 write_files:
   - content: |
       #include <tunables/global>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The latest 1.17.19 package from ubuntu on 2404 does not play nice with our config.  Temporarily pinning to avoid issues in our testing.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

