### PR TITLE
Invoke log collector script with eks_hybrid flag

### DIFF
--- a/test/e2e/os/testdata/log-collector.sh
+++ b/test/e2e/os/testdata/log-collector.sh
@@ -21,7 +21,7 @@ LOG_SCRIPT_URL="https://raw.githubusercontent.com/awslabs/amazon-eks-ami/refs/he
 
 curl -s --retry 5  $LOG_SCRIPT_URL -o /tmp/eks-log-collector.sh
 
-bash /tmp/eks-log-collector.sh
+bash /tmp/eks-log-collector.sh --eks_hybrid=true
 
 if ls /var/log/eks_* > /dev/null 2>&1; then
     # do not overwrite if the file is already there


### PR DESCRIPTION
Now we can invoke log collector script with the `eks_hybrid` flag, which will avoid IMDS collection and queries for AWS region and EC2 instance ID.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

