### PR TITLE
preserves cni directory on upgrade

### DIFF
--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/utils/strings/slices"
 
 	"github.com/aws/eks-hybrid/internal/cli"
+	"github.com/aws/eks-hybrid/internal/cni"
 	"github.com/aws/eks-hybrid/internal/containerd"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/flows"
@@ -107,6 +108,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		PackageManager: packageManager,
 		SSMUninstall:   ssm.DeregisterAndUninstall,
 		Logger:         log,
+		CNIUninstall:   cni.Uninstall,
 	}
 
 	return uninstaller.Run(ctx)

--- a/cmd/nodeadm/upgrade/upgrade.go
+++ b/cmd/nodeadm/upgrade/upgrade.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/eks-hybrid/internal/aws"
 	"github.com/aws/eks-hybrid/internal/cli"
+	"github.com/aws/eks-hybrid/internal/cni"
 	"github.com/aws/eks-hybrid/internal/containerd"
 	"github.com/aws/eks-hybrid/internal/creds"
 	"github.com/aws/eks-hybrid/internal/daemon"
@@ -166,6 +167,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		PackageManager: packageManager,
 		SSMUninstall:   ssm.Uninstall,
 		Logger:         log,
+		CNIUninstall:   cni.NoOp,
 	}
 
 	installer := &flows.Installer{

--- a/internal/artifact/install.go
+++ b/internal/artifact/install.go
@@ -35,9 +35,6 @@ func InstallFile(dst string, src io.Reader, perms fs.FileMode) error {
 
 // InstallTarGz untars the src file into the dst directory and deletes the src tgz file
 func InstallTarGz(dst string, src string) error {
-	if err := os.RemoveAll(dst); err != nil {
-		return err
-	}
 	if err := os.MkdirAll(dst, DefaultDirPerms); err != nil {
 		return err
 	}

--- a/internal/cni/install.go
+++ b/internal/cni/install.go
@@ -24,6 +24,10 @@ type Source interface {
 	GetCniPlugins(context.Context) (artifact.Source, error)
 }
 
+func NoOp() error {
+	return nil
+}
+
 func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 	cniPlugins, err := src.GetCniPlugins(ctx)
 	if err != nil {

--- a/internal/flows/uninstall.go
+++ b/internal/flows/uninstall.go
@@ -7,7 +7,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/aws/eks-hybrid/internal/cni"
 	"github.com/aws/eks-hybrid/internal/containerd"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/iamauthenticator"
@@ -24,6 +23,7 @@ import (
 const eksConfigDir = "/etc/eks"
 
 type SSMUninstall func(ctx context.Context, logger *zap.Logger, pm ssm.PkgSource) error
+type CNIUninstall func() error
 
 type Uninstaller struct {
 	Artifacts      *tracker.InstalledArtifacts
@@ -31,6 +31,7 @@ type Uninstaller struct {
 	PackageManager *packagemanager.DistroPackageManager
 	SSMUninstall   SSMUninstall
 	Logger         *zap.Logger
+	CNIUninstall   CNIUninstall
 }
 
 func (u *Uninstaller) Run(ctx context.Context) error {
@@ -101,7 +102,7 @@ func (u *Uninstaller) uninstallBinaries(ctx context.Context) error {
 	}
 	if u.Artifacts.CniPlugins {
 		u.Logger.Info("Uninstalling cni-plugins...")
-		if err := cni.Uninstall(); err != nil {
+		if err := u.CNIUninstall(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently upgrade is implemented using uninstall followed by install. This works fine for most artifacts, but for the cni plugins where calioc/cilium add their bin to the same folder this becomes a problem during in-place upgrade.  This follows the same approach as ssm deregister where we do not remove the /opt/cni folder on upgrade, but continue to on uninstall.

We had specifically removed the /opt/cni folder during install before extracting the tar, I am not positive as to why.  We tested to ensure the tar extract will overwrite existing files with the same names.  We should watch out for other consequences to this change.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

