### PR TITLE
Normalize OS architecture

### DIFF
--- a/test/e2e/os/amazonlinux.go
+++ b/test/e2e/os/amazonlinux.go
@@ -19,34 +19,34 @@ type amazonLinuxCloudInitData struct {
 }
 
 type AmazonLinux2023 struct {
-	Architecture string
+	amiArchitecture string
+	architecture    architecture
 }
 
 func NewAmazonLinux2023AMD() *AmazonLinux2023 {
 	al := new(AmazonLinux2023)
-	al.Architecture = x8664Arch
+	al.amiArchitecture = x8664Arch
+	al.architecture = amd64
 	return al
 }
 
 func NewAmazonLinux2023ARM() *AmazonLinux2023 {
 	al := new(AmazonLinux2023)
-	al.Architecture = arm64Arch
+	al.amiArchitecture = arm64Arch
+	al.architecture = arm64
 	return al
 }
 
 func (a AmazonLinux2023) Name() string {
-	if a.Architecture == x8664Arch {
-		return "al23-amd64"
-	}
-	return "al23-arm64"
+	return "al23-" + a.architecture.String()
 }
 
 func (a AmazonLinux2023) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, normalizeArch(a.Architecture))
+	return getInstanceTypeFromRegionAndArch(region, a.architecture)
 }
 
 func (a AmazonLinux2023) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
-	amiId, err := getAmiIDFromSSM(ctx, ssm.New(awsSession), "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-"+a.Architecture)
+	amiId, err := getAmiIDFromSSM(ctx, ssm.New(awsSession), "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-"+a.amiArchitecture)
 	return *amiId, err
 }
 
@@ -60,7 +60,7 @@ func (a AmazonLinux2023) BuildUserData(userDataInput e2e.UserDataInput) ([]byte,
 		NodeadmUrl:    userDataInput.NodeadmUrls.AMD,
 	}
 
-	if a.Architecture == arm64Arch {
+	if a.architecture.arm() {
 		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
 	}
 

--- a/test/e2e/os/arch.go
+++ b/test/e2e/os/arch.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
+
 	"github.com/aws/eks-hybrid/test/e2e"
 )
 
@@ -15,6 +16,25 @@ const (
 	arm64Arch = "arm64"
 	x8664Arch = "x86_64"
 )
+
+type architecture string
+
+const (
+	amd64 architecture = "amd64"
+	arm64 architecture = "arm64"
+)
+
+func (a architecture) String() string {
+	return string(a)
+}
+
+func (a architecture) arm() bool {
+	return a == arm64
+}
+
+func (a architecture) amd() bool {
+	return a == amd64
+}
 
 func populateBaseScripts(userDataInput *e2e.UserDataInput) error {
 	logCollector, err := executeTemplate(logCollectorScript, userDataInput)
@@ -58,15 +78,8 @@ func getAmiIDFromSSM(ctx context.Context, client *ssm.SSM, amiName string) (*str
 	return output.Parameter.Value, nil
 }
 
-func normalizeArch(arch string) string {
-	if arch == x8664Arch {
-		return amd64Arch
-	}
-	return arch
-}
-
-func getInstanceTypeFromRegionAndArch(region, arch string) string {
-	if arch == amd64Arch {
+func getInstanceTypeFromRegionAndArch(region string, arch architecture) string {
+	if arch.amd() {
 		if region == "ap-southeast-5" {
 			return "m6i.large"
 		}

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -30,9 +30,10 @@ type rhelCloudInitData struct {
 }
 
 type RedHat8 struct {
-	RhelUsername string
-	RhelPassword string
-	Architecture string
+	rhelUsername    string
+	rhelPassword    string
+	amiArchitecture string
+	architecture    architecture
 }
 
 const (
@@ -42,35 +43,34 @@ const (
 
 func NewRedHat8AMD(rhelUsername, rhelPassword string) *RedHat8 {
 	rh8 := new(RedHat8)
-	rh8.RhelUsername = rhelUsername
-	rh8.RhelPassword = rhelPassword
-	rh8.Architecture = x8664Arch
+	rh8.rhelUsername = rhelUsername
+	rh8.rhelPassword = rhelPassword
+	rh8.amiArchitecture = x8664Arch
+	rh8.architecture = amd64
 	return rh8
 }
 
 func NewRedHat8ARM(rhelUsername, rhelPassword string) *RedHat8 {
 	rh8 := new(RedHat8)
-	rh8.RhelUsername = rhelUsername
-	rh8.RhelPassword = rhelPassword
-	rh8.Architecture = arm64Arch
+	rh8.rhelUsername = rhelUsername
+	rh8.rhelPassword = rhelPassword
+	rh8.amiArchitecture = arm64Arch
+	rh8.architecture = arm64
 	return rh8
 }
 
 func (r RedHat8) Name() string {
-	if r.Architecture == x8664Arch {
-		return "rhel8-amd64"
-	}
-	return "rhel8-arm64"
+	return "rhel8-" + r.architecture.String()
 }
 
 func (r RedHat8) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, normalizeArch(r.Architecture))
+	return getInstanceTypeFromRegionAndArch(region, r.architecture)
 }
 
 func (r RedHat8) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
 	// there is no rhel ssm parameter
 	// aws ec2 describe-images --owners 309956199498 --query 'sort_by(Images, &CreationDate)[-1].[ImageId]' --filters "Name=name,Values=RHEL-8*" "Name=architecture,Values=x86_64" --region us-west-2
-	return findLatestImage(ec2.New(awsSession), "RHEL-8*", r.Architecture)
+	return findLatestImage(ec2.New(awsSession), "RHEL-8*", r.amiArchitecture)
 }
 
 func (r RedHat8) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) {
@@ -81,11 +81,11 @@ func (r RedHat8) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) 
 	data := rhelCloudInitData{
 		UserDataInput: userDataInput,
 		NodeadmUrl:    userDataInput.NodeadmUrls.AMD,
-		RhelUsername:  r.RhelUsername,
-		RhelPassword:  r.RhelPassword,
+		RhelUsername:  r.rhelUsername,
+		RhelPassword:  r.rhelPassword,
 	}
 
-	if r.Architecture == arm64Arch {
+	if r.architecture.arm() {
 		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
 	}
 
@@ -93,42 +93,42 @@ func (r RedHat8) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) 
 }
 
 type RedHat9 struct {
-	RhelUsername string
-	RhelPassword string
-	Architecture string
+	rhelUsername    string
+	rhelPassword    string
+	amiArchitecture string
+	architecture    architecture
 }
 
 func NewRedHat9AMD(rhelUsername, rhelPassword string) *RedHat9 {
 	rh9 := new(RedHat9)
-	rh9.RhelUsername = rhelUsername
-	rh9.RhelPassword = rhelPassword
-	rh9.Architecture = x8664Arch
+	rh9.rhelUsername = rhelUsername
+	rh9.rhelPassword = rhelPassword
+	rh9.amiArchitecture = x8664Arch
+	rh9.architecture = amd64
 	return rh9
 }
 
 func NewRedHat9ARM(rhelUsername, rhelPassword string) *RedHat9 {
 	rh9 := new(RedHat9)
-	rh9.RhelUsername = rhelUsername
-	rh9.RhelPassword = rhelPassword
-	rh9.Architecture = arm64Arch
+	rh9.rhelUsername = rhelUsername
+	rh9.rhelPassword = rhelPassword
+	rh9.amiArchitecture = arm64Arch
+	rh9.architecture = arm64
 	return rh9
 }
 
 func (r RedHat9) Name() string {
-	if r.Architecture == x8664Arch {
-		return "rhel9-amd64"
-	}
-	return "rhel9-arm64"
+	return "rhel9-" + r.architecture.String()
 }
 
 func (r RedHat9) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, normalizeArch(r.Architecture))
+	return getInstanceTypeFromRegionAndArch(region, r.architecture)
 }
 
 func (r RedHat9) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
 	// there is no rhel ssm parameter
 	// aws ec2 describe-images --owners 309956199498 --query 'sort_by(Images, &CreationDate)[-1].[ImageId]' --filters "Name=name,Values=RHEL-9*" "Name=architecture,Values=x86_64" --region us-west-2
-	return findLatestImage(ec2.New(awsSession), "RHEL-9*", r.Architecture)
+	return findLatestImage(ec2.New(awsSession), "RHEL-9*", r.amiArchitecture)
 }
 
 func (r RedHat9) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) {
@@ -139,12 +139,12 @@ func (r RedHat9) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) 
 	data := rhelCloudInitData{
 		UserDataInput: userDataInput,
 		NodeadmUrl:    userDataInput.NodeadmUrls.AMD,
-		RhelUsername:  r.RhelUsername,
-		RhelPassword:  r.RhelPassword,
+		RhelUsername:  r.rhelUsername,
+		RhelPassword:  r.rhelPassword,
 		SSMAgentURL:   rhelSsmAgentAMD,
 	}
 
-	if r.Architecture == arm64Arch {
+	if r.architecture.arm() {
 		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
 		data.SSMAgentURL = rhelSsmAgentARM
 	}

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -42,45 +42,49 @@ func templateFuncMap() map[string]interface{} {
 }
 
 type Ubuntu2004 struct {
-	Architecture     string
-	ContainerdSource string
+	architecture     architecture
+	amiArchitecture  string
+	containerdSource string
 }
 
 func NewUbuntu2004AMD() *Ubuntu2004 {
 	u := new(Ubuntu2004)
-	u.Architecture = amd64Arch
-	u.ContainerdSource = "distro"
+	u.amiArchitecture = amd64Arch
+	u.architecture = amd64
+	u.containerdSource = "distro"
 	return u
 }
 
 func NewUbuntu2004DockerSource() *Ubuntu2004 {
 	u := new(Ubuntu2004)
-	u.Architecture = amd64Arch
-	u.ContainerdSource = "docker"
+	u.amiArchitecture = amd64Arch
+	u.architecture = amd64
+	u.containerdSource = "docker"
 	return u
 }
 
 func NewUbuntu2004ARM() *Ubuntu2004 {
 	u := new(Ubuntu2004)
-	u.Architecture = arm64Arch
-	u.ContainerdSource = "distro"
+	u.amiArchitecture = arm64Arch
+	u.architecture = arm64
+	u.containerdSource = "distro"
 	return u
 }
 
 func (u Ubuntu2004) Name() string {
-	name := "ubuntu2004-" + u.Architecture
-	if u.ContainerdSource == "docker" {
+	name := "ubuntu2004-" + u.architecture.String()
+	if u.containerdSource == "docker" {
 		name += "-docker"
 	}
 	return name
 }
 
 func (u Ubuntu2004) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, normalizeArch(u.Architecture))
+	return getInstanceTypeFromRegionAndArch(region, u.architecture)
 }
 
 func (u Ubuntu2004) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
-	amiId, err := getAmiIDFromSSM(ctx, ssm.New(awsSession), "/aws/service/canonical/ubuntu/server/20.04/stable/current/"+u.Architecture+"/hvm/ebs-gp2/ami-id")
+	amiId, err := getAmiIDFromSSM(ctx, ssm.New(awsSession), "/aws/service/canonical/ubuntu/server/20.04/stable/current/"+u.amiArchitecture+"/hvm/ebs-gp2/ami-id")
 	return *amiId, err
 }
 
@@ -94,11 +98,11 @@ func (u Ubuntu2004) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, erro
 		NodeadmUrl:    userDataInput.NodeadmUrls.AMD,
 	}
 
-	if u.Architecture == arm64Arch {
+	if u.architecture.arm() {
 		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
 	}
 
-	if u.ContainerdSource == "docker" {
+	if u.containerdSource == "docker" {
 		data.NodeadmAdditionalArgs = "--containerd-source docker"
 	}
 
@@ -106,45 +110,49 @@ func (u Ubuntu2004) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, erro
 }
 
 type Ubuntu2204 struct {
-	Architecture     string
-	ContainerdSource string
+	amiArchitecture  string
+	architecture     architecture
+	containerdSource string
 }
 
 func NewUbuntu2204AMD() *Ubuntu2204 {
 	u := new(Ubuntu2204)
-	u.Architecture = amd64Arch
-	u.ContainerdSource = "distro"
+	u.amiArchitecture = amd64Arch
+	u.architecture = amd64
+	u.containerdSource = "distro"
 	return u
 }
 
 func NewUbuntu2204DockerSource() *Ubuntu2204 {
 	u := new(Ubuntu2204)
-	u.Architecture = amd64Arch
-	u.ContainerdSource = "docker"
+	u.amiArchitecture = amd64Arch
+	u.architecture = amd64
+	u.containerdSource = "docker"
 	return u
 }
 
 func NewUbuntu2204ARM() *Ubuntu2204 {
 	u := new(Ubuntu2204)
-	u.Architecture = arm64Arch
-	u.ContainerdSource = "distro"
+	u.amiArchitecture = arm64Arch
+	u.architecture = arm64
+	u.containerdSource = "distro"
 	return u
 }
 
 func (u Ubuntu2204) Name() string {
-	name := "ubuntu2204-" + u.Architecture
-	if u.ContainerdSource == "docker" {
+	name := "ubuntu2204-" + u.architecture.String()
+	if u.containerdSource == "docker" {
 		name += "-docker"
 	}
 	return name
 }
 
 func (u Ubuntu2204) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, normalizeArch(u.Architecture))
+	return getInstanceTypeFromRegionAndArch(region, u.architecture)
 }
 
 func (u Ubuntu2204) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
-	amiId, err := getAmiIDFromSSM(ctx, ssm.New(awsSession), "/aws/service/canonical/ubuntu/server/22.04/stable/current/"+u.Architecture+"/hvm/ebs-gp2/ami-id")
+	amiId, err := getAmiIDFromSSM(ctx, ssm.New(awsSession), "/aws/service/canonical/ubuntu/server/22.04/stable/current/"+u.amiArchitecture+"/hvm/ebs-gp2/ami-id")
 	return *amiId, err
 }
 
@@ -158,11 +166,11 @@ func (u Ubuntu2204) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, erro
 		NodeadmUrl:    userDataInput.NodeadmUrls.AMD,
 	}
 
-	if u.Architecture == arm64Arch {
+	if u.architecture.arm() {
 		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
 	}
 
-	if u.ContainerdSource == "docker" {
+	if u.containerdSource == "docker" {
 		data.NodeadmAdditionalArgs = "--containerd-source docker"
 	}
 
@@ -170,45 +178,49 @@ func (u Ubuntu2204) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, erro
 }
 
 type Ubuntu2404 struct {
-	Architecture     string
-	ContainerdSource string
+	amiArchitecture  string
+	architecture     architecture
+	containerdSource string
 }
 
 func NewUbuntu2404AMD() *Ubuntu2404 {
 	u := new(Ubuntu2404)
-	u.Architecture = amd64Arch
-	u.ContainerdSource = "distro"
+	u.amiArchitecture = amd64Arch
+	u.architecture = amd64
+	u.containerdSource = "distro"
 	return u
 }
 
 func NewUbuntu2404DockerSource() *Ubuntu2404 {
 	u := new(Ubuntu2404)
-	u.Architecture = amd64Arch
-	u.ContainerdSource = "docker"
+	u.amiArchitecture = amd64Arch
+	u.architecture = amd64
+	u.containerdSource = "docker"
 	return u
 }
 
 func NewUbuntu2404ARM() *Ubuntu2404 {
 	u := new(Ubuntu2404)
-	u.Architecture = arm64Arch
-	u.ContainerdSource = "distro"
+	u.amiArchitecture = arm64Arch
+	u.architecture = arm64
+	u.containerdSource = "distro"
 	return u
 }
 
 func (u Ubuntu2404) Name() string {
-	name := "ubuntu2404-" + u.Architecture
-	if u.ContainerdSource == "docker" {
+	name := "ubuntu2404-" + u.architecture.String()
+	if u.containerdSource == "docker" {
 		name += "-docker"
 	}
 	return name
 }
 
 func (u Ubuntu2404) InstanceType(region string) string {
-	return getInstanceTypeFromRegionAndArch(region, normalizeArch(u.Architecture))
+	return getInstanceTypeFromRegionAndArch(region, u.architecture)
 }
 
 func (u Ubuntu2404) AMIName(ctx context.Context, awsSession *session.Session) (string, error) {
-	amiId, err := getAmiIDFromSSM(ctx, ssm.New(awsSession), "/aws/service/canonical/ubuntu/server/24.04/stable/current/"+u.Architecture+"/hvm/ebs-gp3/ami-id")
+	amiId, err := getAmiIDFromSSM(ctx, ssm.New(awsSession), "/aws/service/canonical/ubuntu/server/24.04/stable/current/"+u.amiArchitecture+"/hvm/ebs-gp3/ami-id")
 	return *amiId, err
 }
 
@@ -222,11 +234,11 @@ func (u Ubuntu2404) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, erro
 		NodeadmUrl:    userDataInput.NodeadmUrls.AMD,
 	}
 
-	if u.Architecture == arm64Arch {
+	if u.architecture.arm() {
 		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
 	}
 
-	if u.ContainerdSource == "docker" {
+	if u.containerdSource == "docker" {
 		data.NodeadmAdditionalArgs = "--containerd-source docker"
 	}
 


### PR DESCRIPTION
*Description of changes:*
We have probably overgrew the original architecture abstraction and we end ended up using it for multiple things. The differences between the ami arch name between OS made the code prone to errors and required having a lot of context to modify safely.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

