### PR TITLE
Use absolute path for skipped tests file

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -77,7 +77,7 @@ logsBucket: "$LOGS_BUCKET"
 EOF
 
 
-SKIP_FILE=SKIPPED_TESTS.yaml
+SKIP_FILE=$REPO_ROOT/hack/SKIPPED_TESTS.yaml
 # Extract skipped_tests field from SKIP_FILE file and join entries with ' || '
 skip=$(yq '.skipped_tests | join(" || ")' ${SKIP_FILE})
 


### PR DESCRIPTION
Use absolute path for skipped tests file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

