### PR TITLE
removes container pin on ubuntu and calico apiserver

### DIFF
--- a/test/e2e/testdata/calico/calico-template.yaml
+++ b/test/e2e/testdata/calico/calico-template.yaml
@@ -1,14 +1,6 @@
 ---
 # Source: tigera-operator/templates/crs/custom-resources.yaml
 apiVersion: operator.tigera.io/v1
-kind: APIServer
-metadata:
-  name: default
-spec:
-  {}
----
-# Source: tigera-operator/templates/crs/custom-resources.yaml
-apiVersion: operator.tigera.io/v1
 kind: Installation
 metadata:
   name: default

--- a/test/e2e/testdata/ubuntu/2404/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2404/cloud-init.txt
@@ -6,8 +6,6 @@ users:
     hashed_passwd: {{ .RootPasswordHash }}
 {{- end }}
 package_update: true
-packages:
-  - [containerd,1.7.12-0ubuntu4]
 write_files:
   - content: |
       #include <tunables/global>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- The incompat version of container for ubuntu 2404 was reverted upstream.
- Removing the apiserver in the calico template since we arent using that in our test env yet.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

