### PR TITLE
removes us of jq walk in e2e cleanup

### DIFF
--- a/hack/e2e-cleanup.sh
+++ b/hack/e2e-cleanup.sh
@@ -84,10 +84,12 @@ function get_cluster_name_from_tags(){
         return
     fi
 
-    # the iam roles anywhere api returns tags where key/value are lower case, whereas the other apis all start with a upper...
-    tags=$(echo $json | jq ".Tags | walk(if type==\"object\" then with_entries(.key|=ascii_downcase) else . end)")
-
-    cluster_name=$(echo $tags | jq -r "map(select(.key == \"$TEST_CLUSTER_TAG_KEY\"))[0].value")
+    cluster_name=$(echo $json | jq -r ".Tags | map(select(.Key == \"$TEST_CLUSTER_TAG_KEY\"))[0].Value")
+    if [ -z "$cluster_name" ] || [ "$cluster_name" == "null" ]; then
+        # the iam roles anywhere api returns tags where key/value are lower case, whereas the other apis all start with a upper...
+        cluster_name=$(echo $json | jq -r ".Tags | map(select(.key == \"$TEST_CLUSTER_TAG_KEY\"))[0].value")       
+    fi
+    
     if [ -z "$cluster_name" ] || [ "$cluster_name" == "null" ]; then
         echo ""
         return


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We use the jq version provided by al2 in some cases, which does not support the walk command.  The only reason we were doing it was to avoid having to check for Key/Value and key/value.  Removed the walk in favor of two calls.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

