### PR TITLE
Create both the providers resources all the time for e2e tests

### DIFF
--- a/test/e2e/cfn-templates/hybrid-cfn.yaml
+++ b/test/e2e/cfn-templates/hybrid-cfn.yaml
@@ -2,16 +2,6 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: CloudFormation template to create IAM roles and an EC2 instance with customizable volume size.
 
 Parameters:
-  ssm:
-    Type: String
-    Description: Specify whether to use the SSM provider.
-    AllowedValues: ['true', 'false']
-    Default: 'false'
-  iamra:
-    Type: String
-    Description: Specify whether to use the IAM RA provider.
-    AllowedValues: ['true', 'false']
-    Default: 'false'
   caBundleCert:
     Type: String
   clusterArn:
@@ -21,13 +11,8 @@ Parameters:
     Type: String
     Description: The name of the EKS cluster.
 
-Conditions:
-  CreateSSMRole: !Equals [!Ref ssm, 'true']
-  CreateIRAResource: !Equals [!Ref 'iamra', 'true']
-
 Resources:
   SSMRole:
-    Condition: CreateSSMRole
     Type: AWS::IAM::Role
     Properties: 
       RoleName: !Sub "${AWS::StackName}-ssm"
@@ -75,7 +60,6 @@ Resources:
           Value: !Sub '${AWS::StackName}'
 
   SSMClusterAccessEntry:
-    Condition: CreateSSMRole
     Type: AWS::EKS::AccessEntry
     Properties:
       ClusterName: !Ref clusterName
@@ -84,7 +68,6 @@ Resources:
 
 
   TrustAnchor:
-    Condition: CreateIRAResource
     Type: AWS::RolesAnywhere::TrustAnchor
     Properties:
       Enabled: true
@@ -95,7 +78,6 @@ Resources:
           X509CertificateData: !Ref caBundleCert
   
   AnywhereProfile:
-    Condition: CreateIRAResource
     Type: AWS::RolesAnywhere::Profile
     Properties:
       Enabled: true
@@ -107,7 +89,6 @@ Resources:
       - IRARole
 
   IRARole:
-    Condition: CreateIRAResource
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Sub '${AWS::StackName}-ira'
@@ -150,7 +131,6 @@ Resources:
     - TrustAnchor
   
   IRAClusterAccessEntry:
-    Condition: CreateIRAResource
     Type: AWS::EKS::AccessEntry
     Properties:
       ClusterName: !Ref clusterName
@@ -179,31 +159,25 @@ Outputs:
     Value: !Ref EC2Role
 
   SSMNodeRoleName:
-    Condition: CreateSSMRole
     Description: The name of the IAM Role for SSM.
     Value: !Ref SSMRole
 
   SSMNodeRoleARN:
-    Condition: CreateSSMRole
     Description: The ARN of the IAM Role for SSM.
     Value: !GetAtt SSMRole.Arn
   
   IRANodeRoleName:
-    Condition: CreateIRAResource
     Description: IAM Role for IAM Roles Anywhere
     Value: !Ref IRARole
   
   IRANodeRoleARN:
-    Condition: CreateIRAResource
     Description: ARN of the EKS Hybrid IRA Role
     Value: !GetAtt IRARole.Arn
 
   IRATrustAnchorARN:
-    Condition: CreateIRAResource
     Description: ARN of the EKS Hybrid IRA Trust Anchor
     Value: !GetAtt TrustAnchor.TrustAnchorArn
 
   IRAProfileARN:
-    Condition: CreateIRAResource
     Description: ARN of the EKS Hybrid IRA Profile
     Value: !GetAtt AnywhereProfile.ProfileArn

--- a/test/e2e/nodeadm_test.go
+++ b/test/e2e/nodeadm_test.go
@@ -160,20 +160,13 @@ var _ = SynchronizedBeforeSuite(
 		cluster, err := getHybridClusterDetails(ctx, eksClient, ec2Client, config.ClusterName, config.ClusterRegion, config.HybridVpcID)
 		Expect(err).NotTo(HaveOccurred(), "expected to get cluster details")
 
-		providerFilter := enabledCredentialsProviders(credentialProviders)
-		// if there is no credential provider filter provided, then create resources for all the credential providers
-		if len(providerFilter) == 0 {
-			providerFilter = credentialProviders
-		}
-
 		rolesAnywhereCA, err := createCA()
 		Expect(err).NotTo(HaveOccurred())
 
-		stackName := fmt.Sprintf("EKSHybridCI-%s-%s", removeSpecialChars(config.ClusterName), getCredentialProviderNames(providerFilter))
+		stackName := fmt.Sprintf("EKSHybridCI-%s", removeSpecialChars(config.ClusterName))
 		stack := &e2eCfnStack{
 			clusterName:            cluster.clusterName,
 			clusterArn:             cluster.clusterArn,
-			credentialProviders:    providerFilter,
 			stackName:              GetTruncatedName(stackName, 60),
 			iamRolesAnywhereCACert: rolesAnywhereCA.CertPEM,
 			cfn:                    cfnClient,

--- a/test/e2e/stack.go
+++ b/test/e2e/stack.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -24,7 +23,6 @@ var cfnTemplateBody []byte
 type e2eCfnStack struct {
 	clusterName            string
 	stackName              string
-	credentialProviders    []NodeadmCredentialsProvider
 	clusterArn             string
 	cfn                    *cloudformation.CloudFormation
 	iam                    *iam.IAM
@@ -90,14 +88,6 @@ func (e *e2eCfnStack) deployStack(ctx context.Context, logger logr.Logger) error
 			ParameterKey:   aws.String("caBundleCert"),
 			ParameterValue: aws.String(string(e.iamRolesAnywhereCACert)),
 		},
-	}
-
-	for _, credProvider := range e.credentialProviders {
-		params = append(params, &cloudformation.Parameter{
-			// assume that the name of the param is the same as the name of the provider minus the dashes
-			ParameterKey:   aws.String(strings.ReplaceAll(string(credProvider.Name()), "-", "")),
-			ParameterValue: aws.String("true"),
-		})
 	}
 
 	if len(resp.Stacks) == 0 {


### PR DESCRIPTION
*Description of changes:*
Create both the providers resources all the time for e2e tests.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

