### PR TITLE
removes ubuntu 2404 apparmor fix

### DIFF
--- a/test/e2e/os/testdata/ubuntu/2404/cloud-init.txt
+++ b/test/e2e/os/testdata/ubuntu/2404/cloud-init.txt
@@ -8,53 +8,6 @@ users:
 package_update: true
 write_files:
   - content: |
-      #include <tunables/global>
-
-      profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
-        #include <abstractions/base>
-
-        network,
-        capability,
-        file,
-        umount,
-        # Host (privileged) processes may send signals to container processes.
-        signal (receive) peer=unconfined,
-        # runc may send signals to container processes.
-        signal (receive) peer=runc,
-        # crun may send signals to container processes.
-        signal (receive) peer=crun,
-        # Manager may send signals to container processes.
-        signal (receive) peer=cri-containerd.apparmor.d,
-        # Container processes may send signals amongst themselves.
-        signal (send,receive) peer=cri-containerd.apparmor.d,
-
-        deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
-        # deny write to files not in /proc/<number>/** or /proc/sys/**
-        deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
-        deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
-        deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
-        deny @{PROC}/sysrq-trigger rwklx,
-        deny @{PROC}/mem rwklx,
-        deny @{PROC}/kmem rwklx,
-        deny @{PROC}/kcore rwklx,
-
-        deny mount,
-
-        deny /sys/[^f]*/** wklx,
-        deny /sys/f[^s]*/** wklx,
-        deny /sys/fs/[^c]*/** wklx,
-        deny /sys/fs/c[^g]*/** wklx,
-        deny /sys/fs/cg[^r]*/** wklx,
-        deny /sys/firmware/** rwklx,
-        deny /sys/devices/virtual/powercap/** rwklx,
-        deny /sys/kernel/security/** rwklx,
-
-        # allow processes within the container to trace each other,
-        # provided all other LSM and yama setting allow it.
-        ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d,
-      }
-    path: /etc/apparmor.d/cri-containerd.apparmor.d
-  - content: |
 {{ .NodeadmConfigYaml | indent 6 }}
     path: nodeadm-config.yaml
 {{ range $file := .Files }}
@@ -67,7 +20,6 @@ write_files:
 {{- end }}
 
 runcmd:
-  - systemctl restart apparmor.service
   - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .NodeadmAdditionalArgs }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ubuntu pushed a new containerd, 1.7.19+really1.7.12-0ubuntu4.2, to 2404 this week.  This version includes the app armor fix. We can remove this workaround from our tests and docs.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

