### PR TITLE
Increase default timeout to 20 minutes

### DIFF
--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -17,7 +17,7 @@ import (
 
 func NewCommand() cli.Command {
 	cmd := command{
-		timeout: 5 * time.Minute,
+		timeout: 20 * time.Minute,
 	}
 
 	fc := flaggy.NewSubcommand("install")

--- a/cmd/nodeadm/upgrade/upgrade.go
+++ b/cmd/nodeadm/upgrade/upgrade.go
@@ -31,7 +31,7 @@ const (
 
 func NewUpgradeCommand() cli.Command {
 	cmd := command{
-		timeout: 10 * time.Minute,
+		timeout: 20 * time.Minute,
 	}
 
 	fc := flaggy.NewSubcommand("upgrade")

--- a/internal/artifact/package.go
+++ b/internal/artifact/package.go
@@ -27,6 +27,11 @@ type Cmd struct {
 	Args []string
 }
 
+// Command returns a new exec.Cmd.
+func (c Cmd) Command(ctx context.Context) *exec.Cmd {
+	return exec.CommandContext(ctx, c.Path, c.Args...)
+}
+
 // NewCmd returns a new Cmd.
 func NewCmd(path string, args ...string) Cmd {
 	return Cmd{
@@ -43,9 +48,9 @@ func NewPackageSource(installCmd, uninstallCmd Cmd) Package {
 }
 
 func (ps *packageSource) InstallCmd(ctx context.Context) *exec.Cmd {
-	return exec.CommandContext(ctx, ps.installCmd.Path, ps.installCmd.Args...)
+	return ps.installCmd.Command(ctx)
 }
 
 func (ps *packageSource) UninstallCmd(ctx context.Context) *exec.Cmd {
-	return exec.CommandContext(ctx, ps.uninstallCmd.Path, ps.uninstallCmd.Args...)
+	return ps.uninstallCmd.Command(ctx)
 }

--- a/internal/containerd/install.go
+++ b/internal/containerd/install.go
@@ -40,8 +40,6 @@ func Install(ctx context.Context, tracker *tracker.Tracker, source Source, conta
 		// Sometimes install fails due to conflicts with other processes
 		// updating packages, specially when automating at machine startup.
 		// We assume errors are transient and just retry for a bit.
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-		defer cancel()
 		if err := artifact.InstallPackageWithRetries(ctx, containerd, 5*time.Second); err != nil {
 			return errors.Wrap(err, "failed to install containerd")
 		}

--- a/internal/iptables/iptables.go
+++ b/internal/iptables/iptables.go
@@ -25,8 +25,6 @@ func Install(ctx context.Context, tracker *tracker.Tracker, source Source) error
 		// Sometimes install fails due to conflicts with other processes
 		// updating packages, specially when automating at machine startup.
 		// We assume errors are transient and just retry for a bit.
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-		defer cancel()
 		if err := artifact.InstallPackageWithRetries(ctx, iptablesSrc, 5*time.Second); err != nil {
 			return errors.Wrap(err, "failed to install iptables")
 		}


### PR DESCRIPTION
*Description of changes:*
In addition, make package manager install command respect the global context deadline instead of a hardcoded 5 minutes for each. This was the user can leverage the timeout flag to influence all timeouts through the main top level context.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

