### PR TITLE
fixes cleanup script running on al2's bash

### DIFF
--- a/hack/e2e-cleanup.sh
+++ b/hack/e2e-cleanup.sh
@@ -389,8 +389,8 @@ done
 # This deletion is retried since in some cases it has to be remade with the force flag
 # If the cluster-name is passed to the script, only stacks who's tag matches that cluster
 # are deleted
-ARCH_STACKS=()
-TEST_STACKS=()
+declare -A ARCH_STACKS=()
+declare -A TEST_STACKS=()
 for stack in $(aws cloudformation describe-stacks --query "Stacks[*].{StackId:StackId,CreationTime:CreationTime,StackName:StackName,StackStatus:StackStatus,Tags:Tags} | reverse(sort_by(@, &CreationTime))" --output json | jq -c '.[]'); do
     stack_name=$(echo $stack | jq -r ".StackName")
     if [[ $stack_name != EKSHybridCI-* ]]; then

--- a/hack/e2e-cleanup.sh
+++ b/hack/e2e-cleanup.sh
@@ -389,8 +389,8 @@ done
 # This deletion is retried since in some cases it has to be remade with the force flag
 # If the cluster-name is passed to the script, only stacks who's tag matches that cluster
 # are deleted
-declare -A ARCH_STACKS=()
-declare -A TEST_STACKS=()
+ARCH_STACKS=()
+TEST_STACKS=()
 for stack in $(aws cloudformation describe-stacks --query "Stacks[*].{StackId:StackId,CreationTime:CreationTime,StackName:StackName,StackStatus:StackStatus,Tags:Tags} | reverse(sort_by(@, &CreationTime))" --output json | jq -c '.[]'); do
     stack_name=$(echo $stack | jq -r ".StackName")
     if [[ $stack_name != EKSHybridCI-* ]]; then
@@ -407,7 +407,7 @@ for stack in $(aws cloudformation describe-stacks --query "Stacks[*].{StackId:St
     fi
 done
 
-for stack in ${TEST_STACKS[@]}; do
+for stack in "${TEST_STACKS[@]}"; do
     delete_stack "$stack"
 done
 
@@ -425,7 +425,7 @@ else
     done
 fi
 
-for stack in ${ARCH_STACKS[@]}; do
+for stack in "${ARCH_STACKS[@]}"; do
     delete_stack "$stack"
 done
 

--- a/hack/e2e-cleanup.sh
+++ b/hack/e2e-cleanup.sh
@@ -407,9 +407,11 @@ for stack in $(aws cloudformation describe-stacks --query "Stacks[*].{StackId:St
     fi
 done
 
-for stack in "${TEST_STACKS[@]}"; do
-    delete_stack "$stack"
-done
+if [ "${#TEST_STACKS[@]}" -gt 0 ]; then
+    for stack in "${TEST_STACKS[@]}"; do
+        delete_stack "$stack"
+    done
+fi
 
 # When a cluster name is supplied it along with all its resources are deleted
 # No other resources are deleted
@@ -425,9 +427,11 @@ else
     done
 fi
 
-for stack in "${ARCH_STACKS[@]}"; do
-    delete_stack "$stack"
-done
+if [ "${#ARCH_STACKS[@]}" -gt 0 ]; then
+    for stack in "${ARCH_STACKS[@]}"; do
+        delete_stack "$stack"
+    done
+fi
 
 if [[ "${SKIP_IRA_TEST:-false}" == "false" ]]; then
     # See note above about roles

--- a/hybrid-nodes-cdk/lib/constants.ts
+++ b/hybrid-nodes-cdk/lib/constants.ts
@@ -1,4 +1,4 @@
-export const builderBaseImage = 'public.ecr.aws/eks-distro-build-tooling/builder-base:standard-latest.al23';
+export const builderBaseImage = 'public.ecr.aws/eks-distro-build-tooling/builder-base:standard-latest.al2';
 export const kubernetesVersions = ['1.25', '1.26', '1.27', '1.28', '1.29', '1.30', '1.31'];
 export const cnis = ['calico', 'cilium'];
 export const eksHybridBetaBucketARN = 'arn:aws:s3:::eks-hybrid-beta';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When running on al2's bash this syntax will fail due to the missing declare.  Changed dev stack to use al2 image for cleanup job.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

