### PR TITLE
Fix issue with creating IRA resource

### DIFF
--- a/test/e2e/credentials/stack.go
+++ b/test/e2e/credentials/stack.go
@@ -100,7 +100,7 @@ func (s *Stack) deployStack(ctx context.Context, logger logr.Logger) error {
 	if err != nil {
 		return fmt.Errorf("parsing hybrid-cfn.yaml template: %w", err)
 	}
-	cfnTemplateConfig := &hybridCfnTemplateVars{IncludeRolesAnywhere: isIraSupported()}
+	cfnTemplateConfig := &hybridCfnTemplateVars{IncludeRolesAnywhere: !skipIRATest()}
 	err = cfnTemplate.Execute(&buf, cfnTemplateConfig)
 	if err != nil {
 		return fmt.Errorf("applying data to hybrid-cfn.yaml template: %w", err)
@@ -292,6 +292,6 @@ func isNotFound(err error) bool {
 	return err != nil && ok && aerr.Code() == "NoSuchEntity"
 }
 
-func isIraSupported() bool {
-	return os.Getenv("SKIP_IRA_TEST") != "false"
+func skipIRATest() bool {
+	return os.Getenv("SKIP_IRA_TEST") == "true"
 }


### PR DESCRIPTION
Fix issue with creating IRA resource.

Check if SKIP_IRA_TEST is set to true and only create IRA resources if the value is not true.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

