### PR TITLE
adds cross builds for the e2e bins and ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,19 @@ run: build ## Run nodeadm binary.
 e2e-tests-binary: ## Build binary with e2e tests.
 	CGO_ENABLED=0 $(GO) test -ldflags "-s -w -buildid='' -extldflags -static" -c ./test/e2e/suite -o ./_bin/e2e.test -tags "e2e"
 
+.PHONY: build-cross-e2e-tests-binary
+build-cross-e2e-tests-binary:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) test -ldflags "-s -w -buildid='' -extldflags -static" -c ./test/e2e/suite -o ./_bin/amd64/e2e.test -tags "e2e"
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO) test -ldflags "-s -w -buildid='' -extldflags -static" -c ./test/e2e/suite -o ./_bin/arm64/e2e.test -tags "e2e"
+
 .PHONY: e2e-test
 e2e-test: ## Build e2e test setup binary.
 	CGO_ENABLED=0 $(GO) build -ldflags "-s -w -buildid='' -extldflags -static" -o _bin/e2e-test ./cmd/e2e-test/main.go
+
+.PHONY: build-cross-e2e-test
+build-cross-e2e-test:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -ldflags "-s -w -buildid='' -extldflags -static" -o _bin/amd64/e2e-test ./cmd/e2e-test/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO) build -ldflags "-s -w -buildid='' -extldflags -static" -o _bin/arm64/e2e-test ./cmd/e2e-test/main.go
 
 .PHONY: generate-attribution
 generate-attribution:
@@ -176,6 +186,21 @@ $(CRD_REF_DOCS): $(LOCALBIN)
 ginkgo: $(GINKGO) ## Download ginkgo.
 $(GINKGO): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) $(GO) install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
+
+.PHONY: install-cross-ginkgo
+install-cross-ginkgo: $(LOCALBIN)/amd64/ginkgo $(LOCALBIN)/arm64/ginkgo
+
+# When cross-compiling with go install, you can not override the output directory
+# with GOBIN.  In the case that it is a different arch than the host
+# go install will put the bins in a `goos_goarch` folder under GOPATH/bin
+$(LOCALBIN)/%/ginkgo: GOARCH=$*
+$(LOCALBIN)/%/ginkgo: GOPATH=$(shell $(GO) env GOPATH | cut -d ':' -f 1)
+$(LOCALBIN)/%/ginkgo: CROSS_ARCH_INSTALL_FILE=$(GOPATH)/bin/linux_$(GOARCH)/$(@F)
+$(LOCALBIN)/%/ginkgo: NATIVE_INSTALL_FILE=$(GOPATH)/bin/$(@F)
+$(LOCALBIN)/%/ginkgo:
+	mkdir -p $(@D)
+	GOOS=linux GOARCH=$(GOARCH) $(GO) install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
+	if [ -f $(CROSS_ARCH_INSTALL_FILE) ]; then cp $(CROSS_ARCH_INSTALL_FILE) $@; else cp $(NATIVE_INSTALL_FILE) $@; fi
 
 .PHONY: update-deps
 update-deps:

--- a/buildspecs/build-nodeadm.yml
+++ b/buildspecs/build-nodeadm.yml
@@ -3,11 +3,9 @@ version: 0.2
 phases:
   build:
     commands:
-    - make build-cross-platform e2e-tests-binary e2e-test ginkgo
-    - aws s3 cp _bin/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest-pre/linux/amd64/nodeadm
-    - aws s3 cp _bin/arm64/nodeadm s3://$ARTIFACTS_BUCKET/latest-pre/linux/arm64/nodeadm
-    - aws s3 cp _bin/e2e-test s3://$ARTIFACTS_BUCKET/latest-pre/e2e-test
-    - aws s3 cp _bin/e2e.test s3://$ARTIFACTS_BUCKET/latest-pre/e2e.test
+    - make build-cross-platform build-cross-e2e-tests-binary build-cross-e2e-test install-cross-ginkgo
+    - aws s3 sync _bin/amd64/ s3://$ARTIFACTS_BUCKET/latest-pre/linux/amd64/
+    - aws s3 sync _bin/arm64/ s3://$ARTIFACTS_BUCKET/latest-pre/linux/arm64/
 
 cache:
   paths:

--- a/buildspecs/dev-release-nodeadm.yml
+++ b/buildspecs/dev-release-nodeadm.yml
@@ -5,6 +5,10 @@ phases:
     commands:
     - aws s3 cp _bin/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/amd64/nodeadm --acl public-read
     - aws s3 cp _bin/arm64/nodeadm s3://$ARTIFACTS_BUCKET/latest/linux/arm64/nodeadm --acl public-read
-    - aws s3 cp _bin/e2e-test s3://$ARTIFACTS_BUCKET/latest/e2e-test --acl public-read
-    - aws s3 cp _bin/e2e.test s3://$ARTIFACTS_BUCKET/latest/e2e.test --acl public-read
+    - aws s3 cp _bin/amd64/e2e-test s3://$ARTIFACTS_BUCKET/latest/linux/amd64/e2e-test --acl public-read
+    - aws s3 cp _bin/arm64/e2e-test s3://$ARTIFACTS_BUCKET/latest/linux/arm64/e2e-test --acl public-read
+    - aws s3 cp _bin/amd64/e2e.test s3://$ARTIFACTS_BUCKET/latest/linux/amd64/e2e.test --acl public-read
+    - aws s3 cp _bin/arm64/e2e.test s3://$ARTIFACTS_BUCKET/latest/linux/arm64/e2e.test --acl public-read
+    - aws s3 cp _bin/amd64/ginkgo s3://$ARTIFACTS_BUCKET/latest/linux/amd64/ginkgo --acl public-read
+    - aws s3 cp _bin/arm64/ginkgo s3://$ARTIFACTS_BUCKET/latest/linux/arm64/ginkgo --acl public-read
     - aws s3 sync hack s3://$ARTIFACTS_BUCKET/latest --acl public-read

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -30,7 +30,8 @@ NODEADM_ARM_URL="${6?Please specify the nodeadm arm url}"
 LOGS_BUCKET="${7-}"
 
 CONFIG_DIR="$REPO_ROOT/e2e-config"
-BIN_DIR="$REPO_ROOT/_bin"
+ARCH="$([ "x86_64" = "$(uname -m)" ] && echo amd64 || echo arm64)"
+BIN_DIR="$REPO_ROOT/_bin/$ARCH"
 
 mkdir -p $CONFIG_DIR
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Cross build the e2e test binaries (e2e-test is the bin responsible for running setup/clean and e2e.test is the bin which contains the compiled ginkgo tests) and include ginkgo in the artifacts bucket.  This is to be used by the canaries to avoid having to download ginkgo each time and break the arch dependency between the build instance and the canary runner.

Installing ginkgo with go install introduces a bit of weirdness when doing "compilation", but I have commented the code for future me who almost def be confused when i read this in next week!


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

