### PR TITLE
Run gofumpt and gci on nodeadm codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+run:
+  timeout: 5m
+  skip-files:
+    - "zz_generated.*\\.go$"
+linters:
+  enable:
+    - gofumpt
+    - gci
+linters-settings:
+  gofumpt:
+    extra-rules: true
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/aws/eks-hybrid)
+    custom-order: true
+    skip-generated: false

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -4,9 +4,10 @@
 package v1alpha1
 
 import (
-	"github.com/aws/eks-hybrid/api"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	"github.com/aws/eks-hybrid/api"
 )
 
 var (

--- a/cmd/nodeadm/debug/debug.go
+++ b/cmd/nodeadm/debug/debug.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/smithy-go/logging"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/aws/sts"
 	"github.com/aws/eks-hybrid/internal/cli"
@@ -19,7 +20,6 @@ import (
 	"github.com/aws/eks-hybrid/internal/logger"
 	"github.com/aws/eks-hybrid/internal/node"
 	"github.com/aws/eks-hybrid/internal/validation"
-	"github.com/aws/smithy-go/logging"
 )
 
 func NewCommand() cli.Command {

--- a/cmd/nodeadm/init/init.go
+++ b/cmd/nodeadm/init/init.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"os"
 
+	"github.com/integrii/flaggy"
+	"go.uber.org/zap"
+	"k8s.io/utils/strings/slices"
+
 	"github.com/aws/eks-hybrid/internal/cli"
 	"github.com/aws/eks-hybrid/internal/flows"
 	"github.com/aws/eks-hybrid/internal/logger"
 	"github.com/aws/eks-hybrid/internal/node"
 	"github.com/aws/eks-hybrid/internal/tracker"
-
-	"github.com/integrii/flaggy"
-	"go.uber.org/zap"
-	"k8s.io/utils/strings/slices"
 )
 
 const installValidation = "install-validation"

--- a/internal/api/bridge/decode.go
+++ b/internal/api/bridge/decode.go
@@ -3,12 +3,12 @@ package bridge
 import (
 	"fmt"
 
-	"github.com/aws/eks-hybrid/api"
-	internalapi "github.com/aws/eks-hybrid/internal/api"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-hybrid/api"
+	internalapi "github.com/aws/eks-hybrid/internal/api"
 )
 
 // DecodeNodeConfig unmarshals the given data into an internal NodeConfig object.

--- a/internal/api/bridge/scheme.go
+++ b/internal/api/bridge/scheme.go
@@ -1,18 +1,17 @@
 package bridge
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/aws/eks-hybrid/api"
 	"github.com/aws/eks-hybrid/api/v1alpha1"
 	internalapi "github.com/aws/eks-hybrid/internal/api"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var (
-	localSchemeBuilder = runtime.NewSchemeBuilder(
-		v1alpha1.AddToScheme,
-		addInternalTypes,
-	)
+var localSchemeBuilder = runtime.NewSchemeBuilder(
+	v1alpha1.AddToScheme,
+	addInternalTypes,
 )
 
 func addInternalTypes(scheme *runtime.Scheme) error {

--- a/internal/api/merge.go
+++ b/internal/api/merge.go
@@ -5,8 +5,9 @@ import (
 	"reflect"
 
 	"dario.cat/mergo"
-	"github.com/aws/eks-hybrid/internal/util"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/aws/eks-hybrid/internal/util"
 )
 
 // Merges two NodeConfigs with custom collision handling
@@ -79,7 +80,7 @@ func (k kubeletTransformer) transformConfig(dst, src reflect.Value) error {
 }
 
 func toInlineDocument(m map[string]interface{}) (InlineDocument, error) {
-	var rawMap = make(InlineDocument)
+	rawMap := make(InlineDocument)
 	for key, value := range m {
 		rawBytes, err := json.Marshal(value)
 		if err != nil {

--- a/internal/api/merge_test.go
+++ b/internal/api/merge_test.go
@@ -14,7 +14,7 @@ func toInlineDocumentMust(m map[string]interface{}) InlineDocument {
 }
 
 func TestMerge(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name         string
 		baseSpec     NodeConfigSpec
 		patchSpec    NodeConfigSpec

--- a/internal/api/status.go
+++ b/internal/api/status.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go/aws"
+
 	ec2extra "github.com/aws/eks-hybrid/internal/aws/ec2"
 )
 

--- a/internal/artifact/install.go
+++ b/internal/artifact/install.go
@@ -38,7 +38,7 @@ func InstallFile(dst string, src io.Reader, perms fs.FileMode) error {
 }
 
 // InstallTarGz untars the src file into the dst directory and deletes the src tgz file
-func InstallTarGz(dst string, src string) error {
+func InstallTarGz(dst, src string) error {
 	if err := os.MkdirAll(dst, DefaultDirPerms); err != nil {
 		return err
 	}

--- a/internal/aws/ec2/instance_waiter.go
+++ b/internal/aws/ec2/instance_waiter.go
@@ -17,7 +17,6 @@ type InstanceCondition func(output *ec2.DescribeInstancesOutput) (bool, error)
 
 // InstanceConditionWaiterOptions are options for InstanceConditionWaiter
 type InstanceConditionWaiterOptions struct {
-
 	// Set of options to modify how an operation is invoked. These apply to all
 	// operations invoked for this client. Use functional options on operation call to
 	// modify this list for per operation behavior.

--- a/internal/aws/ecr/ecr.go
+++ b/internal/aws/ecr/ecr.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
+
 	"github.com/aws/eks-hybrid/internal/aws/imds"
 	"github.com/aws/eks-hybrid/internal/system"
 )
@@ -65,11 +66,11 @@ func (r *ECRRegistry) String() string {
 	return string(*r)
 }
 
-func (r *ECRRegistry) GetImageReference(repository string, tag string) string {
+func (r *ECRRegistry) GetImageReference(repository, tag string) string {
 	return fmt.Sprintf("%s/%s:%s", r.String(), repository, tag)
 }
 
-func getRegistry(accountID string, ecrSubdomain string, region string, servicesDomain string) string {
+func getRegistry(accountID, ecrSubdomain, region, servicesDomain string) string {
 	return fmt.Sprintf("%s.dkr.%s.%s.%s", accountID, ecrSubdomain, region, servicesDomain)
 }
 

--- a/internal/aws/eks/cluster_test.go
+++ b/internal/aws/eks/cluster_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/base64"
 	"testing"
 
-	. "github.com/onsi/gomega"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	eks_sdk "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	. "github.com/onsi/gomega"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/aws/eks"
 	"github.com/aws/eks-hybrid/internal/test"

--- a/internal/aws/manifest.go
+++ b/internal/aws/manifest.go
@@ -3,10 +3,10 @@ package aws
 import (
 	"context"
 
-	"github.com/aws/eks-hybrid/internal/util"
-
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-hybrid/internal/util"
 )
 
 // set build time

--- a/internal/aws/source.go
+++ b/internal/aws/source.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/eks-hybrid/internal/artifact"
-	"github.com/aws/eks-hybrid/internal/util"
-
 	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
+
+	"github.com/aws/eks-hybrid/internal/artifact"
+	"github.com/aws/eks-hybrid/internal/util"
 )
 
 // Source defines a single version source for aws provided artifacts

--- a/internal/aws/sts/validate.go
+++ b/internal/aws/sts/validate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	sts_sdk "github.com/aws/aws-sdk-go-v2/service/sts"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/network"
 	"github.com/aws/eks-hybrid/internal/validation"

--- a/internal/aws/sts/validate_test.go
+++ b/internal/aws/sts/validate_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/gomega"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/aws/sts"
 	"github.com/aws/eks-hybrid/internal/test"

--- a/internal/cni/install.go
+++ b/internal/cni/install.go
@@ -35,7 +35,7 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 	}
 	defer cniPlugins.Close()
 
-	if err := artifact.InstallFile(TgzPath, cniPlugins, 0755); err != nil {
+	if err := artifact.InstallFile(TgzPath, cniPlugins, 0o755); err != nil {
 		return errors.Wrap(err, "failed to install cni-plugins archive")
 	}
 

--- a/internal/configprovider/userdata.go
+++ b/internal/configprovider/userdata.go
@@ -94,7 +94,7 @@ func parseMultipart(userDataReader *multipart.Reader) (*internalapi.NodeConfig, 
 		}
 	}
 	if len(nodeConfigs) > 0 {
-		var config = nodeConfigs[0]
+		config := nodeConfigs[0]
 		for _, nodeConfig := range nodeConfigs[1:] {
 			if err := config.Merge(nodeConfig); err != nil {
 				return nil, err

--- a/internal/configprovider/userdata_test.go
+++ b/internal/configprovider/userdata_test.go
@@ -9,12 +9,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/eks-hybrid/internal/api"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/aws/eks-hybrid/internal/api"
 )
 
-const boundary = "#"
-const completeNodeConfig = `---
+const (
+	boundary           = "#"
+	completeNodeConfig = `---
 apiVersion: node.eks.aws/v1alpha1
 kind: NodeConfig
 spec:
@@ -31,6 +33,7 @@ spec:
       - --v=2
       - --node-labels=foo=bar,nodegroup=test
 `
+)
 
 const partialNodeConfig = `---
 apiVersion: node.eks.aws/v1alpha1
@@ -84,7 +87,7 @@ func indent(in string) string {
 }
 
 func mimeifyNodeConfigs(configs ...string) string {
-	var mimeDocLines = []string{
+	mimeDocLines := []string{
 		"MIME-Version: 1.0",
 		`Content-Type: multipart/mixed; boundary="#"`,
 	}

--- a/internal/containerd/config.go
+++ b/internal/containerd/config.go
@@ -19,7 +19,7 @@ const (
 	containerdConfigFile              = "/etc/containerd/config.toml"
 	containerdConfigImportDir         = "/etc/containerd/config.d"
 	containerdKernelModulesConfigFile = "/etc/modules-load.d/containerd.conf"
-	containerdConfigPerm              = 0644
+	containerdConfigPerm              = 0o644
 )
 
 var (

--- a/internal/containerd/daemon.go
+++ b/internal/containerd/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/daemon"
 )

--- a/internal/containerd/sandbox.go
+++ b/internal/containerd/sandbox.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/eks-hybrid/internal/aws/ecr"
-	"github.com/aws/eks-hybrid/internal/util"
 	"github.com/containerd/containerd/integration/remote"
 	"go.uber.org/zap"
 	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/aws/eks-hybrid/internal/aws/ecr"
+	"github.com/aws/eks-hybrid/internal/util"
 )
 
 var containerdSandboxImageRegex = regexp.MustCompile(`sandbox_image = "(.*)"`)

--- a/internal/creds/validation.go
+++ b/internal/creds/validation.go
@@ -2,6 +2,7 @@ package creds
 
 import (
 	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/iamrolesanywhere"
 	"github.com/aws/eks-hybrid/internal/ssm"

--- a/internal/daemon/wait_test.go
+++ b/internal/daemon/wait_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/eks-hybrid/internal/daemon"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/daemon"
 )
 
 func TestWaitForStatusSuccess(t *testing.T) {

--- a/internal/flows/uninstall.go
+++ b/internal/flows/uninstall.go
@@ -22,8 +22,10 @@ import (
 
 const eksConfigDir = "/etc/eks"
 
-type SSMUninstall func(ctx context.Context, logger *zap.Logger, pm ssm.PkgSource) error
-type CNIUninstall func() error
+type (
+	SSMUninstall func(ctx context.Context, logger *zap.Logger, pm ssm.PkgSource) error
+	CNIUninstall func() error
+)
 
 type Uninstaller struct {
 	Artifacts      *tracker.InstalledArtifacts

--- a/internal/iamauthenticator/install.go
+++ b/internal/iamauthenticator/install.go
@@ -26,7 +26,7 @@ func Install(ctx context.Context, tracker *tracker.Tracker, iamAuthSrc IAMAuthen
 	}
 	defer authenticator.Close()
 
-	if err := artifact.InstallFile(IAMAuthenticatorBinPath, authenticator, 0755); err != nil {
+	if err := artifact.InstallFile(IAMAuthenticatorBinPath, authenticator, 0o755); err != nil {
 		return fmt.Errorf("failed to install aws-iam-authenticator: %w", err)
 	}
 

--- a/internal/iamrolesanywhere/install.go
+++ b/internal/iamrolesanywhere/install.go
@@ -26,7 +26,7 @@ func Install(ctx context.Context, tracker *tracker.Tracker, signingHelperSrc Sig
 	}
 	defer signingHelper.Close()
 
-	if err := artifact.InstallFile(SigningHelperBinPath, signingHelper, 0755); err != nil {
+	if err := artifact.InstallFile(SigningHelperBinPath, signingHelper, 0o755); err != nil {
 		return errors.Wrap(err, "failed to install aws_signer_helper")
 	}
 	if err = tracker.Add(artifact.IamRolesAnywhere); err != nil {

--- a/internal/iamrolesanywhere/validate.go
+++ b/internal/iamrolesanywhere/validate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/network"
 	"github.com/aws/eks-hybrid/internal/validation"

--- a/internal/iamrolesanywhere/validate_test.go
+++ b/internal/iamrolesanywhere/validate_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/gomega"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/iamrolesanywhere"
 	"github.com/aws/eks-hybrid/internal/test"

--- a/internal/imagecredentialprovider/install.go
+++ b/internal/imagecredentialprovider/install.go
@@ -27,7 +27,7 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 	}
 	defer imageCredentialProvider.Close()
 
-	if err := artifact.InstallFile(BinPath, imageCredentialProvider, 0755); err != nil {
+	if err := artifact.InstallFile(BinPath, imageCredentialProvider, 0o755); err != nil {
 		return errors.Wrap(err, "failed to install image-credential-provider")
 	}
 

--- a/internal/kubectl/install.go
+++ b/internal/kubectl/install.go
@@ -26,7 +26,7 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 	}
 	defer kubectl.Close()
 
-	if err := artifact.InstallFile(BinPath, kubectl, 0755); err != nil {
+	if err := artifact.InstallFile(BinPath, kubectl, 0o755); err != nil {
 		return errors.Wrap(err, "failed to install kubectl")
 	}
 

--- a/internal/kubelet/config.go
+++ b/internal/kubelet/config.go
@@ -17,17 +17,15 @@ import (
 	"time"
 
 	"dario.cat/mergo"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/aws/smithy-go/ptr"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"golang.org/x/mod/semver"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8skubelet "k8s.io/kubelet/config/v1beta1"
 	"sigs.k8s.io/yaml"
-
-	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
-	"github.com/aws/smithy-go/ptr"
 
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/containerd"
@@ -39,7 +37,7 @@ const (
 	kubeletConfigRoot = "/etc/kubernetes/kubelet"
 	kubeletConfigFile = "config.json"
 	kubeletConfigDir  = "config.json.d"
-	kubeletConfigPerm = 0644
+	kubeletConfigPerm = 0o644
 
 	hybridNodeLabel            = "eks.amazonaws.com/compute-type=hybrid"
 	credentialProviderLabelKey = "eks.amazonaws.com/hybrid-credential-provider"

--- a/internal/kubelet/config_test.go
+++ b/internal/kubelet/config_test.go
@@ -3,10 +3,11 @@ package kubelet
 import (
 	"testing"
 
-	"github.com/aws/eks-hybrid/internal/api"
-	"github.com/aws/eks-hybrid/internal/containerd"
 	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/eks-hybrid/internal/api"
+	"github.com/aws/eks-hybrid/internal/containerd"
 )
 
 func TestKubeletCredentialProvidersFeatureFlag(t *testing.T) {

--- a/internal/kubelet/daemon.go
+++ b/internal/kubelet/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/daemon"
 )

--- a/internal/kubelet/eni_max_pods.go
+++ b/internal/kubelet/eni_max_pods.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/aws/eks-hybrid/internal/util"
 	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/util"
 )
 
 // default value from kubelet
@@ -50,7 +51,7 @@ func init() {
 // The behavior should align with AL2, which essentially is:
 //
 //	# of ENI * (# of IPv4 per ENI - 1) + 2
-func CalcMaxPods(awsRegion string, instanceType string) int32 {
+func CalcMaxPods(awsRegion, instanceType string) int32 {
 	zap.L().Info("calculate the max pod for instance type", zap.String("instanceType", instanceType))
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(awsRegion))
 	if err != nil {

--- a/internal/kubelet/environment.go
+++ b/internal/kubelet/environment.go
@@ -35,6 +35,6 @@ func (k *kubelet) writeKubeletEnvironment() error {
 }
 
 // Add values to the environment variables map in a terse manner
-func (k *kubelet) setEnv(envName string, envArg string) {
+func (k *kubelet) setEnv(envName, envArg string) {
 	k.environment[envName] = envArg
 }

--- a/internal/kubelet/image-credential-provider.go
+++ b/internal/kubelet/image-credential-provider.go
@@ -9,10 +9,11 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/aws/eks-hybrid/internal/api"
-	"github.com/aws/eks-hybrid/internal/util"
 	"go.uber.org/zap"
 	"golang.org/x/mod/semver"
+
+	"github.com/aws/eks-hybrid/internal/api"
+	"github.com/aws/eks-hybrid/internal/util"
 )
 
 const (
@@ -20,7 +21,7 @@ const (
 	imageCredentialProviderRoot = "/etc/eks/image-credential-provider"
 	// #nosec G101 //constant path, not credential
 	imageCredentialProviderConfig = "config.json"
-	imageCredentialProviderPerm   = 0644
+	imageCredentialProviderPerm   = 0o644
 	// #nosec G101 //constant path, not credential
 	ecrCredentialProviderBinPathEnvironmentName = "ECR_CREDENTIAL_PROVIDER_BIN_PATH"
 )

--- a/internal/kubelet/install.go
+++ b/internal/kubelet/install.go
@@ -38,7 +38,7 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 	}
 	defer kubelet.Close()
 
-	if err := artifact.InstallFile(BinPath, kubelet, 0755); err != nil {
+	if err := artifact.InstallFile(BinPath, kubelet, 0o755); err != nil {
 		return errors.Wrap(err, "failed to install kubelet")
 	}
 
@@ -51,7 +51,7 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 
 	buf := bytes.NewBuffer(kubeletUnitFile)
 
-	if err := artifact.InstallFile(UnitPath, buf, 0644); err != nil {
+	if err := artifact.InstallFile(UnitPath, buf, 0o644); err != nil {
 		return errors.Errorf("failed to install kubelet systemd unit: %v", err)
 	}
 

--- a/internal/kubernetes/access_test.go
+++ b/internal/kubernetes/access_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/gomega"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/aws/eks"
 	"github.com/aws/eks-hybrid/internal/kubernetes"

--- a/internal/kubernetes/connection_test.go
+++ b/internal/kubernetes/connection_test.go
@@ -5,11 +5,12 @@ import (
 	"net/http"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/kubernetes"
 	"github.com/aws/eks-hybrid/internal/test"
 	"github.com/aws/eks-hybrid/internal/validation"
-	. "github.com/onsi/gomega"
 )
 
 func TestCheckConnectionSuccess(t *testing.T) {

--- a/internal/kubernetes/unauthenticated_test.go
+++ b/internal/kubernetes/unauthenticated_test.go
@@ -14,11 +14,12 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/kubernetes"
 	"github.com/aws/eks-hybrid/internal/test"
 	"github.com/aws/eks-hybrid/internal/validation"
-	. "github.com/onsi/gomega"
 )
 
 type apiServerResponse struct {

--- a/internal/logger/context_test.go
+++ b/internal/logger/context_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/eks-hybrid/internal/logger"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/logger"
 )
 
 func TestFromContext(t *testing.T) {

--- a/internal/network/connection.go
+++ b/internal/network/connection.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/url"
 	"time"
-	
 )
 
 const dialTimeout = 5 * time.Second

--- a/internal/node/ec2/aws.go
+++ b/internal/node/ec2/aws.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-
 	"github.com/aws/aws-sdk-go-v2/config"
 )
 

--- a/internal/node/ec2/ec2node.go
+++ b/internal/node/ec2/ec2node.go
@@ -2,10 +2,11 @@ package ec2
 
 import (
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"go.uber.org/zap"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/nodeprovider"
-	"go.uber.org/zap"
 )
 
 type ec2NodeProvider struct {

--- a/internal/node/hybrid/aws_test.go
+++ b/internal/node/hybrid/aws_test.go
@@ -5,11 +5,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/aws/eks-hybrid/internal/api"
-	"github.com/aws/eks-hybrid/internal/node/hybrid"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-hybrid/internal/api"
+	"github.com/aws/eks-hybrid/internal/node/hybrid"
 )
 
 func TestRolesAnywhereAWSConfigurator_Configure(t *testing.T) {

--- a/internal/node/hybrid/hybrid.go
+++ b/internal/node/hybrid/hybrid.go
@@ -1,9 +1,9 @@
 package hybrid
 
 import (
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.uber.org/zap"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/nodeprovider"

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -1,12 +1,12 @@
 package node
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/aws/eks-hybrid/internal/configprovider"
 	"github.com/aws/eks-hybrid/internal/node/ec2"
 	"github.com/aws/eks-hybrid/internal/node/hybrid"
 	"github.com/aws/eks-hybrid/internal/nodeprovider"
-
-	"go.uber.org/zap"
 )
 
 func NewNodeProvider(configSource string, logger *zap.Logger) (nodeprovider.NodeProvider, error) {

--- a/internal/node/pods.go
+++ b/internal/node/pods.go
@@ -91,7 +91,7 @@ func getPodsOnNode() ([]corev1.Pod, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	clientset, err := kubelet.GetKubeClientFromKubeConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create kubernetes client")

--- a/internal/node/validations.go
+++ b/internal/node/validations.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/eks-hybrid/internal/kubelet"
-
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-hybrid/internal/kubelet"
 )
 
 const defaultStaticPodManifestPath = "/etc/kubernetes/manifest"

--- a/internal/nodeprovider/interface.go
+++ b/internal/nodeprovider/interface.go
@@ -3,13 +3,13 @@ package nodeprovider
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/aws"
 	"github.com/aws/eks-hybrid/internal/configenricher"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/system"
-
-	"go.uber.org/zap"
 )
 
 // NodeProvider is an interface that defines functions that a nodeProvider should implement

--- a/internal/packagemanager/packagemanager.go
+++ b/internal/packagemanager/packagemanager.go
@@ -159,8 +159,8 @@ func (pm *DistroPackageManager) installPackage(ctx context.Context, packageName 
 // updateAllPackages updates all packages and repo metadata on the system
 func (pm *DistroPackageManager) updateDockerAptPackagesCommand(ctx context.Context) *exec.Cmd {
 	return exec.CommandContext(ctx, pm.manager, pm.updateVerb, "-y", "-o", fmt.Sprintf("Dir::Etc::sourcelist=\"%s\"", aptDockerRepoSourceFilePath))
-
 }
+
 func (pm *DistroPackageManager) updateDockerAptPackagesWithRetries(ctx context.Context) error {
 	return cmd.Retry(ctx, pm.updateDockerAptPackagesCommand, 5*time.Second)
 }

--- a/internal/ssm/credentials_test.go
+++ b/internal/ssm/credentials_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/ssm"
-	. "github.com/onsi/gomega"
 )
 
 func TestWaitForAWSConfigSuccess(t *testing.T) {

--- a/internal/ssm/install.go
+++ b/internal/ssm/install.go
@@ -7,11 +7,11 @@ import (
 	"os/exec"
 	"path"
 
+	"github.com/aws/aws-sdk-go-v2/config"
+	awsSsm "github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/aws/aws-sdk-go-v2/config"
-	awsSsm "github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/eks-hybrid/internal/artifact"
 	"github.com/aws/eks-hybrid/internal/tracker"
 )

--- a/internal/ssm/validate.go
+++ b/internal/ssm/validate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ssm_sdk "github.com/aws/aws-sdk-go-v2/service/ssm"
+
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/network"
 	"github.com/aws/eks-hybrid/internal/validation"

--- a/internal/ssm/validate_test.go
+++ b/internal/ssm/validate_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/gomega"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/ssm"
 	"github.com/aws/eks-hybrid/internal/test"

--- a/internal/system/local_disk.go
+++ b/internal/system/local_disk.go
@@ -5,8 +5,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/aws/eks-hybrid/internal/api"
 	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/api"
 )
 
 const localDiskAspectName = "local-disk"

--- a/internal/system/networking.go
+++ b/internal/system/networking.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"github.com/aws/eks-hybrid/internal/api"
-	"github.com/aws/eks-hybrid/internal/util"
-	"go.uber.org/zap"
 	"os"
 	"os/exec"
 	"text/template"
+
+	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/api"
+	"github.com/aws/eks-hybrid/internal/util"
 )
 
 const (
@@ -20,8 +22,8 @@ const (
 	// https://github.com/amazonlinux/amazon-ec2-net-utils/blob/c6626fb5cd094bbfeb62c456fe088011dbab3f95/systemd/network/80-ec2.network
 	ec2NetworkConfigurationName = "80-ec2.network"
 	eksPrimaryENIOnlyConfName   = "10-eks_primary_eni_only.conf"
-	networkConfDropInDirPerms   = 0755
-	networkConfFilePerms        = 0644
+	networkConfDropInDirPerms   = 0o755
+	networkConfFilePerms        = 0o644
 )
 
 var (

--- a/internal/system/networking_test.go
+++ b/internal/system/networking_test.go
@@ -2,9 +2,10 @@ package system
 
 import (
 	_ "embed"
-	"github.com/aws/eks-hybrid/internal/api"
 	"reflect"
 	"testing"
+
+	"github.com/aws/eks-hybrid/internal/api"
 )
 
 //go:embed _assets/test_10-eks_primary_eni_only.conf

--- a/internal/system/resources.go
+++ b/internal/system/resources.go
@@ -34,7 +34,7 @@ type core struct {
 }
 
 func init() {
-	//cannot copy file to /sys for doc build, use this as a hack for testing
+	// cannot copy file to /sys for doc build, use this as a hack for testing
 	cpuDirEnv := os.Getenv("CPU_DIR")
 	if cpuDirEnv != "" {
 		cpusPath = cpuDirEnv
@@ -79,7 +79,6 @@ func GetMilliNumCores() (int, error) {
 
 	}
 	return allLogicalCoresCount * 1000, err
-
 }
 
 func getCPUCount() (int, error) {

--- a/internal/system/swap.go
+++ b/internal/system/swap.go
@@ -10,8 +10,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/aws/eks-hybrid/internal/api"
 	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/api"
 )
 
 const (
@@ -96,7 +97,7 @@ func (s *swapAspect) swapOff() error {
 // <path-to-swap-file>   	     file/partition   524280   0       -1
 func getSwapfilePaths() ([]string, error) {
 	var paths []string
-	file, err := os.OpenFile("/proc/swaps", os.O_RDONLY, 0444)
+	file, err := os.OpenFile("/proc/swaps", os.O_RDONLY, 0o444)
 	if err != nil {
 		return paths, err
 	}
@@ -140,7 +141,7 @@ type mount struct {
 }
 
 func disableSwapOnFstab() error {
-	file, err := os.OpenFile("/etc/fstab", os.O_RDWR, 0644)
+	file, err := os.OpenFile("/etc/fstab", os.O_RDWR, 0o644)
 	if err != nil {
 		return err
 	}

--- a/internal/system/sysctl.go
+++ b/internal/system/sysctl.go
@@ -14,7 +14,7 @@ const (
 	sysctlAspectName      = "sysctl"
 	sysctlConfDir         = "/etc/sysctl.d"
 	nodeadmSysctlConfFile = "99-nodeadm.conf"
-	nodeadmSysctlFilePerm = 0644
+	nodeadmSysctlFilePerm = 0o644
 )
 
 var (
@@ -32,6 +32,7 @@ var _ SystemAspect = &sysctlAspect{}
 func NewSysctlAspect(cfg *api.NodeConfig) SystemAspect {
 	return &sysctlAspect{nodeConfig: cfg}
 }
+
 func (s *sysctlAspect) Name() string {
 	return sysctlAspectName
 }

--- a/internal/tracker/artifacts.go
+++ b/internal/tracker/artifacts.go
@@ -67,7 +67,7 @@ func (tracker *Tracker) Save() error {
 		return err
 	}
 
-	return util.WriteFileWithDir(trackerFile, data, 0644)
+	return util.WriteFileWithDir(trackerFile, data, 0o644)
 }
 
 func Clear() error {

--- a/internal/util/cmd/retry.go
+++ b/internal/util/cmd/retry.go
@@ -6,8 +6,9 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/aws/eks-hybrid/internal/logger"
 	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/logger"
 )
 
 // Builder builds a exec.Cmd. Each invocation should return a new instance

--- a/internal/util/ec2.go
+++ b/internal/util/ec2.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
@@ -28,7 +29,6 @@ func GetEniInfoForInstanceType(ec2API EC2API, instanceType string) (EniInfo, err
 	describeResp, err := ec2API.DescribeInstanceTypes(context.Background(), &ec2.DescribeInstanceTypesInput{
 		InstanceTypes: []types.InstanceType{types.InstanceType(instanceType)},
 	})
-
 	if err != nil {
 		return EniInfo{}, fmt.Errorf("error describing instance type %s: %w", instanceType, err)
 	}

--- a/internal/util/ec2_test.go
+++ b/internal/util/ec2_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
 )
 
 type MockEC2Client struct {
@@ -77,5 +78,4 @@ func TestGetEniInfoForInstanceType(t *testing.T) {
 		assert.Equal(t, test.expectedError, err)
 		assert.Equal(t, test.expectedResult, result)
 	}
-
 }

--- a/internal/validation/reader_test.go
+++ b/internal/validation/reader_test.go
@@ -3,8 +3,9 @@ package validation_test
 import (
 	"testing"
 
-	"github.com/aws/eks-hybrid/internal/validation"
 	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-hybrid/internal/validation"
 )
 
 func TestChannelReader(t *testing.T) {

--- a/internal/validation/runner_test.go
+++ b/internal/validation/runner_test.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aws/eks-hybrid/internal/validation"
 	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-hybrid/internal/validation"
 )
 
 func TestRunnerRunAllSuccess(t *testing.T) {

--- a/test/e2e/kubernetes/kubernetes.go
+++ b/test/e2e/kubernetes/kubernetes.go
@@ -146,7 +146,7 @@ func GetNginxPodName(name string) string {
 	return "nginx-" + name
 }
 
-func CreateNginxPodInNode(ctx context.Context, k8s *kubernetes.Clientset, nodeName string, namespace string, logger logr.Logger) error {
+func CreateNginxPodInNode(ctx context.Context, k8s *kubernetes.Clientset, nodeName, namespace string, logger logr.Logger) error {
 	podName := GetNginxPodName(nodeName)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/os/arch.go
+++ b/test/e2e/os/arch.go
@@ -57,7 +57,7 @@ func getAmiIDFromSSM(ctx context.Context, client *ssm.SSM, amiName string) (*str
 	return output.Parameter.Value, nil
 }
 
-func getInstanceTypeFromRegionAndArch(region string, arch string) string {
+func getInstanceTypeFromRegionAndArch(region, arch string) string {
 	if arch == amd64Arch {
 		if region == "ap-southeast-5" {
 			return "m6i.large"

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -41,8 +41,8 @@ import (
 )
 
 const (
-	ec2VolumeSize   = int32(30)
-	podNamespace    = "default"
+	ec2VolumeSize = int32(30)
+	podNamespace  = "default"
 )
 
 var (


### PR DESCRIPTION
This PR contains the changes from running `gofumpt` and `gci` on nodeadm codebase. I also added a custom Golangci lint config file with additional configuration for linters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

