### PR TITLE
adds retries to package install/uninstalls

### DIFF
--- a/internal/artifact/install.go
+++ b/internal/artifact/install.go
@@ -55,26 +55,14 @@ func InstallTarGz(dst, src string) error {
 	return nil
 }
 
-func InstallPackage(ctx context.Context, pkgSource Package) error {
-	installCmd := pkgSource.InstallCmd(ctx)
-	out, err := installCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("running install command using package manager: %s, err: %v", out, err)
-	}
-	return nil
-}
-
 // InstallPackageWithRetries installs a package and retries errors until the context is
 // cancelled. The backoff duration is the time to wait between retries.
 func InstallPackageWithRetries(ctx context.Context, pkgSource Package, backoff time.Duration) error {
 	return cmd.Retry(ctx, pkgSource.InstallCmd, backoff)
 }
 
-func UninstallPackage(ctx context.Context, pkgSource Package) error {
-	uninstallCmd := pkgSource.UninstallCmd(ctx)
-	out, err := uninstallCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("running uninstall command using package manager: %s, err: %v", out, err)
-	}
-	return nil
+// UninstallPackageWithRetries uninstalls a package and retries errors until the context is
+// cancelled. The backoff duration is the time to wait between retries.
+func UninstallPackageWithRetries(ctx context.Context, pkgSource Package, backoff time.Duration) error {
+	return cmd.Retry(ctx, pkgSource.UninstallCmd, backoff)
 }

--- a/internal/containerd/install.go
+++ b/internal/containerd/install.go
@@ -51,7 +51,7 @@ func Install(ctx context.Context, tracker *tracker.Tracker, source Source, conta
 func Uninstall(ctx context.Context, source Source) error {
 	if isContainerdInstalled() {
 		containerd := source.GetContainerd()
-		if err := artifact.UninstallPackage(ctx, containerd); err != nil {
+		if err := artifact.UninstallPackageWithRetries(ctx, containerd, 5*time.Second); err != nil {
 			return errors.Wrap(err, "failed to uninstall containerd")
 		}
 

--- a/internal/iptables/iptables.go
+++ b/internal/iptables/iptables.go
@@ -37,7 +37,7 @@ func Install(ctx context.Context, tracker *tracker.Tracker, source Source) error
 func Uninstall(ctx context.Context, source Source) error {
 	if isIptablesInstalled() {
 		iptablesSrc := source.GetIptables()
-		if err := artifact.UninstallPackage(ctx, iptablesSrc); err != nil {
+		if err := artifact.UninstallPackageWithRetries(ctx, iptablesSrc, 5*time.Second); err != nil {
 			return errors.Wrap(err, "failed to uninstall iptables")
 		}
 	}

--- a/internal/ssm/install.go
+++ b/internal/ssm/install.go
@@ -110,7 +110,7 @@ func Uninstall(ctx context.Context, logger *zap.Logger, pkgSource PkgSource) err
 
 func uninstallPreRegisterComponents(ctx context.Context, pkgSource PkgSource) error {
 	ssmPkg := pkgSource.GetSSMPackage()
-	if err := artifact.UninstallPackage(ctx, ssmPkg); err != nil {
+	if err := artifact.UninstallPackageWithRetries(ctx, ssmPkg, 5*time.Second); err != nil {
 		return errors.Wrapf(err, "failed to uninstall ssm")
 	}
 	return os.RemoveAll(installerPath)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We added retries for installing containerd/iptables previously, but I have seen a couple e2e failures due to failure to install yum-utils on rhel, since we need it to register the docker repo to install containerd/runc.  

This adds the retries to all the package installs (yum-utils, ca-certs) and adds a UninstallWithRetries method for all package removals.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

