### PR TITLE
Retry package manager install commands

### DIFF
--- a/internal/artifact/install_test.go
+++ b/internal/artifact/install_test.go
@@ -2,10 +2,14 @@ package artifact_test
 
 import (
 	"bytes"
+	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
 
 	"github.com/aws/eks-hybrid/internal/artifact"
 )
@@ -15,7 +19,7 @@ func TestInstallFile(t *testing.T) {
 	tmp := t.TempDir()
 	src := bytes.NewBuffer(srcData)
 	dst := filepath.Join(tmp, "file")
-	perms := fs.FileMode(0644)
+	perms := fs.FileMode(0o644)
 
 	err := artifact.InstallFile(dst, src, perms)
 	if err != nil {
@@ -45,9 +49,9 @@ func TestInstallFile_FileExists(t *testing.T) {
 	tmp := t.TempDir()
 	src := bytes.NewBufferString("hello, world!")
 	dst := filepath.Join(tmp, "file")
-	perms := fs.FileMode(0644)
+	perms := fs.FileMode(0o644)
 
-	if err := os.WriteFile(dst, []byte("hello, world!"), 0644); err != nil {
+	if err := os.WriteFile(dst, []byte("hello, world!"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -62,7 +66,7 @@ func TestInstallFile_DirNotExists(t *testing.T) {
 	src := bytes.NewBufferString("hello, world!")
 	dir := filepath.Join(tmp, "nonexistent")
 	dst := filepath.Join(dir, "file")
-	perms := fs.FileMode(0644)
+	perms := fs.FileMode(0o644)
 
 	err := artifact.InstallFile(dst, src, perms)
 	if err != nil {
@@ -80,5 +84,44 @@ func TestInstallFile_DirNotExists(t *testing.T) {
 
 	if info.Mode() != artifact.DefaultDirPerms {
 		t.Fatalf("Expected dir with %v permissions; received %v", artifact.DefaultDirPerms, info.Mode())
+	}
+}
+
+func TestInstallPackageWithRetries(t *testing.T) {
+	testCases := []struct {
+		name    string
+		source  artifact.Package
+		wantErr string
+	}{
+		{
+			name: "happy path",
+			source: artifact.NewPackageSource(
+				artifact.NewCmd("echo", "hello"),
+				artifact.Cmd{},
+			),
+		},
+		{
+			name: "error",
+			source: artifact.NewPackageSource(
+				artifact.NewCmd("fake-command", "1"),
+				artifact.Cmd{},
+			),
+			wantErr: `running command [fake-command 1]:  [Err exec: "fake-command": executable file not found in $PATH]`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+			defer cancel()
+
+			err := artifact.InstallPackageWithRetries(ctx, tc.source, 1*time.Millisecond)
+			if tc.wantErr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tc.wantErr)))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
 	}
 }

--- a/internal/packagemanager/packagemanager.go
+++ b/internal/packagemanager/packagemanager.go
@@ -29,7 +29,7 @@ const (
 	ubuntuDockerRepo            = "https://download.docker.com/linux/ubuntu"
 	ubuntuDockerGpgKey          = "https://download.docker.com/linux/ubuntu/gpg"
 	ubuntuDockerGpgKeyPath      = "/etc/apt/keyrings/docker.asc"
-	ubuntuDockerGpgKeyFilePerms = 0755
+	ubuntuDockerGpgKeyFilePerms = 0o755
 	aptDockerRepoSourceFilePath = "/etc/apt/sources.list.d/docker.list"
 
 	containerdDistroPkgName = "containerd"
@@ -190,38 +190,38 @@ func (pm *DistroPackageManager) removePackage(ctx context.Context, packageName s
 
 // GetContainerd gets the Package
 // Satisfies the containerd source interface
-func (pm *DistroPackageManager) GetContainerd(ctx context.Context) artifact.Package {
+func (pm *DistroPackageManager) GetContainerd() artifact.Package {
 	packageName := containerdDistroPkgName
 	if pm.dockerRepo != "" {
 		packageName = containerdDockerPkgName
 	}
 	return artifact.NewPackageSource(
-		exec.CommandContext(ctx, pm.manager, pm.installVerb, packageName, "-y"),
-		exec.CommandContext(ctx, pm.manager, pm.deleteVerb, packageName, "-y"),
+		artifact.NewCmd(pm.manager, pm.installVerb, packageName, "-y"),
+		artifact.NewCmd(pm.manager, pm.deleteVerb, packageName, "-y"),
 	)
 }
 
 // GetIptables satisfies the getiptables source interface
-func (pm *DistroPackageManager) GetIptables(ctx context.Context) artifact.Package {
+func (pm *DistroPackageManager) GetIptables() artifact.Package {
 	return artifact.NewPackageSource(
-		exec.CommandContext(ctx, pm.manager, pm.installVerb, "iptables", "-y"),
-		exec.CommandContext(ctx, pm.manager, pm.deleteVerb, "iptables", "-y"),
+		artifact.NewCmd(pm.manager, pm.installVerb, "iptables", "-y"),
+		artifact.NewCmd(pm.manager, pm.deleteVerb, "iptables", "-y"),
 	)
 }
 
 // GetSSMPackage satisfies the getssmpackage source interface
-func (pm *DistroPackageManager) GetSSMPackage(ctx context.Context) artifact.Package {
+func (pm *DistroPackageManager) GetSSMPackage() artifact.Package {
 	// SSM is installed using snap package manager. If apt package manager
 	// is detected, use snap to install/uninstall SSM.
 	if pm.manager == aptPackageManager {
 		return artifact.NewPackageSource(
-			exec.CommandContext(ctx, snapPackageManager, snapRemoveVerb, "amazon-ssm-agent"),
-			exec.CommandContext(ctx, snapPackageManager, snapRemoveVerb, "amazon-ssm-agent"),
+			artifact.NewCmd(snapPackageManager, snapRemoveVerb, "amazon-ssm-agent"),
+			artifact.NewCmd(snapPackageManager, snapRemoveVerb, "amazon-ssm-agent"),
 		)
 	}
 	return artifact.NewPackageSource(
-		exec.CommandContext(ctx, pm.manager, pm.installVerb, "amazon-ssm-agent", "-y"),
-		exec.CommandContext(ctx, pm.manager, pm.deleteVerb, "amazon-ssm-agent", "-y"),
+		artifact.NewCmd(pm.manager, pm.installVerb, "amazon-ssm-agent", "-y"),
+		artifact.NewCmd(pm.manager, pm.deleteVerb, "amazon-ssm-agent", "-y"),
 	)
 }
 
@@ -244,6 +244,7 @@ var packageManagerUpdateCmd = map[string]string{
 	aptPackageManager: "update",
 	yumPackageManager: "update",
 }
+
 var packageManagerDeleteCmd = map[string]string{
 	aptPackageManager: "autoremove",
 	yumPackageManager: "remove",

--- a/internal/ssm/install.go
+++ b/internal/ssm/install.go
@@ -28,7 +28,7 @@ type Source interface {
 
 // PkgSource serves and defines the package for target platform
 type PkgSource interface {
-	GetSSMPackage(ctx context.Context) artifact.Package
+	GetSSMPackage() artifact.Package
 }
 
 func Install(ctx context.Context, tracker *tracker.Tracker, source Source) error {
@@ -109,8 +109,8 @@ func Uninstall(ctx context.Context, logger *zap.Logger, pkgSource PkgSource) err
 }
 
 func uninstallPreRegisterComponents(ctx context.Context, pkgSource PkgSource) error {
-	ssmPkg := pkgSource.GetSSMPackage(ctx)
-	if err := artifact.UninstallPackage(ssmPkg); err != nil {
+	ssmPkg := pkgSource.GetSSMPackage()
+	if err := artifact.UninstallPackage(ctx, ssmPkg); err != nil {
 		return errors.Wrapf(err, "failed to uninstall ssm")
 	}
 	return os.RemoveAll(installerPath)


### PR DESCRIPTION
## Description of changes
Sometimes (yum/apt) install fails due to conflicts with other processes updating packages at the same time, specially when automating at machine startup. We assume errors are transient and just retry for a bit.

## Testing
Running this through AL2023 and ubuntu. Will try with RHEL later if I can as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

