### PR TITLE
adds iam-ra profiles/trust-anchors to cleanup

### DIFF
--- a/hybrid-nodes-cdk/lib/nodeadm-stack.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm-stack.ts
@@ -490,6 +490,14 @@ export class NodeadmBuildStack extends cdk.Stack {
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
           actions: [
+            "rolesanywhere:ListTrustAnchors",
+            "rolesanywhere:ListProfiles"
+          ],
+          resources: ['*']
+        }),
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: [
             "rolesanywhere:DeleteProfile",
             "rolesanywhere:DeleteTrustAnchor",
             "rolesanywhere:GetTrustAnchor",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We werent cleaning up the roles anywhere trust anchors and profiles. This adds it to the cleanup script.  
- Normalized tag key casing, since these apis do not match ALL the others in their casing...
- Cleaned up some comments
- Skip iam-ra cleanup on ap-southeast-5 which does not support this api.  We should probably change this to be an env var that is set in the canary to make disabling this easier per region.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

