### PR TITLE
Skip creating IRA resources in e2e on region that does not support IRA

### DIFF
--- a/test/e2e/cfn-templates/hybrid-cfn.yaml
+++ b/test/e2e/cfn-templates/hybrid-cfn.yaml
@@ -66,7 +66,7 @@ Resources:
       PrincipalArn: !GetAtt SSMRole.Arn
       Type: HYBRID_LINUX
 
-
+{{- if .IncludeRolesAnywhere}}
   TrustAnchor:
     Type: AWS::RolesAnywhere::TrustAnchor
     Properties:
@@ -129,13 +129,14 @@ Resources:
                 'aws:SourceArn': !GetAtt TrustAnchor.TrustAnchorArn
     DependsOn:
     - TrustAnchor
-  
+
   IRAClusterAccessEntry:
     Type: AWS::EKS::AccessEntry
     Properties:
       ClusterName: !Ref clusterName
       PrincipalArn: !GetAtt IRARole.Arn
       Type: HYBRID_LINUX
+{{- end}}
 
 
   # Create IAM Role for EC2
@@ -165,7 +166,7 @@ Outputs:
   SSMNodeRoleARN:
     Description: The ARN of the IAM Role for SSM.
     Value: !GetAtt SSMRole.Arn
-  
+{{- if .IncludeRolesAnywhere}}
   IRANodeRoleName:
     Description: IAM Role for IAM Roles Anywhere
     Value: !Ref IRARole
@@ -181,3 +182,4 @@ Outputs:
   IRAProfileARN:
     Description: ARN of the EKS Hybrid IRA Profile
     Value: !GetAtt AnywhereProfile.ProfileArn
+{{- end}}

--- a/test/e2e/vpc.go
+++ b/test/e2e/vpc.go
@@ -167,7 +167,7 @@ func createSubnet(client *ec2.EC2, vpcID, subnetCidr, az, tagName, clusterName s
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to tag private subnet: %v", err)
+		return "", fmt.Errorf("failed to tag subnet: %v", err)
 	}
 	return subnetId, nil
 }


### PR DESCRIPTION
Some region (ap-southeast-5 for example) does not support IAM Roles Anywhere. We will need to skip creating IRA resources when setting up e2e test on those region.

We need to use a template with condition to only create IRA resource when the region supports IRA because it will cause template parsing error in those region if IRA resource exists in template.

`Unrecognized resource types: [AWS::RolesAnywhere::Profile, AWS::RolesAnywhere::TrustAnchor]`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

