### PR TITLE
changes e2e log collection to happen only once

### DIFF
--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -28,7 +28,6 @@ type UserDataInput struct {
 	PublicKey         string
 	RootPasswordHash  string
 	Files             []File
-	LogsUploadUrls    []LogsUploadUrl
 }
 
 type NodeadmURLs struct {

--- a/test/e2e/nodeadm/commands.go
+++ b/test/e2e/nodeadm/commands.go
@@ -9,8 +9,6 @@ import (
 
 func RunNodeadmUninstall(ctx context.Context, runner commands.RemoteCommandRunner, instanceIP string) error {
 	commands := []string{
-		"set -eux",
-		"trap \"/tmp/log-collector.sh 'post-uninstall' 'post-final-uninstall'\" EXIT",
 		"/tmp/nodeadm uninstall",
 	}
 
@@ -28,8 +26,6 @@ func RunNodeadmUninstall(ctx context.Context, runner commands.RemoteCommandRunne
 
 func RunNodeadmUpgrade(ctx context.Context, runner commands.RemoteCommandRunner, instanceIP, kubernetesVersion string) error {
 	commands := []string{
-		"set -eux",
-		"trap \"/tmp/log-collector.sh 'post-upgrade'\" EXIT",
 		fmt.Sprintf("/tmp/nodeadm upgrade %s -c file:///nodeadm-config.yaml", kubernetesVersion),
 	}
 
@@ -57,6 +53,23 @@ func RebootInstance(ctx context.Context, runner commands.RemoteCommandRunner, in
 	_, err := runner.Run(ctx, instanceIP, commands)
 	if err != nil {
 		return fmt.Errorf("running remote command: %w", err)
+	}
+
+	return nil
+}
+
+func RunLogCollector(ctx context.Context, runner commands.RemoteCommandRunner, instanceIP, logBundleUrl string) error {
+	commands := []string{
+		fmt.Sprintf("/tmp/log-collector.sh '%s'", logBundleUrl),
+	}
+
+	output, err := runner.Run(ctx, instanceIP, commands)
+	if err != nil {
+		return fmt.Errorf("running remote command: %w", err)
+	}
+
+	if output.Status != "Success" {
+		return fmt.Errorf("log collector remote command did not succeed")
 	}
 
 	return nil

--- a/test/e2e/os/testdata/log-collector.sh
+++ b/test/e2e/os/testdata/log-collector.sh
@@ -4,31 +4,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-LOGS_UPLOAD_NAME="$1"
-FAILBACK_UPLOAD_NAME="${2:-}"
-
-declare -A LOGS_UPLOAD_URLS=()
-{{ range $url := .LogsUploadUrls }}
-LOGS_UPLOAD_URLS["{{ $url.Name }}"]="{{ $url.Url }}"
-{{- end }}
-
-if [ ! ${LOGS_UPLOAD_URLS[$LOGS_UPLOAD_NAME]+1} ]; then
-    # no presigned url for name
-    exit
-fi
+LOGS_UPLOAD_URL="$1"
 
 LOG_SCRIPT_URL="https://raw.githubusercontent.com/awslabs/amazon-eks-ami/refs/heads/main/log-collector-script/linux/eks-log-collector.sh"
 
-curl -s --retry 5  $LOG_SCRIPT_URL -o /tmp/eks-log-collector.sh
+for i in {1..5}; do curl --fail -s --retry 5 -L "$LOG_SCRIPT_URL" -o /tmp/eks-log-collector.sh && break || sleep 5; done
 
 bash /tmp/eks-log-collector.sh --eks_hybrid=true
 
 if ls /var/log/eks_* > /dev/null 2>&1; then
-    # do not overwrite if the file is already there
-    # s3 will return a 412 PreconditionFailed if the file already exists
-    HTTP_CODE=$(curl --header 'If-None-Match: *' -w "%{http_code}" -s -o /dev/null --retry 5 --request PUT --upload-file /var/log/eks_* "${LOGS_UPLOAD_URLS[$LOGS_UPLOAD_NAME]}")
-    if [[ ${HTTP_CODE} -eq 412 ]] && [ -n "${FAILBACK_UPLOAD_NAME}" ] ; then
-        curl --retry 5 --request PUT --upload-file /var/log/eks_* "${LOGS_UPLOAD_URLS[$FAILBACK_UPLOAD_NAME]}"
-    fi
+    curl --retry 5 --request PUT --upload-file /var/log/eks_* "${LOGS_UPLOAD_URL}"    
     rm /var/log/eks_*
 fi

--- a/test/e2e/os/testdata/nodeadm-init.sh
+++ b/test/e2e/os/testdata/nodeadm-init.sh
@@ -9,15 +9,11 @@ KUBERNETES_VERSION="$2"
 PROVDER="$3"
 NODEADM_ADDITIONAL_ARGS="${4-}"
 
-function gather_logs(){
+function run_debug(){
     /tmp/nodeadm debug -c file:///nodeadm-config.yaml || true
-    # Arbitrary wait to give enough time for logs to populated with potential errors
-    # if the node successfully joins and reboots in this, we wont get the logs
-    sleep 15
-    /tmp/log-collector.sh "post-install" "post-uninstall-install"
 }
 
-trap "gather_logs" EXIT
+trap "run_debug" EXIT
 
 # nodeadmin uninstall does not remove this folder, which contains the cilium/calico config
 # which kubelet uses to determine if a node is "Ready"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Now that we are using the jumpbox to run remote commands on the worker nodes we can simplify the log collection.  

We used to rely on running the collection in traps in each "bash" script we ran since during some of our phases we may "break" the ec2 ssm, or in the case of cloud-init its just running during booth, to ensure we could capture as many logs, as often as we could.  Now, as long the node boots, we can rely on the jumpbox and ssh to be able to run the log collector.

This also removes the extract complexity around pre generating the links and using them by name, with a fallback.

Now the logs are only collected in the deferCleanup, on failure or success.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

