### PR TITLE
Fix Ginkgo label filter argument

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -86,4 +86,4 @@ skip=$(yq '.skipped_tests | join(" || ")' ${SKIP_FILE})
 # on how the CI runner has been configured. However, even if only one CPU is avaialble,
 # there is still value in running the tests in multiple processes, since most of the work is
 # "waiting" for infra to be created and nodes to join the cluster.
-$BIN_DIR/ginkgo --procs 64 -v -tags=e2e --label-filter='!(${skip})' $BIN_DIR/e2e.test -- -filepath=$CONFIG_DIR/e2e-param.yaml
+$BIN_DIR/ginkgo --procs 64 -v -tags=e2e --label-filter="!(${skip})" $BIN_DIR/e2e.test -- -filepath=$CONFIG_DIR/e2e-param.yaml


### PR DESCRIPTION
Fix Ginkgo label filter argument by using double quotes so that variable substitution is done.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

