### PR TITLE
Fix linter errors

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,7 +26,6 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.61.0
-          only-new-issues: true
           # Disable package caching to avoid a double cache with setup-go.
           skip-pkg-cache: true
           args: --timeout 10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,10 @@
 run:
   timeout: 5m
-  skip-files:
-    - "zz_generated.*\\.go$"
+  build-tags:
+    - e2e
+issues:
+  exclude-files:
+  - "zz_generated.*\\.go$"
 linters:
   enable:
     - gofumpt

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ test-integration: ## Run integration tests.
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint.
-	$(GOLANGCI_LINT) run --new-from-rev main
+	$(GOLANGCI_LINT) run -v
 
 ##@ Build
 

--- a/internal/kubelet/config.go
+++ b/internal/kubelet/config.go
@@ -462,7 +462,7 @@ func (k *kubelet) writeKubeletConfigToDir() error {
 		return err
 	}
 
-	if k.nodeConfig.Spec.Kubelet.Config != nil && len(k.nodeConfig.Spec.Kubelet.Config) > 0 {
+	if len(k.nodeConfig.Spec.Kubelet.Config) > 0 {
 		dirPath := path.Join(kubeletConfigRoot, kubeletConfigDir)
 		k.flags["config-dir"] = dirPath
 

--- a/internal/kubelet/config.go
+++ b/internal/kubelet/config.go
@@ -202,10 +202,6 @@ func (ksc *kubeletConfig) withOutpostSetup(cfg *api.NodeConfig) error {
 		}
 		output := strings.Join(ipHostMappings, "\n") + "\n"
 
-		if err != nil {
-			return err
-		}
-
 		// append to /etc/hosts file with shuffled mappings of "IP address to API server domain name"
 		f, err := os.OpenFile("/etc/hosts", os.O_APPEND|os.O_WRONLY, kubeletConfigPerm)
 		if err != nil {
@@ -422,7 +418,7 @@ func (k *kubelet) writeKubeletConfigToFile() error {
 	}
 
 	var kubeletConfigBytes []byte
-	if k.nodeConfig.Spec.Kubelet.Config != nil && len(k.nodeConfig.Spec.Kubelet.Config) > 0 {
+	if len(k.nodeConfig.Spec.Kubelet.Config) > 0 {
 		mergedMap, err := util.DocumentMerge(kubeletConfig, k.nodeConfig.Spec.Kubelet.Config, mergo.WithOverride)
 		if err != nil {
 			return err

--- a/internal/ssm/daemon.go
+++ b/internal/ssm/daemon.go
@@ -18,9 +18,8 @@ var (
 	_             daemon.Daemon = &ssm{}
 	SsmDaemonName               = "amazon-ssm-agent"
 
-	checksumMismatchErrorRegex = regexp.MustCompile(`.*checksum mismatch with latest ssm-setup-cli*`)
-	activationExpiredRegex     = regexp.MustCompile(`.*ActivationExpired*`)
-	invalidActivationRegex     = regexp.MustCompile(`.*InvalidActivation*`)
+	activationExpiredRegex = regexp.MustCompile(`.*ActivationExpired*`)
+	invalidActivationRegex = regexp.MustCompile(`.*InvalidActivation*`)
 )
 
 const (

--- a/internal/ssm/install.go
+++ b/internal/ssm/install.go
@@ -115,19 +115,3 @@ func uninstallPreRegisterComponents(ctx context.Context, pkgSource PkgSource) er
 	}
 	return os.RemoveAll(installerPath)
 }
-
-// redownloadInstaller deletes and downloads a new ssm installer
-func redownloadInstaller(region string) error {
-	if err := os.RemoveAll(installerPath); err != nil {
-		return err
-	}
-	trackerConf, err := tracker.GetCurrentState()
-	if err != nil {
-		return err
-	}
-	installer := NewSSMInstaller(region)
-	if err := Install(context.Background(), trackerConf, installer); err != nil {
-		return errors.Wrapf(err, "failed to install ssm installer")
-	}
-	return trackerConf.Save()
-}

--- a/test/e2e/aws.go
+++ b/test/e2e/aws.go
@@ -2,20 +2,7 @@ package e2e
 
 import (
 	"regexp"
-
-	"github.com/aws/aws-sdk-go/aws/awserr"
 )
-
-func isErrCode(err error, code string) bool {
-	if err == nil {
-		return false
-	}
-	if awsErr, ok := err.(awserr.Error); ok {
-		return awsErr.Code() == code
-	}
-
-	return false
-}
 
 // SanitizeForAWSName removes everything except alphanumeric characters and hyphens from a string.
 func SanitizeForAWSName(input string) string {

--- a/test/e2e/credentials/certificate.go
+++ b/test/e2e/credentials/certificate.go
@@ -59,10 +59,13 @@ func CreateCA() (*Certificate, error) {
 	}
 
 	caPEM := new(bytes.Buffer)
-	pem.Encode(caPEM, &pem.Block{
+	err = pem.Encode(caPEM, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: caBytes,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("encoding CA certificate: %w", err)
+	}
 
 	privateKeyBytes, err := x509.MarshalECPrivateKey(privateKey)
 	if err != nil {
@@ -70,7 +73,9 @@ func CreateCA() (*Certificate, error) {
 	}
 
 	keyPEM := new(bytes.Buffer)
-	pem.Encode(keyPEM, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyBytes})
+	if err := pem.Encode(keyPEM, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyBytes}); err != nil {
+		return nil, fmt.Errorf("encoding private key: %w", err)
+	}
 
 	if err := os.WriteFile(caCertFile, caPEM.Bytes(), 0o600); err != nil {
 		return nil, fmt.Errorf("writing CA cert to file: %w", err)
@@ -121,10 +126,13 @@ func CreateCertificateForNode(ca *x509.Certificate, caPrivKey any, nodeName stri
 	}
 
 	certPEM := new(bytes.Buffer)
-	pem.Encode(certPEM, &pem.Block{
+	err = pem.Encode(certPEM, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: certBytes,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("encoding certificate: %w", err)
+	}
 
 	privateKeyBytes, err := x509.MarshalECPrivateKey(privateKey)
 	if err != nil {
@@ -132,7 +140,9 @@ func CreateCertificateForNode(ca *x509.Certificate, caPrivKey any, nodeName stri
 	}
 
 	keyPEM := new(bytes.Buffer)
-	pem.Encode(keyPEM, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyBytes})
+	if err := pem.Encode(keyPEM, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyBytes}); err != nil {
+		return nil, fmt.Errorf("encoding private key: %w", err)
+	}
 
 	return &Certificate{
 		CertPEM: certPEM.Bytes(),

--- a/test/e2e/os/arch.go
+++ b/test/e2e/os/arch.go
@@ -78,7 +78,7 @@ func getAmiIDFromSSM(ctx context.Context, client *ssm.SSM, amiName string) (*str
 	return output.Parameter.Value, nil
 }
 
-func getInstanceTypeFromRegionAndArch(region string, arch architecture) string {
+func getInstanceTypeFromRegionAndArch(_ string, arch architecture) string {
 	if arch.amd() {
 		return "t3.large"
 	}

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
+
 	"github.com/aws/eks-hybrid/test/e2e"
 )
 

--- a/test/e2e/ssm/command.go
+++ b/test/e2e/ssm/command.go
@@ -17,39 +17,6 @@ type ssmConfig struct {
 	commands   []string
 }
 
-func (s *ssmConfig) runCommandsOnInstance(ctx context.Context, logger logr.Logger) ([]ssm.GetCommandInvocationOutput, error) {
-	outputs := []ssm.GetCommandInvocationOutput{}
-	for _, command := range s.commands {
-		logger.Info("Running command: ", "command", command)
-		input := &ssm.SendCommandInput{
-			DocumentName: aws.String("AWS-RunShellScript"),
-			Parameters: map[string][]*string{
-				"commands": aws.StringSlice([]string{command}),
-			},
-			InstanceIds: []*string{aws.String(s.instanceID)},
-		}
-		output, err := s.client.SendCommandWithContext(ctx, input)
-		// Retry if the ThrottlingException occurred
-		for err != nil && isThrottlingException(err) {
-			logger.Info("ThrottlingException encountered, retrying..")
-			output, err = s.client.SendCommandWithContext(ctx, input)
-		}
-		invocationInput := &ssm.GetCommandInvocationInput{
-			CommandId:  output.Command.CommandId,
-			InstanceId: aws.String(s.instanceID),
-		}
-		// Will wait on Pending, InProgress, or Cancelling until we reach a terminal status of Success, Cancelled, Failed, TimedOut
-		_ = s.client.WaitUntilCommandExecutedWithContext(ctx, invocationInput)
-		invocationOutput, err := s.client.GetCommandInvocationWithContext(ctx, invocationInput)
-		if err != nil {
-			return nil, fmt.Errorf("got an error calling GetCommandInvocation: %w", err)
-		}
-		logger.Info("Command output", "output", invocationOutput.String())
-		outputs = append(outputs, *invocationOutput)
-	}
-	return outputs, nil
-}
-
 func (s *ssmConfig) runCommandsOnInstanceWaitForInProgress(ctx context.Context, logger logr.Logger) ([]ssm.GetCommandInvocationOutput, error) {
 	outputs := []ssm.GetCommandInvocationOutput{}
 	logger.Info(fmt.Sprintf("Running command: %v\n", s.commands))

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	clientgo "k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
 
@@ -80,18 +79,17 @@ func TestE2E(t *testing.T) {
 }
 
 type peeredVPCTest struct {
-	aws             awsconfig.Config // TODO: move everything to aws sdk v2
-	awsSession      *session.Session
-	eksClient       *eks.EKS
-	ec2Client       *ec2v1.EC2
-	ec2ClientV2     *ec2v2.Client
-	ssmClient       *ssmv1.SSM
-	ssmClientV2     *ssmv2.Client
-	cfnClient       *cloudformation.CloudFormation
-	k8sClient       *clientgo.Clientset
-	k8sClientConfig *restclient.Config
-	s3Client        *s3v1.S3
-	iamClient       *iam.IAM
+	aws         awsconfig.Config // TODO: move everything to aws sdk v2
+	awsSession  *session.Session
+	eksClient   *eks.EKS
+	ec2Client   *ec2v1.EC2
+	ec2ClientV2 *ec2v2.Client
+	ssmClient   *ssmv1.SSM
+	ssmClientV2 *ssmv2.Client
+	cfnClient   *cloudformation.CloudFormation
+	k8sClient   *clientgo.Clientset
+	s3Client    *s3v1.S3
+	iamClient   *iam.IAM
 
 	logger logr.Logger
 


### PR DESCRIPTION
## Description of changes
Just ran the `golangci-lint` and fixed all issues (for the linters we have enabled). I separated the changes with one lint error per commit for easier review.

Now we run the linter globally and not only on new changes. This avoids issues being introduced by two PRs merging without being aware of each other.

As a bonus, I fixed the linter config since it was using deprecated fields.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

