### PR TITLE
drops the e2e node instance size

### DIFF
--- a/test/e2e/os/arch.go
+++ b/test/e2e/os/arch.go
@@ -80,10 +80,7 @@ func getAmiIDFromSSM(ctx context.Context, client *ssm.SSM, amiName string) (*str
 
 func getInstanceTypeFromRegionAndArch(region string, arch architecture) string {
 	if arch.amd() {
-		if region == "ap-southeast-5" {
-			return "m6i.large"
-		}
-		return "m5.2xlarge"
+		return "t3.large"
 	}
-	return "t4g.2xlarge"
+	return "t4g.large"
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I don't think we need to use such a large instance for these tests. Dropping this down until we see otherwise.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

