### PR TITLE
Fix instance type assignment based on architecture

### DIFF
--- a/test/e2e/os/amazonlinux.go
+++ b/test/e2e/os/amazonlinux.go
@@ -24,7 +24,7 @@ type AmazonLinux2023 struct {
 
 func NewAmazonLinux2023AMD() *AmazonLinux2023 {
 	al := new(AmazonLinux2023)
-	al.Architecture = amd64Arch
+	al.Architecture = x8664Arch
 	return al
 }
 
@@ -35,14 +35,14 @@ func NewAmazonLinux2023ARM() *AmazonLinux2023 {
 }
 
 func (a AmazonLinux2023) Name() string {
-	if a.Architecture == amd64Arch {
+	if a.Architecture == x8664Arch {
 		return "al23-amd64"
 	}
 	return "al23-arm64"
 }
 
 func (a AmazonLinux2023) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, a.Architecture)
+	return getInstanceTypeFromRegionAndArch(region, normalizeArch(a.Architecture))
 }
 
 func (a AmazonLinux2023) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {

--- a/test/e2e/os/arch.go
+++ b/test/e2e/os/arch.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	amd64Arch = "x86_64"
+	amd64Arch = "amd64"
 	arm64Arch = "arm64"
+	x8664Arch = "x86_64"
 )
 
 func populateBaseScripts(userDataInput *e2e.UserDataInput) error {
@@ -55,6 +56,13 @@ func getAmiIDFromSSM(ctx context.Context, client *ssm.SSM, amiName string) (*str
 	}
 
 	return output.Parameter.Value, nil
+}
+
+func normalizeArch(arch string) string {
+	if arch == x8664Arch {
+		return amd64Arch
+	}
+	return arch
 }
 
 func getInstanceTypeFromRegionAndArch(region, arch string) string {

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -44,7 +44,7 @@ func NewRedHat8AMD(rhelUsername, rhelPassword string) *RedHat8 {
 	rh8 := new(RedHat8)
 	rh8.RhelUsername = rhelUsername
 	rh8.RhelPassword = rhelPassword
-	rh8.Architecture = amd64Arch
+	rh8.Architecture = x8664Arch
 	return rh8
 }
 
@@ -57,14 +57,14 @@ func NewRedHat8ARM(rhelUsername, rhelPassword string) *RedHat8 {
 }
 
 func (r RedHat8) Name() string {
-	if r.Architecture == amd64Arch {
+	if r.Architecture == x8664Arch {
 		return "rhel8-amd64"
 	}
 	return "rhel8-arm64"
 }
 
 func (r RedHat8) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, r.Architecture)
+	return getInstanceTypeFromRegionAndArch(region, normalizeArch(r.Architecture))
 }
 
 func (r RedHat8) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
@@ -102,7 +102,7 @@ func NewRedHat9AMD(rhelUsername, rhelPassword string) *RedHat9 {
 	rh9 := new(RedHat9)
 	rh9.RhelUsername = rhelUsername
 	rh9.RhelPassword = rhelPassword
-	rh9.Architecture = amd64Arch
+	rh9.Architecture = x8664Arch
 	return rh9
 }
 
@@ -115,14 +115,14 @@ func NewRedHat9ARM(rhelUsername, rhelPassword string) *RedHat9 {
 }
 
 func (r RedHat9) Name() string {
-	if r.Architecture == amd64Arch {
+	if r.Architecture == x8664Arch {
 		return "rhel9-amd64"
 	}
 	return "rhel9-arm64"
 }
 
 func (r RedHat9) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, r.Architecture)
+	return getInstanceTypeFromRegionAndArch(region, normalizeArch(r.Architecture))
 }
 
 func (r RedHat9) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -48,14 +48,14 @@ type Ubuntu2004 struct {
 
 func NewUbuntu2004AMD() *Ubuntu2004 {
 	u := new(Ubuntu2004)
-	u.Architecture = "amd64"
+	u.Architecture = amd64Arch
 	u.ContainerdSource = "distro"
 	return u
 }
 
 func NewUbuntu2004DockerSource() *Ubuntu2004 {
 	u := new(Ubuntu2004)
-	u.Architecture = "amd64"
+	u.Architecture = amd64Arch
 	u.ContainerdSource = "docker"
 	return u
 }
@@ -76,7 +76,7 @@ func (u Ubuntu2004) Name() string {
 }
 
 func (u Ubuntu2004) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, u.Architecture)
+	return getInstanceTypeFromRegionAndArch(region, normalizeArch(u.Architecture))
 }
 
 func (u Ubuntu2004) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
@@ -112,14 +112,14 @@ type Ubuntu2204 struct {
 
 func NewUbuntu2204AMD() *Ubuntu2204 {
 	u := new(Ubuntu2204)
-	u.Architecture = "amd64"
+	u.Architecture = amd64Arch
 	u.ContainerdSource = "distro"
 	return u
 }
 
 func NewUbuntu2204DockerSource() *Ubuntu2204 {
 	u := new(Ubuntu2204)
-	u.Architecture = "amd64"
+	u.Architecture = amd64Arch
 	u.ContainerdSource = "docker"
 	return u
 }
@@ -140,7 +140,7 @@ func (u Ubuntu2204) Name() string {
 }
 
 func (u Ubuntu2204) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, u.Architecture)
+	return getInstanceTypeFromRegionAndArch(region, normalizeArch(u.Architecture))
 }
 
 func (u Ubuntu2204) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
@@ -176,14 +176,14 @@ type Ubuntu2404 struct {
 
 func NewUbuntu2404AMD() *Ubuntu2404 {
 	u := new(Ubuntu2404)
-	u.Architecture = "amd64"
+	u.Architecture = amd64Arch
 	u.ContainerdSource = "distro"
 	return u
 }
 
 func NewUbuntu2404DockerSource() *Ubuntu2404 {
 	u := new(Ubuntu2404)
-	u.Architecture = "amd64"
+	u.Architecture = amd64Arch
 	u.ContainerdSource = "docker"
 	return u
 }
@@ -204,7 +204,7 @@ func (u Ubuntu2404) Name() string {
 }
 
 func (u Ubuntu2404) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, u.Architecture)
+	return getInstanceTypeFromRegionAndArch(region, normalizeArch(u.Architecture))
 }
 
 func (u Ubuntu2404) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {


### PR DESCRIPTION
This PR fixes the instance type assignment based on architecture. Earlier we were only checking if the architecture was `x86_64` to assign an AMD64 instance type, and otherwise assigning ARM64 if the check fails, but Ubuntu uses `amd64` and so the check was failing, leading to us using an ARM64 instance type for an AMD64 AMI which led to the error
```console
The architecture 'arm64' of the specified instance type does not match the architecture 'x86_64' of the specified AMI. Specify an instance type and an AMI that have matching architectures, and try again.
```
Now we are checking for both `amd64` and `x86_64` when assigning instance types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

