### PR TITLE
improves swap partition checking

### DIFF
--- a/test/integration/.dockerignore
+++ b/test/integration/.dockerignore
@@ -1,3 +1,0 @@
-# we don't want to constantly invalidate the build cache while we're writing a new test case
-cases/
-run.sh

--- a/test/integration/cases/init-with-swap-partition/config.yaml
+++ b/test/integration/cases/init-with-swap-partition/config.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+    region: us-west-2
+  hybrid:
+    iamRolesAnywhere:
+      nodeName: mock-hybrid-node
+      awsConfigPath: /.aws/config
+      roleArn: arn:aws:iam::123456789010:role/mockHybridNodeRole
+      profileArn: arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole
+      trustAnchorArn: arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7

--- a/test/integration/cases/init-with-swap-partition/run.sh
+++ b/test/integration/cases/init-with-swap-partition/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+mock::kubelet 1.30.0
+wait::dbus-ready
+
+mkdir -p /etc/iam/pki
+touch /etc/iam/pki/server.pem
+touch /etc/iam/pki/server.key
+
+nodeadm install 1.30  --credential-provider iam-ra
+
+mount --bind $(pwd)/swaps-partition /proc/swaps
+assert::path-exists /usr/bin/containerd
+
+exit_code=0
+STDERR=$(nodeadm init --config-source file://config.yaml 2>&1) || exit_code=$?
+if [ $exit_code -ne 0 ]; then
+    assert::is-substring "$STDERR" "partition type swap found on the host"
+else
+    echo "nodeadm init should have failed with: partition type swap found on the host"
+    exit 1
+fi
+
+mount --bind $(pwd)/swaps-file /proc/swaps
+if ! nodeadm init --skip run --config-source file://config.yaml; then
+    echo "nodeadm should have successfully completed init"
+    exit 1
+fi
+
+# Check if swap has been disabled and partition removed from /etc/fstab
+assert::file-not-contains /etc/fstab "swap"
+assert::swap-disabled-validate-path

--- a/test/integration/cases/init-with-swap-partition/swaps-file
+++ b/test/integration/cases/init-with-swap-partition/swaps-file
@@ -1,0 +1,2 @@
+Filename				Type		Size	Used	Priority
+/swap.img               file	6291448	65680	0

--- a/test/integration/cases/init-with-swap-partition/swaps-partition
+++ b/test/integration/cases/init-with-swap-partition/swaps-partition
@@ -1,0 +1,2 @@
+Filename				Type		Size	Used	Priority
+/dev/sda3               partition	6291448	65680	0

--- a/test/integration/infra/.dockerignore
+++ b/test/integration/infra/.dockerignore
@@ -1,3 +1,0 @@
-test/integration/cases/
-test/integration/run.sh
-_bin/

--- a/test/integration/infra/Dockerfile
+++ b/test/integration/infra/Dockerfile
@@ -1,13 +1,14 @@
-FROM golang:1.23 AS imds-mock-build
-ARG GOPROXY
-RUN go env -w GOPROXY=${GOPROXY}
-RUN GOBIN=/bin go install github.com/aws/amazon-ec2-metadata-mock/cmd@v1.11.2
-RUN mv /bin/cmd /imds-mock
+FROM public.ecr.aws/eks-distro-build-tooling/golang:1.23 AS imds-mock-build
+ARG TARGETARCH
+RUN curl -Lo /imds-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v1.12.0/ec2-metadata-mock-linux-${TARGETARCH}
+RUN chmod +x /imds-mock
 
-FROM golang:1.23 AS nodeadm-build
+FROM public.ecr.aws/eks-distro-build-tooling/golang:1.23 AS nodeadm-build
 WORKDIR /go/src/github.com/aws/eks-hybrid
 ARG GOPROXY
 RUN go env -w GOPROXY=${GOPROXY}
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
 RUN make build
 RUN mv _bin/nodeadm /nodeadm

--- a/test/integration/infra/Dockerfile.dockerignore
+++ b/test/integration/infra/Dockerfile.dockerignore
@@ -1,0 +1,3 @@
+test/integration/cases
+test/integration/run.sh
+_bin


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If nodeadm detects a swap partition, it errors out to the user to disable that.  If its a file, it can remove/disable it.  The logic that checked for this was exec swapon/awk.  This changes the code to be more like kubeadm's preflight check.  Added a new integration test to validate this.

Improved integration tests docker setup:
- fixed the dockerignore location/paths
- use public ecr golang image from eksd
- pull mock metadata built artifact instead of go install
- copy go.mod/sum and run download to improve rerun caching

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

