### PR TITLE
Upgrade crd-ref-docs version to fix memory issue when generating doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ GINKGO ?= $(LOCALBIN)/ginkgo
 KUSTOMIZE_VERSION ?= v5.0.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.3
 CODE_GENERATOR_VERSION ?= v0.30.6
-CRD_REF_DOCS_VERSION ?= cf959ab94ea543cb8efd25dc35081880b7ca6a81
+CRD_REF_DOCS_VERSION ?= v0.1.0
 GINKGO_VERSION ?= v2.19.0
 
 tools: kustomize controller-gen conversion-gen crd-ref-docs ginkgo ## Install the toolchain.

--- a/doc/api.md
+++ b/doc/api.md
@@ -10,7 +10,8 @@
 
 #### ClusterDetails
 
-ClusterDetails contains the coordinates of your EKS cluster. These details can be found using the [DescribeCluster API](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeCluster.html).
+ClusterDetails contains the coordinates of your EKS cluster.
+These details can be found using the [DescribeCluster API](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeCluster.html).
 
 _Appears in:_
 - [NodeConfigSpec](#nodeconfigspec)
@@ -18,9 +19,9 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `name` _string_ | Name is the name of your EKS cluster |
-| `region` _string_ | Region is an AWS region (e.g. us-east-1) used to retrieve regional artifacts as well as region where EKS cluster lives. |
+| `region` _string_ | Region is an AWS region (e.g. us-east-1) used to retrieve regional artifacts<br />as well as region where EKS cluster lives. |
 | `apiServerEndpoint` _string_ | APIServerEndpoint is the URL of your EKS cluster's kube-apiserver. |
-| `certificateAuthority` _[byte](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#byte-v1-meta) array_ | CertificateAuthority is a base64-encoded string of your cluster's certificate authority chain. |
+| `certificateAuthority` _integer array_ | CertificateAuthority is a base64-encoded string of your cluster's certificate authority chain. |
 | `cidr` _string_ | CIDR is your cluster's Pod IP CIDR. This value is used to infer your cluster's DNS address. |
 | `enableOutpost` _boolean_ | EnableOutpost determines how your node is configured when running on an AWS Outpost. |
 | `id` _string_ | ID is an identifier for your cluster; this is only used when your node is running on an AWS Outpost. |
@@ -34,7 +35,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `config` _string_ | Config is inline [`containerd` configuration TOML](https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md) that will be [imported](https://github.com/containerd/containerd/blob/32169d591dbc6133ef7411329b29d0c0433f8c4d/docs/man/containerd-config.toml.5.md?plain=1#L146-L154) by the default configuration file. |
+| `config` _string_ | Config is inline [`containerd` configuration TOML](https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md)<br />that will be [imported](https://github.com/containerd/containerd/blob/32169d591dbc6133ef7411329b29d0c0433f8c4d/docs/man/containerd-config.toml.5.md?plain=1#L146-L154)<br />by the default configuration file. |
 
 #### HybridOptions
 
@@ -45,9 +46,9 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `enableCredentialsFile` _boolean_ | EnableCredentialsFile enables a shared credentials file on the host at /eks-hybrid/.aws/credentials For SSM, this means that nodeadm will not create symlink from `/root/.aws/credentials` to `/eks-hybrid/.aws/credentials`. For IAM Roles Anywhere, this means that nodeadm will not set up a systemd service to write and refresh the credentials to `/eks-hybrid/.aws/credentials`. |
-| `iamRolesAnywhere` _[IAMRolesAnywhere](#iamrolesanywhere)_ | IAMRolesAnywhere includes IAM Roles Anywhere specific configuration and is mutually exclusive with SSM. |
-| `ssm` _[SSM](#ssm)_ | SSM includes Systems Manager specific configuration and is mutually exclusive with IAMRolesAnywhere. |
+| `enableCredentialsFile` _boolean_ | EnableCredentialsFile enables a shared credentials file on the host at /eks-hybrid/.aws/credentials<br />For SSM, this means that nodeadm will not create symlink from `/root/.aws/credentials` to `/eks-hybrid/.aws/credentials`.<br />For IAM Roles Anywhere, this means that nodeadm will not set up a systemd service to write and refresh the credentials to `/eks-hybrid/.aws/credentials`. |
+| `iamRolesAnywhere` _[IAMRolesAnywhere](#iamrolesanywhere)_ | IAMRolesAnywhere includes IAM Roles Anywhere specific configuration and is mutually exclusive<br />with SSM. |
+| `ssm` _[SSM](#ssm)_ | SSM includes Systems Manager specific configuration and is mutually exclusive with<br />IAMRolesAnywhere. |
 
 #### IAMRolesAnywhere
 
@@ -62,7 +63,9 @@ _Appears in:_
 | `trustAnchorArn` _string_ | TrustAnchorARN is the ARN of the trust anchor. |
 | `profileArn` _string_ | ProfileARN is the ARN of the profile linked with the Hybrid IAM Role. |
 | `roleArn` _string_ | RoleARN is the role to IAM roles anywhere gets authorized as to get temporary credentials. |
-| `awsConfigPath` _string_ | AwsConfigPath is the path where the Aws config is stored for hybrid nodes. This field is only used to init phase |
+| `awsConfigPath` _string_ | AwsConfigPath is the path where the Aws config is stored for hybrid nodes.<br />This field is only used to init phase |
+| `certificatePath` _string_ | CertificatePath is the location on disk for the certificate used to authenticate with AWS. |
+| `privateKeyPath` _string_ | PrivateKeyPath is the location on disk for the certificate's private key. |
 
 #### InstanceOptions
 
@@ -84,12 +87,13 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `config` _object (keys:string, values:RawExtension)_ | Config is a [`KubeletConfiguration`](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1/) that will be merged with the defaults. |
-| `flags` _string array_ | Flags are [command-line `kubelet`` arguments](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/). that will be appended to the defaults. |
+| `config` _object (keys:string, values:[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#rawextension-runtime-pkg))_ | Config is a [`KubeletConfiguration`](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1/)<br />that will be merged with the defaults. |
+| `flags` _string array_ | Flags are [command-line `kubelet`` arguments](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/).<br />that will be appended to the defaults. |
 
 #### LocalStorageOptions
 
-LocalStorageOptions control how [EC2 instance stores](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html) are used when available.
+LocalStorageOptions control how [EC2 instance stores](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html)
+are used when available.
 
 _Appears in:_
 - [InstanceOptions](#instanceoptions)
@@ -118,8 +122,8 @@ NodeConfig is the primary configuration object for `nodeadm`.
 | --- | --- |
 | `apiVersion` _string_ | `node.eks.aws/v1alpha1`
 | `kind` _string_ | `NodeConfig`
-| `kind` _string_ | Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |
-| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[NodeConfigSpec](#nodeconfigspec)_ |  |
 
@@ -138,7 +142,9 @@ _Appears in:_
 
 #### SSM
 
-SSM defines Systems Manager specific configuration. ActivationCode and ActivationID are generated on the aws console or cli during hybrid activations. During activation an IAM role is chosen for the SSM agent to assume. This is not overridable from the agent.
+SSM defines Systems Manager specific configuration.
+ActivationCode and ActivationID are generated on the aws console or cli during hybrid activations.
+During activation an IAM role is chosen for the SSM agent to assume. This is not overridable from the agent.
 
 _Appears in:_
 - [HybridOptions](#hybridoptions)


### PR DESCRIPTION
*Issue #, if available:*

The previous crd-ref-docs has a memory issue when generating docs.

```
2024-12-10T15:29:39.731-0800	INFO	crd-ref-docs	Loading configuration	{"path": "../eks-hybrid/doc/config.yaml"}
2024-12-10T15:29:39.733-0800	INFO	crd-ref-docs	Processing source directory	{"directory": "../eks-hybrid/api/", "depth": 6}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1007b4164]

goroutine 120 [running]:
go/types.(*Checker).handleBailout(0x14000c461c0, 0x14000c1bd38)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:404 +0x9c
panic({0x100e10b40?, 0x1013e8a30?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/panic.go:785 +0x124
go/types.(*StdSizes).Sizeof(0x0, {0x100ee4eb0, 0x1013f1fc0})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/sizes.go:229 +0x314
go/types.(*Config).sizeof(...)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/sizes.go:334
go/types.representableConst.func1({0x100ee4eb0?, 0x1013f1fc0?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:77 +0x90
go/types.representableConst({0x100eeb2b8, 0x1013bc1c0}, 0x14000c461c0, 0x1013f1fc0, 0x0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:93 +0x134
go/types.(*Checker).arrayLength(0x14000c461c0, {0x100ee8648, 0x14000c1e580?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/typexpr.go:537 +0x1bc
go/types.(*Checker).typInternal(0x14000c461c0, {0x100ee8798, 0x14000c20000}, 0x0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/typexpr.go:320 +0x3b0
go/types.(*Checker).definedType(0x14000c461c0, {0x100ee8798, 0x14000c20000}, 0x100ee4ed8?)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/typexpr.go:201 +0x28
go/types.(*Checker).varType(0x14000c461c0, {0x100ee8798, 0x14000c20000})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/typexpr.go:166 +0x2c
go/types.(*Checker).structType(0x14000c461c0, 0x140004ef8c0, 0x140004ef8c0?)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/struct.go:114 +0x11c
go/types.(*Checker).typInternal(0x14000c461c0, {0x100ee87c8, 0x14000c07b00}, 0x1400052c050)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/typexpr.go:337 +0xc20
go/types.(*Checker).definedType(0x14000c461c0, {0x100ee87c8, 0x14000c07b00}, 0x100c45790?)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/typexpr.go:201 +0x28
go/types.(*Checker).typeDecl(0x14000c461c0, 0x1400052c050, 0x14000c14b40, 0x0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/decl.go:649 +0x454
go/types.(*Checker).objDecl(0x14000c461c0, {0x100ef15e0, 0x1400052c050}, 0x0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/decl.go:191 +0x874
go/types.(*Checker).packageObjects(0x14000c461c0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/resolver.go:702 +0x350
go/types.(*Checker).checkFiles(0x14000c461c0, {0x140006df008, 0x3, 0x3})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:459 +0x190
go/types.(*Checker).Files(0x140001923d0?, {0x140006df008?, 0x1400030fce0?, 0x6?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:422 +0x80
sigs.k8s.io/controller-tools/pkg/loader.(*loader).typeCheck(0x140002ecd50, 0x140003925e0)
	/Users/jupeng/workplace/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/loader.go:286 +0x2d8
sigs.k8s.io/controller-tools/pkg/loader.(*Package).NeedTypesInfo(0x140003925e0)
	/Users/jupeng/workplace/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/loader.go:99 +0x44
sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check(0x140004dd710, 0x140003925e0)
	/Users/jupeng/workplace/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/refs.go:268 +0x300
sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check.func1(0x56?)
	/Users/jupeng/workplace/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/refs.go:262 +0x54
created by sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check in goroutine 15
	/Users/jupeng/workplace/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/refs.go:260 +0x22c
```

*Description of changes:*
Upgrade to version v0.1.0 to fix the issue.

*Testing (if applicable):*
Run `make` before and after the commit.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

