### PR TITLE
Set ec2 instance type based on region and arch

### DIFF
--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -16,7 +16,7 @@ type NodeadmOS interface {
 	Name() string
 	AMIName(ctx context.Context, awsSession *session.Session) (string, error)
 	BuildUserData(UserDataInput UserDataInput) ([]byte, error)
-	InstanceType() string
+	InstanceType(region string) string
 }
 
 type UserDataInput struct {

--- a/test/e2e/os/amazonlinux.go
+++ b/test/e2e/os/amazonlinux.go
@@ -41,11 +41,8 @@ func (a AmazonLinux2023) Name() string {
 	return "al23-arm64"
 }
 
-func (a AmazonLinux2023) InstanceType() string {
-	if a.Architecture == amd64Arch {
-		return "m5.2xlarge"
-	}
-	return "t4g.2xlarge"
+func (a AmazonLinux2023) InstanceType(region string) string {
+	return getInstanceTypeFromRegionAndArch(region, a.Architecture)
 }
 
 func (a AmazonLinux2023) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {

--- a/test/e2e/os/arch.go
+++ b/test/e2e/os/arch.go
@@ -56,3 +56,13 @@ func getAmiIDFromSSM(ctx context.Context, client *ssm.SSM, amiName string) (*str
 
 	return output.Parameter.Value, nil
 }
+
+func getInstanceTypeFromRegionAndArch(region string, arch string) string {
+	if arch == amd64Arch {
+		if region == "ap-southeast-5" {
+			return "m6i.large"
+		}
+		return "m5.2xlarge"
+	}
+	return "t4g.2xlarge"
+}

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -63,11 +63,8 @@ func (r RedHat8) Name() string {
 	return "rhel8-arm64"
 }
 
-func (r RedHat8) InstanceType() string {
-	if r.Architecture == amd64Arch {
-		return "m5.2xlarge"
-	}
-	return "t4g.2xlarge"
+func (r RedHat8) InstanceType(region string) string {
+	return getInstanceTypeFromRegionAndArch(region, r.Architecture)
 }
 
 func (r RedHat8) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
@@ -124,11 +121,8 @@ func (r RedHat9) Name() string {
 	return "rhel9-arm64"
 }
 
-func (r RedHat9) InstanceType() string {
-	if r.Architecture == amd64Arch {
-		return "m5.2xlarge"
-	}
-	return "t4g.2xlarge"
+func (r RedHat9) InstanceType(region string) string {
+	return getInstanceTypeFromRegionAndArch(region, r.Architecture)
 }
 
 func (r RedHat9) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -75,11 +75,8 @@ func (u Ubuntu2004) Name() string {
 	return name
 }
 
-func (u Ubuntu2004) InstanceType() string {
-	if u.Architecture == "amd64" {
-		return "m5.2xlarge"
-	}
-	return "t4g.2xlarge"
+func (u Ubuntu2004) InstanceType(region string) string {
+	return getInstanceTypeFromRegionAndArch(region, u.Architecture)
 }
 
 func (u Ubuntu2004) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
@@ -142,11 +139,8 @@ func (u Ubuntu2204) Name() string {
 	return name
 }
 
-func (u Ubuntu2204) InstanceType() string {
-	if u.Architecture == "amd64" {
-		return "m5.2xlarge"
-	}
-	return "t4g.2xlarge"
+func (u Ubuntu2204) InstanceType(region string) string {
+	return getInstanceTypeFromRegionAndArch(region, u.Architecture)
 }
 
 func (u Ubuntu2204) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
@@ -209,11 +203,8 @@ func (u Ubuntu2404) Name() string {
 	return name
 }
 
-func (u Ubuntu2404) InstanceType() string {
-	if u.Architecture == "amd64" {
-		return "m5.2xlarge"
-	}
-	return "t4g.2xlarge"
+func (u Ubuntu2404) InstanceType(region string) string {
+	return getInstanceTypeFromRegionAndArch(region, u.Architecture)
 }
 
 func (u Ubuntu2404) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -391,7 +391,7 @@ var _ = Describe("Hybrid Nodes", func() {
 								ClusterName:        test.cluster.Name,
 								InstanceName:       instanceName,
 								AmiID:              amiId,
-								InstanceType:       os.InstanceType(),
+								InstanceType:       os.InstanceType(suite.TestConfig.ClusterRegion),
 								VolumeSize:         ec2VolumeSize,
 								SubnetID:           test.cluster.SubnetID,
 								SecurityGroupID:    test.cluster.SecurityGroupID,


### PR DESCRIPTION
Create a method that returns the EC2 instance type that will be used in e2e test based region and OS architecture and remove the InstanceType definition in all OS packages.

*Testing (if applicable):*
Built e2e.test binary and ran test on a cluster on ap-southeast-5 region, an EC2 of type m6i.large was created and e2e test passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

