### PR TITLE
increases e2e cluster wait timeout to 30 minutes

### DIFF
--- a/test/e2e/cluster/cluster.go
+++ b/test/e2e/cluster/cluster.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	createClusterTimeout = 15 * time.Minute
+	createClusterTimeout = 30 * time.Minute
 )
 
 type hybridCluster struct {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Notice a few failures in CI due to clusters taking longer than 15 mins to create. Based on the cloudtrail logs it seems like the cluster did in fact eventually go active so increasing the timeout here may improve stability. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

