### PR TITLE
improves pm update and adds ubuntu docker source tests

### DIFF
--- a/hack/SKIPPED_TESTS.yaml
+++ b/hack/SKIPPED_TESTS.yaml
@@ -3,3 +3,6 @@ skipped_tests:
   - "rhel8-amd64.*iam-ra"
   - "ubuntu2004-arm64.*iam-ra"
   - "rhel8-arm64.*iam-ra"
+  - "ubuntu2004-amd64-docker.*"
+  - "ubuntu2204-amd64-docker.*"
+  - "ubuntu2404-amd64-docker.*"

--- a/test/e2e/nodeadm_test.go
+++ b/test/e2e/nodeadm_test.go
@@ -216,10 +216,13 @@ var _ = Describe("Hybrid Nodes", func() {
 	osList := []NodeadmOS{
 		NewUbuntu2004AMD(),
 		NewUbuntu2004ARM(),
+		NewUbuntu2004DockerSource(),
 		NewUbuntu2204AMD(),
 		NewUbuntu2204ARM(),
+		NewUbuntu2204DockerSource(),
 		NewUbuntu2404AMD(),
 		NewUbuntu2404ARM(),
+		NewUbuntu2404DockerSource(),
 		NewAmazonLinux2023AMD(),
 		NewAmazonLinux2023ARM(),
 		NewRedHat8AMD(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),

--- a/test/e2e/testdata/ubuntu/2004/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2004/cloud-init.txt
@@ -20,6 +20,6 @@ write_files:
 {{- end }}
 
 runcmd:
-  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}"
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .NodeadmAdditionalArgs }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/testdata/ubuntu/2204/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2204/cloud-init.txt
@@ -20,6 +20,6 @@ write_files:
 {{- end }}
 
 runcmd:
-  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}"
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .NodeadmAdditionalArgs }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/testdata/ubuntu/2404/cloud-init.txt
+++ b/test/e2e/testdata/ubuntu/2404/cloud-init.txt
@@ -68,6 +68,6 @@ write_files:
 
 runcmd:
   - systemctl restart apparmor.service
-  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}"
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .NodeadmAdditionalArgs }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/ubuntu.go
+++ b/test/e2e/ubuntu.go
@@ -31,8 +31,9 @@ var logCollectorScript []byte
 
 type ubuntuCloudInitData struct {
 	UserDataInput
-	NodeadmUrl        string
-	NodeadmInitScript string
+	NodeadmUrl            string
+	NodeadmInitScript     string
+	NodeadmAdditionalArgs string
 }
 
 func templateFuncMap() map[string]interface{} {
@@ -45,23 +46,37 @@ func templateFuncMap() map[string]interface{} {
 }
 
 type Ubuntu2004 struct {
-	Architecture string
+	Architecture     string
+	ContainerdSource string
 }
 
 func NewUbuntu2004AMD() *Ubuntu2004 {
 	u := new(Ubuntu2004)
 	u.Architecture = "amd64"
+	u.ContainerdSource = "distro"
+	return u
+}
+
+func NewUbuntu2004DockerSource() *Ubuntu2004 {
+	u := new(Ubuntu2004)
+	u.Architecture = "amd64"
+	u.ContainerdSource = "docker"
 	return u
 }
 
 func NewUbuntu2004ARM() *Ubuntu2004 {
 	u := new(Ubuntu2004)
 	u.Architecture = arm64Arch
+	u.ContainerdSource = "distro"
 	return u
 }
 
 func (u Ubuntu2004) Name() string {
-	return "ubuntu2004-" + u.Architecture
+	name := "ubuntu2004-" + u.Architecture
+	if u.ContainerdSource == "docker" {
+		name += "-docker"
+	}
+	return name
 }
 
 func (u Ubuntu2004) InstanceType() string {
@@ -90,27 +105,44 @@ func (u Ubuntu2004) BuildUserData(userDataInput UserDataInput) ([]byte, error) {
 		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
 	}
 
+	if u.ContainerdSource == "docker" {
+		data.NodeadmAdditionalArgs = "--containerd-source docker"
+	}
+
 	return executeTemplate(ubuntu2004CloudInit, data)
 }
 
 type Ubuntu2204 struct {
-	Architecture string
+	Architecture     string
+	ContainerdSource string
 }
 
 func NewUbuntu2204AMD() *Ubuntu2204 {
 	u := new(Ubuntu2204)
 	u.Architecture = "amd64"
+	u.ContainerdSource = "distro"
+	return u
+}
+func NewUbuntu2204DockerSource() *Ubuntu2204 {
+	u := new(Ubuntu2204)
+	u.Architecture = "amd64"
+	u.ContainerdSource = "docker"
 	return u
 }
 
 func NewUbuntu2204ARM() *Ubuntu2204 {
 	u := new(Ubuntu2204)
 	u.Architecture = arm64Arch
+	u.ContainerdSource = "distro"
 	return u
 }
 
 func (u Ubuntu2204) Name() string {
-	return "ubuntu2204-" + u.Architecture
+	name := "ubuntu2204-" + u.Architecture
+	if u.ContainerdSource == "docker" {
+		name += "-docker"
+	}
+	return name
 }
 
 func (u Ubuntu2204) InstanceType() string {
@@ -139,27 +171,45 @@ func (u Ubuntu2204) BuildUserData(userDataInput UserDataInput) ([]byte, error) {
 		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
 	}
 
+	if u.ContainerdSource == "docker" {
+		data.NodeadmAdditionalArgs = "--containerd-source docker"
+	}
+
 	return executeTemplate(ubuntu2204CloudInit, data)
 }
 
 type Ubuntu2404 struct {
-	Architecture string
+	Architecture     string
+	ContainerdSource string
 }
 
 func NewUbuntu2404AMD() *Ubuntu2404 {
 	u := new(Ubuntu2404)
 	u.Architecture = "amd64"
+	u.ContainerdSource = "distro"
+	return u
+}
+
+func NewUbuntu2404DockerSource() *Ubuntu2404 {
+	u := new(Ubuntu2404)
+	u.Architecture = "amd64"
+	u.ContainerdSource = "docker"
 	return u
 }
 
 func NewUbuntu2404ARM() *Ubuntu2404 {
 	u := new(Ubuntu2404)
 	u.Architecture = arm64Arch
+	u.ContainerdSource = "distro"
 	return u
 }
 
 func (u Ubuntu2404) Name() string {
-	return "ubuntu2404-" + u.Architecture
+	name := "ubuntu2404-" + u.Architecture
+	if u.ContainerdSource == "docker" {
+		name += "-docker"
+	}
+	return name
 }
 
 func (u Ubuntu2404) InstanceType() string {
@@ -186,6 +236,10 @@ func (u Ubuntu2404) BuildUserData(userDataInput UserDataInput) ([]byte, error) {
 
 	if u.Architecture == arm64Arch {
 		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
+	}
+
+	if u.ContainerdSource == "docker" {
+		data.NodeadmAdditionalArgs = "--containerd-source docker"
 	}
 
 	return executeTemplate(ubuntu2404CloudInit, data)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This standardizes, a bit, our yum and apt update usage. 
- Removes the `yum update` when installing containerd from the docker repos for rhel instances
- Changes the `apt update` to specifically target the docker repos added, if the user has requested them to used
- Adds ubuntu tests using the upstream docker containerd repos
- Wraps the apt update in retries using the new util.

We should still discuss if we should at least run `apt update` always to make sure the repo metadata is updated.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

