### PR TITLE
use region ecr for nginx container

### DIFF
--- a/buildspecs/ecr-cache.yml
+++ b/buildspecs/ecr-cache.yml
@@ -5,4 +5,5 @@ phases:
     commands:
     - mkdir -p /root/.docker && cp hack/docker-ecr-config.json /root/.docker/config.json
     - ./test/e2e/cni/testdata/cilium/mirror-cilium.sh
-    - ./test/e2e/cni/testdata/calico/mirror-calico.sh 
+    - ./test/e2e/cni/testdata/calico/mirror-calico.sh
+    - for region in "us-west-2" "us-west-1"; do docker buildx imagetools inspect "381492195191.dkr.ecr.${region}.amazonaws.com/ecr-public/nginx/nginx:latest"; done

--- a/test/e2e/kubernetes/kubernetes.go
+++ b/test/e2e/kubernetes/kubernetes.go
@@ -22,6 +22,8 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubectl/pkg/drain"
+
+	"github.com/aws/eks-hybrid/test/e2e/constants"
 )
 
 const (
@@ -158,7 +160,7 @@ func GetNginxPodName(name string) string {
 	return "nginx-" + name
 }
 
-func CreateNginxPodInNode(ctx context.Context, k8s *kubernetes.Clientset, nodeName, namespace string, logger logr.Logger) error {
+func CreateNginxPodInNode(ctx context.Context, k8s *kubernetes.Clientset, nodeName, namespace, region string, logger logr.Logger) error {
 	podName := GetNginxPodName(nodeName)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -169,7 +171,7 @@ func CreateNginxPodInNode(ctx context.Context, k8s *kubernetes.Clientset, nodeNa
 			Containers: []corev1.Container{
 				{
 					Name:  "nginx",
-					Image: "public.ecr.aws/nginx/nginx:latest",
+					Image: fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/ecr-public/nginx/nginx:latest", constants.EcrAccounId, region),
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: 80,

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -266,6 +266,7 @@ var _ = Describe("Hybrid Nodes", func() {
 								k8s:           test.k8sClient,
 								nodeIPAddress: instance.IP,
 								logger:        test.logger,
+								region:        test.cluster.Region,
 							}
 							Expect(joinNodeTest.Run(ctx)).To(Succeed(), "node should have joined the cluster successfully")
 
@@ -344,6 +345,7 @@ var _ = Describe("Hybrid Nodes", func() {
 								k8s:           test.k8sClient,
 								nodeIPAddress: instance.IP,
 								logger:        test.logger,
+								region:        test.cluster.Region,
 							}
 							Expect(joinNodeTest.Run(ctx)).To(Succeed(), "node should have joined the cluster sucessfully")
 
@@ -501,6 +503,7 @@ type joinNodeTest struct {
 	k8s           *clientgo.Clientset
 	nodeIPAddress string
 	logger        logr.Logger
+	region        string
 }
 
 func (t joinNodeTest) Run(ctx context.Context) error {
@@ -522,7 +525,7 @@ func (t joinNodeTest) Run(ctx context.Context) error {
 
 	t.logger.Info("Creating a test pod on the hybrid node...")
 	podName := kubernetes.GetNginxPodName(nodeName)
-	if err = kubernetes.CreateNginxPodInNode(ctx, t.k8s, nodeName, podNamespace, t.logger); err != nil {
+	if err = kubernetes.CreateNginxPodInNode(ctx, t.k8s, nodeName, podNamespace, t.region, t.logger); err != nil {
 		return err
 	}
 	t.logger.Info(fmt.Sprintf("Pod %s created and running on node %s", podName, nodeName))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The build account now has the nginx image in the regional ecr repos, like the other CNI images.  This changes the test to use the region ecr instead of public ecr.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

