### PR TITLE
fixes e2e cfn update flow

### DIFF
--- a/test/e2e/credentials/stack.go
+++ b/test/e2e/credentials/stack.go
@@ -137,7 +137,7 @@ func (s *Stack) deployStack(ctx context.Context, logger logr.Logger) error {
 			Capabilities: []*string{
 				aws.String("CAPABILITY_NAMED_IAM"),
 			},
-			TemplateBody: aws.String(string(cfnTemplateBody)),
+			TemplateBody: aws.String(buf.String()),
 			Parameters:   params,
 		})
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If running test with skip_cleanup, the second run will fail because we were passing the wrong string.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

