### PR TITLE
Refactor e2e suite and tests setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _bin
 cover.out
 coverage.out
 .idea
+.vscode
 .DS_Store
 vendor
 e2e-config

--- a/test/e2e/aws.go
+++ b/test/e2e/aws.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"regexp"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
@@ -13,4 +15,10 @@ func isErrCode(err error, code string) bool {
 	}
 
 	return false
+}
+
+// SanitizeForAWSName removes everything except alphanumeric characters and hyphens from a string.
+func SanitizeForAWSName(input string) string {
+	re := regexp.MustCompile(`[^a-zA-Z0-9-]+`)
+	return re.ReplaceAllString(input, "")
 }

--- a/test/e2e/credentials/setup.go
+++ b/test/e2e/credentials/setup.go
@@ -1,0 +1,69 @@
+package credentials
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/go-logr/logr"
+
+	"github.com/aws/eks-hybrid/test/e2e"
+)
+
+// Infrastructure represents the necessary infrastructure for credentials providers to be used by nodeadm.
+type Infrastructure struct {
+	StackOutput
+	RolesAnywhereCA *Certificate
+
+	stack  *Stack
+	logger logr.Logger
+}
+
+// Setup creates the necessary infrastructure for credentials providers to be used by nodeadm.
+func Setup(ctx context.Context, logger logr.Logger, awsSession *session.Session, config aws.Config, clusterName string) (*Infrastructure, error) {
+	eksClient := eks.NewFromConfig(config)
+	cfnClient := cloudformation.New(awsSession)
+	iamClient := iam.New(awsSession)
+
+	cluster, err := eksClient.DescribeCluster(ctx, &eks.DescribeClusterInput{
+		Name: aws.String(clusterName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting cluster details: %w", err)
+	}
+
+	rolesAnywhereCA, err := CreateCA()
+	if err != nil {
+		return nil, err
+	}
+
+	stackName := fmt.Sprintf("EKSHybridCI-%s", e2e.SanitizeForAWSName(clusterName))
+	stack := &Stack{
+		ClusterName:            *cluster.Cluster.Name,
+		ClusterArn:             *cluster.Cluster.Arn,
+		Name:                   e2e.GetTruncatedName(stackName, 60),
+		IAMRolesAnywhereCACert: rolesAnywhereCA.CertPEM,
+		CFN:                    cfnClient,
+		IAM:                    iamClient,
+	}
+	stackOut, err := stack.Deploy(ctx, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Infrastructure{
+		StackOutput:     *stackOut,
+		RolesAnywhereCA: rolesAnywhereCA,
+		stack:           stack,
+		logger:          logger,
+	}, nil
+}
+
+func (p *Infrastructure) Teardown(ctx context.Context) error {
+	p.logger.Info("Deleting e2e resources stack", "stackName", p.stack.Name)
+	return p.stack.Delete(ctx, p.logger, &p.StackOutput)
+}

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -81,14 +80,13 @@ func TestE2E(t *testing.T) {
 }
 
 type peeredVPCTest struct {
-	aws         awsconfig.Config // TODO: move everything to aws sdk v2
-	awsSession  *session.Session
-	eksClient   *eks.EKS
-	ec2Client   *ec2v1.EC2
-	ec2ClientV2 *ec2v2.Client
-	ssmClient   *ssmv1.SSM
-	ssmClientV2 *ssmv2.Client
-
+	aws             awsconfig.Config // TODO: move everything to aws sdk v2
+	awsSession      *session.Session
+	eksClient       *eks.EKS
+	ec2Client       *ec2v1.EC2
+	ec2ClientV2     *ec2v2.Client
+	ssmClient       *ssmv1.SSM
+	ssmClientV2     *ssmv2.Client
 	cfnClient       *cloudformation.CloudFormation
 	k8sClient       *clientgo.Clientset
 	k8sClientConfig *restclient.Config
@@ -97,11 +95,9 @@ type peeredVPCTest struct {
 
 	logger logr.Logger
 
-	cluster  *peered.HybridCluster
-	stackOut *credentials.StackOutput
-
-	NodeadmURLs e2e.NodeadmURLs
-
+	cluster         *peered.HybridCluster
+	stackOut        *credentials.StackOutput
+	nodeadmURLs     e2e.NodeadmURLs
 	rolesAnywhereCA *credentials.Certificate
 }
 
@@ -123,7 +119,9 @@ var _ = SynchronizedBeforeSuite(
 		Expect(err).NotTo(HaveOccurred(), "should read valid test configuration")
 
 		logger := e2e.NewLogger()
-		awsSession, err := newE2EAWSSession(config.ClusterRegion)
+		awsSession, err := session.NewSession(&aws.Config{
+			Region: aws.String(config.ClusterRegion),
+		})
 		Expect(err).NotTo(HaveOccurred())
 		aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.ClusterRegion))
 		Expect(err).NotTo(HaveOccurred())
@@ -198,43 +196,10 @@ var _ = Describe("Hybrid Nodes", func() {
 			Expect(suite).NotTo(BeNil(), "suite configuration should have been set")
 			Expect(suite.TestConfig).NotTo(BeNil(), "test configuration should have been set")
 			Expect(suite.CredentialsStackOutput).NotTo(BeNil(), "credentials stack output should have been set")
-			test = &peeredVPCTest{
-				stackOut: suite.CredentialsStackOutput,
-				logger:   e2e.NewLogger(),
-			}
 
-			awsSession, err := newE2EAWSSession(suite.TestConfig.ClusterRegion)
-			Expect(err).NotTo(HaveOccurred())
-
-			aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(suite.TestConfig.ClusterRegion))
-			Expect(err).NotTo(HaveOccurred())
-
-			test.aws = aws
-			test.awsSession = awsSession
-			test.eksClient = eks.New(awsSession)
-			test.ec2Client = ec2v1.New(awsSession)
-			test.ec2ClientV2 = ec2v2.NewFromConfig(aws) // TODO: move everything else to ec2 sdk v2
-			test.ssmClient = ssmv1.New(awsSession)
-			test.ssmClientV2 = ssmv2.NewFromConfig(aws)
-			test.s3Client = s3v1.New(awsSession)
-			test.cfnClient = cloudformation.New(awsSession)
-			test.iamClient = iam.New(awsSession)
-
-			ca, err := credentials.ParseCertificate(suite.RolesAnywhereCACertPEM, suite.RolesAnywhereCAKeyPEM)
-			Expect(err).NotTo(HaveOccurred())
-
-			test.rolesAnywhereCA = ca
-
-			// TODO: ideally this should be an input to the tests and not just
-			// assume same name/path used by the setup command.
-			clientConfig, err := clientcmd.BuildConfigFromFlags("", e2e.KubeconfigPath(suite.TestConfig.ClusterName))
-			Expect(err).NotTo(HaveOccurred(), "should load correctly kubeconfig file for cluster %s", suite.TestConfig.ClusterName)
-
-			test.k8sClient, err = clientgo.NewForConfig(clientConfig)
-			Expect(err).NotTo(HaveOccurred(), "expected to build kubernetes client")
-
-			test.cluster, err = peered.GetHybridCluster(ctx, test.eksClient, test.ec2ClientV2, suite.TestConfig.ClusterName)
-			Expect(err).NotTo(HaveOccurred(), "expected to get cluster details")
+			var err error
+			test, err = buildPeeredVPCTestForSuite(ctx, suite)
+			Expect(err).NotTo(HaveOccurred(), "should build peered VPC test config")
 
 			for _, provider := range credentialProviders {
 				switch p := provider.(type) {
@@ -248,17 +213,6 @@ var _ = Describe("Hybrid Nodes", func() {
 					p.TrustAnchorARN = test.stackOut.IRATrustAnchorARN
 					p.CA = test.rolesAnywhereCA
 				}
-			}
-
-			if suite.TestConfig.NodeadmUrlAMD != "" {
-				nodeadmUrl, err := s3.GetNodeadmURL(test.s3Client, suite.TestConfig.NodeadmUrlAMD)
-				Expect(err).NotTo(HaveOccurred(), "expected to retrieve nodeadm amd URL from S3 successfully")
-				test.NodeadmURLs.AMD = nodeadmUrl
-			}
-			if suite.TestConfig.NodeadmUrlARM != "" {
-				nodeadmUrl, err := s3.GetNodeadmURL(test.s3Client, suite.TestConfig.NodeadmUrlARM)
-				Expect(err).NotTo(HaveOccurred(), "expected to retrieve nodeadm arm URL from S3 successfully")
-				test.NodeadmURLs.ARM = nodeadmUrl
 			}
 		})
 
@@ -321,7 +275,7 @@ var _ = Describe("Hybrid Nodes", func() {
 
 							userdata, err := os.BuildUserData(e2e.UserDataInput{
 								KubernetesVersion: k8sVersion,
-								NodeadmUrls:       test.NodeadmURLs,
+								NodeadmUrls:       test.nodeadmURLs,
 								NodeadmConfigYaml: string(nodeadmConfigYaml),
 								Provider:          string(provider.Name()),
 								RootPasswordHash:  rootPasswordHash,
@@ -485,17 +439,6 @@ func (u uninstallNodeTest) Run(ctx context.Context) error {
 	return nil
 }
 
-// newE2EAWSSession constructs AWS session.
-func newE2EAWSSession(region string) (*session.Session, error) {
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(region),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating AWS session: %w", err)
-	}
-	return sess, nil
-}
-
 // readTestConfig reads the configuration from the specified file path and unmarshals it into the TestConfig struct.
 func readTestConfig(configPath string) (*TestConfig, error) {
 	config := &TestConfig{}
@@ -511,22 +454,69 @@ func readTestConfig(configPath string) (*TestConfig, error) {
 	return config, nil
 }
 
-func enabledCredentialsProviders(providers []e2e.NodeadmCredentialsProvider) []e2e.NodeadmCredentialsProvider {
-	filter := GinkgoLabelFilter()
-	providerList := []e2e.NodeadmCredentialsProvider{}
+func buildPeeredVPCTestForSuite(ctx context.Context, suite *suiteConfiguration) (*peeredVPCTest, error) {
+	test := &peeredVPCTest{
+		stackOut: suite.CredentialsStackOutput,
+		logger:   e2e.NewLogger(),
+	}
 
-	for _, provider := range providers {
-		if strings.Contains(filter, string(provider.Name())) {
-			providerList = append(providerList, provider)
+	awsSession, err := session.NewSession(&aws.Config{
+		Region: aws.String(suite.TestConfig.ClusterRegion),
+	})
+	if err != nil {
+		return nil, err
+	}
+	aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(suite.TestConfig.ClusterRegion))
+	if err != nil {
+		return nil, err
+	}
+
+	test.aws = aws
+	test.awsSession = awsSession
+	test.eksClient = eks.New(awsSession)
+	test.ec2Client = ec2v1.New(awsSession)
+	test.ec2ClientV2 = ec2v2.NewFromConfig(aws) // TODO: move everything else to ec2 sdk v2
+	test.ssmClient = ssmv1.New(awsSession)
+	test.ssmClientV2 = ssmv2.NewFromConfig(aws)
+	test.s3Client = s3v1.New(awsSession)
+	test.cfnClient = cloudformation.New(awsSession)
+	test.iamClient = iam.New(awsSession)
+
+	ca, err := credentials.ParseCertificate(suite.RolesAnywhereCACertPEM, suite.RolesAnywhereCAKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	test.rolesAnywhereCA = ca
+
+	// TODO: ideally this should be an input to the tests and not just
+	// assume same name/path used by the setup command.
+	clientConfig, err := clientcmd.BuildConfigFromFlags("", e2e.KubeconfigPath(suite.TestConfig.ClusterName))
+	if err != nil {
+		return nil, err
+	}
+	test.k8sClient, err = clientgo.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	test.cluster, err = peered.GetHybridCluster(ctx, test.eksClient, test.ec2ClientV2, suite.TestConfig.ClusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	if suite.TestConfig.NodeadmUrlAMD != "" {
+		nodeadmUrl, err := s3.GetNodeadmURL(test.s3Client, suite.TestConfig.NodeadmUrlAMD)
+		if err != nil {
+			return nil, err
 		}
+		test.nodeadmURLs.AMD = nodeadmUrl
 	}
-	return providerList
-}
-
-func getCredentialProviderNames(providers []e2e.NodeadmCredentialsProvider) string {
-	var names []string
-	for _, provider := range providers {
-		names = append(names, string(provider.Name()))
+	if suite.TestConfig.NodeadmUrlARM != "" {
+		nodeadmUrl, err := s3.GetNodeadmURL(test.s3Client, suite.TestConfig.NodeadmUrlARM)
+		if err != nil {
+			return nil, err
+		}
+		test.nodeadmURLs.ARM = nodeadmUrl
 	}
-	return strings.Join(names, "-")
+	return test, nil
 }

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -41,7 +41,6 @@ import (
 )
 
 const (
-	ec2InstanceType = "t2.large"
 	ec2VolumeSize   = int32(30)
 	podNamespace    = "default"
 )

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -320,7 +320,7 @@ var _ = Describe("Hybrid Nodes", func() {
 								nodeIPAddress: instance.IP,
 								logger:        test.logger,
 							}
-							Expect(joinNodeTest.Run(ctx)).To(Succeed(), "node should have joined the cluster sucessfully")
+							Expect(joinNodeTest.Run(ctx)).To(Succeed(), "node should have joined the cluster successfully")
 
 							test.logger.Info("Resetting hybrid node...")
 
@@ -331,7 +331,7 @@ var _ = Describe("Hybrid Nodes", func() {
 								provider: provider,
 								logger:   test.logger,
 							}
-							Expect(uninstallNodeTest.Run(ctx)).To(Succeed(), "node should have been reset sucessfully")
+							Expect(uninstallNodeTest.Run(ctx)).To(Succeed(), "node should have been reset successfully")
 
 							test.logger.Info("Rebooting EC2 Instance.")
 							Expect(ec2.RebootEC2Instance(ctx, test.ec2ClientV2, instance.ID)).NotTo(HaveOccurred(), "EC2 Instance should have rebooted successfully")

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"testing"
 	"time"


### PR DESCRIPTION
## Description of changes
Next refactor piece after separating test code from "library". This PR focuses on the tests setup code, making some pieces reusable when possible and when not, splitting the long setup functions into smaller logic units. Most of that code is boiler plate, so by just moving it to separate functions with meaningful names we make reading the test code top to bottom easier.

In addition, a couple minor improvements/cleanups, that don't really change the flow of the test:
* Simplify the code that reads cluster details for a Hybrid cluster. Now it can infer all the data from just the cluster name by querying AWS APIs.
* Moved all that code to use go SDK v2. Eventually we should move all of it, but it's ok to do it piece meal.
* Now the `skipCleanup` is a flag that gets passed from the suite config. This toggle is still controller through the same env variable, but now it's only the suite setup code that reads it, and the rest of the test code just pulls this info from the the test config objects. This ensures the code behaves consistently for the duration of the test and allows to easily add/change the logic that drives the toggle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

