### PR TITLE
Support HTTPS nodeadm URLs in E2E script

### DIFF
--- a/test/e2e/rhel.go
+++ b/test/e2e/rhel.go
@@ -41,7 +41,7 @@ const (
 	rhelSsmAgentARM = "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm"
 )
 
-func NewRedHat8AMD(rhelUsername string, rhelPassword string) *RedHat8 {
+func NewRedHat8AMD(rhelUsername, rhelPassword string) *RedHat8 {
 	rh8 := new(RedHat8)
 	rh8.RhelUsername = rhelUsername
 	rh8.RhelPassword = rhelPassword
@@ -49,7 +49,7 @@ func NewRedHat8AMD(rhelUsername string, rhelPassword string) *RedHat8 {
 	return rh8
 }
 
-func NewRedHat8ARM(rhelUsername string, rhelPassword string) *RedHat8 {
+func NewRedHat8ARM(rhelUsername, rhelPassword string) *RedHat8 {
 	rh8 := new(RedHat8)
 	rh8.RhelUsername = rhelUsername
 	rh8.RhelPassword = rhelPassword
@@ -102,7 +102,7 @@ type RedHat9 struct {
 	Architecture string
 }
 
-func NewRedHat9AMD(rhelUsername string, rhelPassword string) *RedHat9 {
+func NewRedHat9AMD(rhelUsername, rhelPassword string) *RedHat9 {
 	rh9 := new(RedHat9)
 	rh9.RhelUsername = rhelUsername
 	rh9.RhelPassword = rhelPassword
@@ -110,7 +110,7 @@ func NewRedHat9AMD(rhelUsername string, rhelPassword string) *RedHat9 {
 	return rh9
 }
 
-func NewRedHat9ARM(rhelUsername string, rhelPassword string) *RedHat9 {
+func NewRedHat9ARM(rhelUsername, rhelPassword string) *RedHat9 {
 	rh9 := new(RedHat9)
 	rh9.RhelUsername = rhelUsername
 	rh9.RhelPassword = rhelPassword
@@ -166,7 +166,7 @@ type AMI struct {
 }
 
 // findLatestImage returns the most recent redhat image matching the amiPrefix and and arch
-func findLatestImage(client *ec2.EC2, amiPrefix string, arch string) (string, error) {
+func findLatestImage(client *ec2.EC2, amiPrefix, arch string) (string, error) {
 	var latestAMI AMI
 
 	in := &ec2.DescribeImagesInput{

--- a/test/e2e/ssm.go
+++ b/test/e2e/ssm.go
@@ -17,7 +17,7 @@ import (
 	"github.com/go-logr/logr"
 )
 
-func createSSMActivation(ctx context.Context, client *ssmv2.Client, iamRole string, ssmActivationName string, clusterName string) (*ssmv2.CreateActivationOutput, error) {
+func createSSMActivation(ctx context.Context, client *ssmv2.Client, iamRole, ssmActivationName, clusterName string) (*ssmv2.CreateActivationOutput, error) {
 	// Define the input for the CreateActivation API
 	input := &ssmv2.CreateActivationInput{
 		IamRole:             aws.String(iamRole),
@@ -36,7 +36,6 @@ func createSSMActivation(ctx context.Context, client *ssmv2.Client, iamRole stri
 		o.RetryMaxAttempts = 20
 		o.RetryMode = awsv2.RetryModeAdaptive
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("creating SSM activation: %v", err)
 	}

--- a/test/e2e/ubuntu.go
+++ b/test/e2e/ubuntu.go
@@ -123,6 +123,7 @@ func NewUbuntu2204AMD() *Ubuntu2204 {
 	u.ContainerdSource = "distro"
 	return u
 }
+
 func NewUbuntu2204DockerSource() *Ubuntu2204 {
 	u := new(Ubuntu2204)
 	u.Architecture = "amd64"

--- a/test/e2e/vpc.go
+++ b/test/e2e/vpc.go
@@ -132,7 +132,7 @@ func createVPC(client *ec2.EC2, vpcParam vpcSubnetParams) (string, error) {
 	return vpcId, nil
 }
 
-func createSubnet(client *ec2.EC2, vpcID, subnetCidr, az, tagName string, clusterName string) (subnetID string, err error) {
+func createSubnet(client *ec2.EC2, vpcID, subnetCidr, az, tagName, clusterName string) (subnetID string, err error) {
 	subnet, err := client.CreateSubnet(&ec2.CreateSubnetInput{
 		VpcId:            aws.String(vpcID),
 		CidrBlock:        aws.String(subnetCidr),
@@ -163,7 +163,7 @@ func createSubnet(client *ec2.EC2, vpcID, subnetCidr, az, tagName string, cluste
 	return subnetId, nil
 }
 
-func createInternetGateway(client *ec2.EC2, vpcId string, clusterName string) (string, error) {
+func createInternetGateway(client *ec2.EC2, vpcId, clusterName string) (string, error) {
 	igwOutput, err := client.CreateInternetGateway(&ec2.CreateInternetGatewayInput{
 		TagSpecifications: []*ec2.TagSpecification{
 			{
@@ -303,7 +303,6 @@ func (t *TestRunner) createVPCPeering(ctx context.Context) (string, error) {
 		o.RetryMaxAttempts = 20
 		o.RetryMode = awsv2.RetryModeAdaptive
 	})
-
 	if err != nil {
 		return "", fmt.Errorf("failed to create VPC peering connection: %v", err)
 	}


### PR DESCRIPTION
Support HTTPS nodeadm URLs in E2E script. If an HTTPS URL is passed in, the URL is just used as is, otherwise if an S3 path is passed in as input, a pre-signed URL is generated using the S3 URL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

