### PR TITLE
improves log collecting in e2e

### DIFF
--- a/hack/e2e-cleanup.sh
+++ b/hack/e2e-cleanup.sh
@@ -224,7 +224,7 @@ else
         if older_than_one_day "$(echo $describe | jq -r ".createdAt")"; then
             if [ "true" == $(echo $describe | jq ".tags | has(\"$TEST_CLUSTER_TAG_KEY\")") ]; then
                 delete_cluster $eks_cluster
-                CLUSTER_STATUSES[$CLUSTER_NAME]="DELETING"
+                CLUSTER_STATUSES[$eks_cluster]="DELETING"
             fi
         fi
     done

--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -260,7 +260,7 @@ func runNodeadmUninstall(ctx context.Context, client *ssm.SSM, instanceID string
 	commands := []string{
 		// TODO: @pjshah run uninstall without node-validation and pod-validation flags after adding cordon and drain node functionality
 		"set -eux",
-		"trap \"/tmp/log-collector.sh 'post-uninstall'\" EXIT",
+		"trap \"/tmp/log-collector.sh 'post-uninstall' 'post-final-uninstall'\" EXIT",
 		"sudo /tmp/nodeadm uninstall -skip node-validation,pod-validation",
 		"sudo cloud-init clean --logs",
 		"sudo rm -rf /var/lib/cloud/instances",

--- a/test/e2e/nodeadm_test.go
+++ b/test/e2e/nodeadm_test.go
@@ -349,7 +349,7 @@ var _ = Describe("Hybrid Nodes", func() {
 							var logsUploadUrls []LogsUploadUrl
 							if suite.TestConfig.LogsBucket != "" {
 								logsS3Prefix := fmt.Sprintf("logs/%s/%s", test.cluster.clusterName, instanceName)
-								for _, name := range []string{"post-install", "post-uninstall", "post-uninstall-install"} {
+								for _, name := range []string{"post-install", "post-uninstall", "post-uninstall-install", "post-final-uninstall"} {
 									url, err := generatePutLogsPreSignedURL(test.s3Client, suite.TestConfig.LogsBucket, fmt.Sprintf("%s/%s.tar.gz", logsS3Prefix, name), 30*time.Minute)
 									logsUploadUrls = append(logsUploadUrls, LogsUploadUrl{Name: name, Url: url})
 									Expect(err).NotTo(HaveOccurred(), "expected to successfully sign logs upload path")

--- a/test/e2e/testdata/log-collector.sh
+++ b/test/e2e/testdata/log-collector.sh
@@ -5,6 +5,7 @@ set -o nounset
 set -o pipefail
 
 LOGS_UPLOAD_NAME="$1"
+FAILBACK_UPLOAD_NAME="$2"
 
 declare -A LOGS_UPLOAD_URLS=()
 {{ range $url := .LogsUploadUrls }}
@@ -21,11 +22,13 @@ LOG_SCRIPT_URL="https://raw.githubusercontent.com/jaxesn/amazon-eks-ami/refs/hea
 curl -s --retry 5  $LOG_SCRIPT_URL -o /tmp/eks-log-collector.sh
 
 bash /tmp/eks-log-collector.sh
-# do not overwrite if the file is already there
-# s3 will return a 412 PreconditionFailed if the file already exists
-HTTP_CODE=$(curl --header 'If-None-Match: *' -w "%{http_code}" -s -o /dev/null --retry 5 --request PUT --upload-file /var/log/eks_* "${LOGS_UPLOAD_URLS[$LOGS_UPLOAD_NAME]}" )
-rm /var/log/eks_*
 
-if [[ ${HTTP_CODE} -lt 200 || ${HTTP_CODE} -gt 299 ]] ; then
-    exit 1
+if ls /var/log/eks_* > /dev/null 2>&1; then
+    # do not overwrite if the file is already there
+    # s3 will return a 412 PreconditionFailed if the file already exists
+    HTTP_CODE=$(curl --header 'If-None-Match: *' -w "%{http_code}" -s -o /dev/null --retry 5 --request PUT --upload-file /var/log/eks_* "${LOGS_UPLOAD_URLS[$LOGS_UPLOAD_NAME]}")
+    if [[ ${HTTP_CODE} -eq 412 ]] && [ -n "${FAILBACK_UPLOAD_NAME}" ] ; then
+        curl --retry 5 --request PUT --upload-file /var/log/eks_* "${LOGS_UPLOAD_URLS[$FAILBACK_UPLOAD_NAME]}"
+    fi
+    rm /var/log/eks_*
 fi

--- a/test/e2e/testdata/nodeadm-init.sh
+++ b/test/e2e/testdata/nodeadm-init.sh
@@ -14,15 +14,14 @@ function gather_logs(){
     # Arbitrary wait to give enough time for logs to populated with potential errors
     # if the node successfully joins and reboots in this, we wont get the logs
     sleep 15
-    if ! /tmp/log-collector.sh "post-install"; then
-        /tmp/log-collector.sh "post-uninstall-install"
-    fi
+    /tmp/log-collector.sh "post-install" "post-uninstall-install"
 }
 
 trap "gather_logs" EXIT
 
 echo "Downloading nodeadm binary"
-curl -s --retry 5 -L "$NODEADM_URL" -o /tmp/nodeadm
+for i in {1..5}; do curl --fail -s --retry 5 -L "$NODEADM_URL" -o /tmp/nodeadm && break || sleep 5; done
+
 chmod +x /tmp/nodeadm
 
 echo "Installing kubernetes components"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This changes the log collecting script to handle the fallback upload directly and only try if its the 412 error code.  This also avoids the scrip returning an exit code other 0 and failing the test.

I also ran into a case where init failed to download nodeadm so add the `--fail` to the curl call and a while retry to try up to 5 times for things like 404.  The curl `--retry` only retries network errors.

I had updated the cleanup script with a typo in the cluster name variable name, fixed here.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

