### PR TITLE
adds wait for containerd service

### DIFF
--- a/internal/containerd/daemon.go
+++ b/internal/containerd/daemon.go
@@ -2,8 +2,11 @@ package containerd
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"go.uber.org/zap"
 
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/daemon"
@@ -20,13 +23,15 @@ type containerd struct {
 	daemonManager daemon.DaemonManager
 	nodeConfig    *api.NodeConfig
 	awsConfig     *aws.Config
+	logger        *zap.Logger
 }
 
-func NewContainerdDaemon(daemonManager daemon.DaemonManager, cfg *api.NodeConfig, awsConfig *aws.Config) daemon.Daemon {
+func NewContainerdDaemon(daemonManager daemon.DaemonManager, cfg *api.NodeConfig, awsConfig *aws.Config, logger *zap.Logger) daemon.Daemon {
 	return &containerd{
 		daemonManager: daemonManager,
 		nodeConfig:    cfg,
 		awsConfig:     awsConfig,
+		logger:        logger,
 	}
 }
 
@@ -44,11 +49,25 @@ func (cd *containerd) EnsureRunning(ctx context.Context) error {
 	if err := cd.daemonManager.RestartDaemon(ctx, kernelModulesSystemdUnit); err != nil {
 		return err
 	}
-	err := cd.daemonManager.EnableDaemon(ContainerdDaemonName)
-	if err != nil {
+
+	if err := cd.daemonManager.EnableDaemon(ContainerdDaemonName); err != nil {
 		return err
 	}
-	return cd.daemonManager.RestartDaemon(ctx, ContainerdDaemonName)
+
+	if err := cd.daemonManager.RestartDaemon(ctx, ContainerdDaemonName); err != nil {
+		return err
+	}
+
+	runningCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	cd.logger.Info("Waiting for containerd to be running...")
+	if err := daemon.WaitForStatus(runningCtx, cd.logger, cd.daemonManager, ContainerdDaemonName, daemon.DaemonStatusRunning, 5*time.Second); err != nil {
+		return fmt.Errorf("waiting for containerd to be running: %w", err)
+	}
+	cd.logger.Info("containerd is running")
+
+	return nil
 }
 
 func (cd *containerd) PostLaunch() error {

--- a/internal/node/ec2/daemons.go
+++ b/internal/node/ec2/daemons.go
@@ -24,7 +24,7 @@ func (enp *ec2NodeProvider) GetDaemons() ([]daemon.Daemon, error) {
 		return nil, errors.New("aws config not set")
 	}
 	return []daemon.Daemon{
-		containerd.NewContainerdDaemon(enp.daemonManager, enp.nodeConfig, enp.awsConfig),
+		containerd.NewContainerdDaemon(enp.daemonManager, enp.nodeConfig, enp.awsConfig, enp.logger),
 		kubelet.NewKubeletDaemon(enp.daemonManager, enp.nodeConfig, enp.awsConfig),
 	}, nil
 }

--- a/internal/node/hybrid/daemons.go
+++ b/internal/node/hybrid/daemons.go
@@ -25,7 +25,7 @@ func (hnp *HybridNodeProvider) GetDaemons() ([]daemon.Daemon, error) {
 		return nil, errors.New("aws config not set")
 	}
 	return []daemon.Daemon{
-		containerd.NewContainerdDaemon(hnp.daemonManager, hnp.nodeConfig, hnp.awsConfig),
+		containerd.NewContainerdDaemon(hnp.daemonManager, hnp.nodeConfig, hnp.awsConfig, hnp.logger),
 		kubelet.NewKubeletDaemon(hnp.daemonManager, hnp.nodeConfig, hnp.awsConfig),
 	}, nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We added WaitForStatus for the SSM agent [install](https://github.com/aws/eks-hybrid/blob/a78d6765835e19fd2cb873832676a87f5f75c2d3/internal/ssm/daemon.go#L78) because we were running into issues where we would try to use the AWS creds before ssm had been fully activated.

We have a similar case with containerd, where after installing we attempt to pull the sandbox image.  The first time this image is pulled it will usually fail because containerd is not fully running, but this usually fixes itself by the second attempt.  

I have noticed 1 test failure due to this where containerd had not come up before the sandbox pull retries were exhausted, which is only 3 right now.

Adding a WaitForStatus here will solve both:
- the annoying "error" message when it fails to pull the first time
- avoiding running out of retires and failing the init process

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

