### PR TITLE
Make retry cmd command info level

### DIFF
--- a/internal/util/cmd/retry.go
+++ b/internal/util/cmd/retry.go
@@ -27,7 +27,7 @@ func Retry(ctx context.Context, newCmd Builder, backoff time.Duration) error {
 			return nil
 		}
 		err = fmt.Errorf("running command %s: %s [Err %s]", cmd.Args, out, err)
-		log.Debug("Command failed, retrying", zap.Duration("backoff", backoff), zap.Error(err))
+		log.Info("Command failed, retrying", zap.Duration("backoff", backoff), zap.Error(err))
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("%s: %w", ctx.Err(), err)


### PR DESCRIPTION
*Description of changes:*
Debug can be annoying when the error is not retryable, since but default it won't print, so for commands like install or upgrade, they user has to sit for 20 minutes until it times out. Instead, let's print the error on each retry by default, so the user can abort if the error needs manual intervention. In the future, we can try to catch non retryable errors and just abort.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

