### PR TITLE
Retry ssm systemd restart

### DIFF
--- a/internal/daemon/retry.go
+++ b/internal/daemon/retry.go
@@ -1,0 +1,27 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// RetryOperation retries an asynchronous operation until it succeeds or the context is cancelled.
+// The backoff duration is the time to wait between retries.
+// Each retry will wait for the operation to complete before retrying.
+func RetryOperation(ctx context.Context, op AsyncOperation, name string, backoff time.Duration, opts ...OperationOption) error {
+	retries := 0
+	var err error
+	for {
+		err = WaitForOperation(ctx, op, name, opts...)
+		if err == nil {
+			return nil
+		}
+		retries++
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("operation didn't succeed after %d retries: %w", retries, err)
+		case <-time.After(backoff):
+		}
+	}
+}


### PR DESCRIPTION
*Description of changes:*
When the restart operation fails, it is usually because there are many operations running running for the same service and we get rate limited. This specially likely to happen when running it during a machine startup. That's why we use a big backoff time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

