### PR TITLE
Register with SSM agent instead of setup CLI

### DIFF
--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -62,6 +62,7 @@ func (m *systemdDaemonManager) RestartDaemon(name string) error {
 }
 
 func (m *systemdDaemonManager) GetDaemonStatus(name string) (DaemonStatus, error) {
+	// TODO(g-gaston): this should take a context to it can be cancelled from the caller
 	unitName := getServiceUnitName(name)
 	status, err := m.conn.GetUnitPropertyContext(context.TODO(), unitName, "ActiveState")
 	if err != nil {

--- a/internal/daemon/wait.go
+++ b/internal/daemon/wait.go
@@ -1,0 +1,33 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// WaitForStatus waits for the daemon to reach the desired status.
+// It will keep checking the status of the daemon until it reaches the desired status
+// or the context is cancelled. If you don't cancel the context, this function will
+// keep retrying indefinitely.
+func WaitForStatus(ctx context.Context, logger *zap.Logger, manager DaemonManager, daemonName string, desired DaemonStatus, backoff time.Duration) error {
+	for {
+		status, err := manager.GetDaemonStatus(daemonName)
+		if err != nil {
+			logger.Error("Failed to get daemon status", zap.String("daemon", daemonName), zap.Error(err))
+		} else {
+			if status == desired {
+				return nil
+			}
+			logger.Info("Daemon is not in the desired state yet", zap.String("daemon", daemonName), zap.String("status", string(status)))
+		}
+		logger.Debug("Waiting before next retry", zap.Duration("backoff", backoff))
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("daemon %s still has status %s: %w", daemonName, status, ctx.Err())
+		case <-time.After(backoff):
+		}
+	}
+}

--- a/internal/daemon/wait_test.go
+++ b/internal/daemon/wait_test.go
@@ -1,0 +1,89 @@
+package daemon_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/eks-hybrid/internal/daemon"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+)
+
+func TestWaitForStatusSuccess(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+	manager := &fakeManager{}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		manager.SetStatus(daemon.DaemonStatusRunning)
+	}()
+
+	g.Expect(
+		daemon.WaitForStatus(ctx, zap.NewNop(), manager, "my-daemon", daemon.DaemonStatusRunning, time.Millisecond),
+	).To(Succeed())
+}
+
+func TestWaitForStatusTimeout(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+	manager := &fakeManager{}
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
+	defer cancel()
+
+	g.Expect(
+		daemon.WaitForStatus(ctx, zap.NewNop(), manager, "my-daemon", daemon.DaemonStatusRunning, 10*time.Nanosecond),
+	).NotTo(MatchError((ContainSubstring("daemon my-daemon still has status unknown: context deadline exceeded"))))
+}
+
+type fakeManager struct {
+	sync.RWMutex
+	status daemon.DaemonStatus
+}
+
+var _ daemon.DaemonManager = &fakeManager{}
+
+func (f *fakeManager) RestartDaemon(name string) error {
+	return nil
+}
+
+func (f *fakeManager) EnableDaemon(name string) error {
+	return nil
+}
+
+func (f *fakeManager) StopDaemon(name string) error {
+	return nil
+}
+
+func (f *fakeManager) StartDaemon(name string) error {
+	return nil
+}
+
+func (f *fakeManager) GetDaemonStatus(name string) (daemon.DaemonStatus, error) {
+	f.RLock()
+	defer f.RUnlock()
+	return f.status, nil
+}
+
+func (f *fakeManager) DisableDaemon(name string) error {
+	return nil
+}
+
+func (f *fakeManager) DaemonReload() error {
+	return nil
+}
+
+func (f *fakeManager) Close() {
+}
+
+func (f *fakeManager) SetStatus(s daemon.DaemonStatus) {
+	f.Lock()
+	defer f.Unlock()
+	f.status = s
+}

--- a/internal/ssm/daemon.go
+++ b/internal/ssm/daemon.go
@@ -1,10 +1,12 @@
 package ssm
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -41,30 +43,8 @@ func NewSsmDaemon(daemonManager daemon.DaemonManager, cfg *api.NodeConfig, logge
 }
 
 func (s *ssm) Configure() error {
-	registerOverride := false
-	_, err := GetManagedHybridInstanceId()
-	if err != nil && os.IsNotExist(err) {
-		// The node is not registered with SSM
-		// In some cases, while the node is not registered, there might be some leftover
-		// registration data from previous registrations. Setting force to true, will override
-		// leftover registration data from the service cache.
-		registerOverride = true
-	} else if err != nil {
-		return err
-	}
-	err = s.registerMachine(s.nodeConfig, registerOverride)
-	if err != nil {
-		// SSM register command will download a new ssm agent installer and verify checksums to match with
-		// downloaded and current running agent installer. If checksums do not match, re-download and run
-		// register again. Checksum mismatch can happen due to new ssm agent releases or switching regions.
-		if match := checksumMismatchErrorRegex.MatchString(err.Error()); match {
-			s.logger.Info("Encountered checksum mismatch on SSM agent installer. Re-downloading installer from",
-				zap.Reflect("region", s.nodeConfig.Spec.Cluster.Region))
-			if err := redownloadInstaller(s.nodeConfig.Spec.Cluster.Region); err != nil {
-				return err
-			}
-			return s.registerMachine(s.nodeConfig, registerOverride)
-		} else if match := activationExpiredRegex.MatchString(err.Error()); match {
+	if err := s.registerMachine(s.nodeConfig); err != nil {
+		if match := activationExpiredRegex.MatchString(err.Error()); match {
 			return fmt.Errorf("SSM activation expired. Please use a valid activation")
 		} else if match := invalidActivationRegex.MatchString(err.Error()); match {
 			return fmt.Errorf("invalid SSM activation. Please use a valid activation code, activation id and region")
@@ -79,13 +59,27 @@ func (s *ssm) EnsureRunning() error {
 	if err != nil {
 		return err
 	}
-	return s.daemonManager.RestartDaemon(SsmDaemonName)
+	if err := s.daemonManager.RestartDaemon(SsmDaemonName); err != nil {
+		return err
+	}
+
+	// TODO(g-gaston): this method should take a context
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	s.logger.Info("Waiting for SSM agent to be running")
+	if err := daemon.WaitForStatus(ctx, s.logger, s.daemonManager, SsmDaemonName, daemon.DaemonStatusRunning, 5*time.Second); err != nil {
+		return fmt.Errorf("waiting for SSM agent to be running: %w", err)
+	}
+
+	return nil
 }
 
 func (s *ssm) PostLaunch() error {
 	if s.nodeConfig.Spec.Hybrid.EnableCredentialsFile {
 		s.logger.Info("Creating symlink for AWS credentials", zap.String("Symbolic link path", symlinkedAWSConfigPath))
-		err := os.MkdirAll(eksHybridPath, 0755)
+		err := os.MkdirAll(eksHybridPath, 0o755)
 		if err != nil {
 			return fmt.Errorf("creating path: %v", err)
 		}
@@ -107,7 +101,6 @@ func (s *ssm) PostLaunch() error {
 // Stop stops the ssm unit only if it is loaded and running
 func (s *ssm) Stop() error {
 	return s.daemonManager.StopDaemon(SsmDaemonName)
-
 }
 
 func (s *ssm) Name() string {


### PR DESCRIPTION
## Description of changes
This ensures that there is no "checksum" error so the setup-cli and agent don't need to be re-downloaded during init.

The downside is that we lose some of the functionality provided by the setup CLI, like verifying if the instance is already registered and making sure the agent is running. So we have to implement this ourselves.

## Testing
Running it through tests right now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

