### PR TITLE
Use skip flag instead of label-filter to skip a few tests

### DIFF
--- a/hack/SKIPPED_TESTS.yaml
+++ b/hack/SKIPPED_TESTS.yaml
@@ -1,5 +1,5 @@
 skipped_tests:
-  - "(ubuntu2004-amd64 && iam-ra)"
-  - "(rhel8-amd64 && iam-ra)"
-  - "(ubuntu2004-arm64 && iam-ra)"
-  - "(rhel8-arm64 && iam-ra)"
+  - "ubuntu2004-amd64.*iam-ra"
+  - "rhel8-amd64.*iam-ra"
+  - "ubuntu2004-arm64.*iam-ra"
+  - "rhel8-arm64.*iam-ra"

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -79,11 +79,11 @@ EOF
 
 SKIP_FILE=$REPO_ROOT/hack/SKIPPED_TESTS.yaml
 # Extract skipped_tests field from SKIP_FILE file and join entries with ' || '
-skip=$(yq '.skipped_tests | join(" || ")' ${SKIP_FILE})
+skip=$(yq '.skipped_tests | join("|")' ${SKIP_FILE})
 
 # We expliclty specify procs instead of letting ginkgo decide (with -p) because in if not
 # ginkgo will use all available CPUs, which could be a small number depending
 # on how the CI runner has been configured. However, even if only one CPU is avaialble,
 # there is still value in running the tests in multiple processes, since most of the work is
 # "waiting" for infra to be created and nodes to join the cluster.
-$BIN_DIR/ginkgo --procs 64 -v -tags=e2e --label-filter="!(${skip})" $BIN_DIR/e2e.test -- -filepath=$CONFIG_DIR/e2e-param.yaml
+$BIN_DIR/ginkgo --procs 64 -v -tags=e2e --skip="${skip}" $BIN_DIR/e2e.test -- -filepath=$CONFIG_DIR/e2e-param.yaml


### PR DESCRIPTION
*Description of changes:*
The `--label-filter` filter to skip a few tests works for but it messes up with the test setup we have done. Adding `--skip` flag to skip tests.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

