### PR TITLE
Fix make lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test-integration: ## Run integration tests.
 	test/integration/run.sh
 
 .PHONY: lint
-lint: $(GOLANGCI_LINT) ## Run golangci-lint.
+lint: golangci-lint ## Run golangci-lint.
 	$(GOLANGCI_LINT) run --new-from-rev main
 
 ##@ Build
@@ -181,6 +181,7 @@ $(GINKGO): $(LOCALBIN)
 update-deps:
 	$(GO) get $(shell $(GO) list -f '{{if not (or .Main .Indirect)}}{{.Path}}{{end}}' -mod=mod -m all) && $(GO) mod tidy
 
+.PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint.
 $(GOLANGCI_LINT): $(LOCALBIN) $(GOLANGCI_LINT_CONFIG)
 	$(eval GOLANGCI_LINT_VERSION?=$(shell cat .github/workflows/golangci-lint.yml | yq e '.jobs.golangci.steps[] | select(.name == "golangci-lint") .with.version' -))


### PR DESCRIPTION
*Description of changes:*
The GOLANGCI_LINT is defined after the lint target, which means that is empty if you only run make lint. If you haven't downloaded the binary before, this won't try to download the binary and will fail.

We could have instead moved the whole development block, but that also affects the order in which we show the blocks in the help. And I think development makes more sense at the top since it's more important. The other option wad to define the GOLANGCI_LINT variable at the top, but then we lose the nice encapsulation of having it defined in the build section with the targets that need it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

