### PR TITLE
Ensure Node object is deleted even when test fails

### DIFF
--- a/test/e2e/nodeadm_test.go
+++ b/test/e2e/nodeadm_test.go
@@ -389,6 +389,7 @@ var _ = Describe("Hybrid Nodes", func() {
 								test.logger.Info("Deleting EC2 Instance", "instanceID", ec2.instanceID)
 								Expect(deleteEC2Instance(ctx, test.ec2ClientV2, ec2.instanceID)).NotTo(HaveOccurred(), "EC2 Instance should have been deleted successfully")
 								test.logger.Info("Successfully deleted EC2 Instance", "instanceID", ec2.instanceID)
+								Expect(ensureNodeWithIPIsDeleted(ctx, test.k8sClient, ec2.ipAddress)).To(Succeed(), "node should have been deleted from the cluster")
 							})
 
 							joinNodeTest := joinNodeTest{


### PR DESCRIPTION
## Description of changes
Very annoying when a test fails, it cleans up the instance but not the node object. For SSM, this means leaven the node orphaned, which can mess future runs, specially with the cilium operator still scheduled in the not ready node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

