### PR TITLE
Fix flaky test

### DIFF
--- a/internal/ssm/credentials_test.go
+++ b/internal/ssm/credentials_test.go
@@ -34,7 +34,7 @@ func TestWaitForAWSConfigSuccess(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	config, err := ssm.WaitForAWSConfig(ctx, node, 1*time.Millisecond)


### PR DESCRIPTION
*Description of changes:*
Use a less aggressive timeout to allow for slower disk writes. There is no benefit in a shorter timeout, it doesn't make the test faster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

