### PR TITLE
use ref instead getatt for instanceid in setup stack

### DIFF
--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -396,7 +396,7 @@ Outputs:
 
   JumpboxInstanceId:
     Description: Instance ID of Jumpbox.
-    Value: !GetAtt Jumpbox.InstanceId
+    Value: !Ref Jumpbox
   
   JumpboxKeyPairSSMParameter:
     Description: SSM parameter storing key pair private key


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ran into an issue in the ap-southeast-5 region where this GetAtt syntax was invalid for InstanceId for some reason, works in all other regions.  We can just use Ref against the instance directly which returns the default resource id, which for Instance is the Id.

Side note, we dont even use these cfn outputs... leaving them for now, but we may eventually want to just get rid of them if we dont need them.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

