### PR TITLE
Show link to docs when using nodeadm --help

### DIFF
--- a/cmd/nodeadm/config/root.go
+++ b/cmd/nodeadm/config/root.go
@@ -9,7 +9,7 @@ const configHelpText = `Examples:
   nodeadm config check --config-source file:///root/nodeConfig.yaml
   
 Documentation:
-  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html#_config_check`
 
 func NewConfigCommand() cli.Command {
 	container := cli.NewCommandContainer("config", "Manage configuration")

--- a/cmd/nodeadm/config/root.go
+++ b/cmd/nodeadm/config/root.go
@@ -4,8 +4,16 @@ import (
 	"github.com/aws/eks-hybrid/internal/cli"
 )
 
+const configHelpText = `Examples:
+  # Check configuration file
+  nodeadm config check --config-source file:///root/nodeConfig.yaml
+  
+Documentation:
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+
 func NewConfigCommand() cli.Command {
 	container := cli.NewCommandContainer("config", "Manage configuration")
+	container.Flaggy().AdditionalHelpAppend = configHelpText
 	container.AddCommand(NewCheckCommand())
 	return container.AsCommand()
 }

--- a/cmd/nodeadm/debug/debug.go
+++ b/cmd/nodeadm/debug/debug.go
@@ -22,11 +22,19 @@ import (
 	"github.com/aws/eks-hybrid/internal/validation"
 )
 
+const debugHelpText = `Examples:
+  # Debug using a local config file
+  nodeadm debug --config-source file://nodeConfig.yaml
+
+Documentation:
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+
 func NewCommand() cli.Command {
 	debug := debug{}
 	debug.cmd = flaggy.NewSubcommand("debug")
 	debug.cmd.String(&debug.nodeConfigSource, "c", "config-source", "Source of node configuration. The format is a URI with supported schemes: [file, imds].")
 	debug.cmd.Description = "Debug the node registration process"
+	debug.cmd.AdditionalHelpPrepend = debugHelpText
 	return &debug
 }
 

--- a/cmd/nodeadm/debug/debug.go
+++ b/cmd/nodeadm/debug/debug.go
@@ -27,7 +27,7 @@ const debugHelpText = `Examples:
   nodeadm debug --config-source file://nodeConfig.yaml
 
 Documentation:
-  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html#_debug`
 
 func NewCommand() cli.Command {
 	debug := debug{}

--- a/cmd/nodeadm/init/init.go
+++ b/cmd/nodeadm/init/init.go
@@ -22,7 +22,7 @@ const initHelpText = `Examples:
   nodeadm init --config-source file://nodeConfig.yaml
 
 Documentation:
-  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html#_init`
 
 func NewInitCommand() cli.Command {
 	init := initCmd{}

--- a/cmd/nodeadm/init/init.go
+++ b/cmd/nodeadm/init/init.go
@@ -17,13 +17,21 @@ import (
 
 const installValidation = "install-validation"
 
+const initHelpText = `Examples:
+  # Initialize using configuration file
+  nodeadm init --config-source file://nodeConfig.yaml
+
+Documentation:
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+
 func NewInitCommand() cli.Command {
 	init := initCmd{}
 	init.cmd = flaggy.NewSubcommand("init")
 	init.cmd.String(&init.configSource, "c", "config-source", "Source of node configuration. The format is a URI with supported schemes: [file, imds].")
-	init.cmd.StringSlice(&init.daemons, "d", "daemon", "specify one or more of `containerd` and `kubelet`. This is intended for testing and should not be used in a production environment.")
-	init.cmd.StringSlice(&init.skipPhases, "s", "skip", "phases of the bootstrap you want to skip")
+	init.cmd.StringSlice(&init.daemons, "d", "daemon", "Specify one or more of `containerd` and `kubelet`. This is intended for testing and should not be used in a production environment.")
+	init.cmd.StringSlice(&init.skipPhases, "s", "skip", "Phases of the bootstrap you want to skip.")
 	init.cmd.Description = "Initialize this instance as a node in an EKS cluster"
+	init.cmd.AdditionalHelpAppend = initHelpText
 	return &init
 }
 

--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -16,6 +16,16 @@ import (
 	"github.com/aws/eks-hybrid/internal/packagemanager"
 )
 
+const installHelpText = `Examples:
+  # Install Kubernetes version 1.31 with AWS Systems Manager (SSM) as the credential provider
+  nodeadm install 1.31 --credential-provider ssm
+
+  # Install Kubernetes version 1.31 with AWS IAM Roles Anywhere as the credential provider and Docker as the containerd source
+  nodeadm install 1.31 --credential-provider ssm --containerd-source docker
+
+Documentation:
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+
 func NewCommand() cli.Command {
 	cmd := command{
 		timeout: 20 * time.Minute,
@@ -23,9 +33,10 @@ func NewCommand() cli.Command {
 
 	fc := flaggy.NewSubcommand("install")
 	fc.Description = "Install components required to join an EKS cluster"
+	fc.AdditionalHelpAppend = installHelpText
 	fc.AddPositionalValue(&cmd.kubernetesVersion, "KUBERNETES_VERSION", 1, true, "The major[.minor[.patch]] version of Kubernetes to install")
-	fc.String(&cmd.credentialProvider, "p", "credential-provider", "Credential process to install. Allowed values are ssm & iam-ra")
-	fc.String(&cmd.containerdSource, "s", "containerd-source", "Source for containerd artifact. Allowed values are none, distro & docker")
+	fc.String(&cmd.credentialProvider, "p", "credential-provider", "Credential process to install. Allowed values are ssm & iam-ra.")
+	fc.String(&cmd.containerdSource, "s", "containerd-source", "Source for containerd artifact. Allowed values are none, distro & docker.")
 	fc.Duration(&cmd.timeout, "t", "timeout", "Maximum install command duration. Input follows duration format. Example: 1h23s")
 	cmd.flaggy = fc
 

--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -21,7 +21,7 @@ const installHelpText = `Examples:
   nodeadm install 1.31 --credential-provider ssm
 
   # Install Kubernetes version 1.31 with AWS IAM Roles Anywhere as the credential provider and Docker as the containerd source
-  nodeadm install 1.31 --credential-provider ssm --containerd-source docker
+  nodeadm install 1.31 --credential-provider iam-ra --containerd-source docker
 
 Documentation:
   https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`

--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -24,7 +24,7 @@ const installHelpText = `Examples:
   nodeadm install 1.31 --credential-provider iam-ra --containerd-source docker
 
 Documentation:
-  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html#_install`
 
 func NewCommand() cli.Command {
 	cmd := command{

--- a/cmd/nodeadm/main.go
+++ b/cmd/nodeadm/main.go
@@ -23,9 +23,11 @@ func main() {
 	flaggy.SetVersion(version.GitVersion)
 	flaggy.DefaultParser.AdditionalHelpPrepend = "http://github.com/aws/eks-hybrid"
 	flaggy.DefaultParser.ShowHelpOnUnexpected = true
-	flaggy.DefaultParser.SetHelpTemplate(cli.HelpTemplate)
-
 	opts := cli.NewGlobalOptions()
+	log := cli.NewLogger(opts)
+	if err := flaggy.DefaultParser.SetHelpTemplate(cli.HelpTemplate); err != nil {
+		log.Fatal("Failed to set help template:", zap.Error(err))
+	}
 
 	cmds := []cli.Command{
 		config.NewConfigCommand(),
@@ -40,8 +42,6 @@ func main() {
 		flaggy.AttachSubcommand(cmd.Flaggy(), 1)
 	}
 	flaggy.Parse()
-
-	log := cli.NewLogger(opts)
 
 	for _, cmd := range cmds {
 		if cmd.Flaggy().Used {

--- a/cmd/nodeadm/main.go
+++ b/cmd/nodeadm/main.go
@@ -21,8 +21,9 @@ func main() {
 	flaggy.SetName("nodeadm")
 	flaggy.SetDescription("From zero to Node faster than you can say Elastic Kubernetes Service")
 	flaggy.SetVersion(version.GitVersion)
-	flaggy.DefaultParser.AdditionalHelpPrepend = "\nhttp://github.com/aws/eks-hybrid"
+	flaggy.DefaultParser.AdditionalHelpPrepend = "http://github.com/aws/eks-hybrid"
 	flaggy.DefaultParser.ShowHelpOnUnexpected = true
+	flaggy.DefaultParser.SetHelpTemplate(cli.HelpTemplate)
 
 	opts := cli.NewGlobalOptions()
 

--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -27,12 +27,23 @@ const (
 	skipNodePreflightCheck = "node-validation"
 )
 
+const uninstallHelpText = `Examples:
+  # Uninstall all components
+  nodeadm uninstall
+
+  # Uninstall all components except pod-validation and node-validation
+  nodeadm uninstall --skip node-validation,pod-validation
+
+Documentation:
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+
 func NewCommand() cli.Command {
 	cmd := command{}
 
 	fc := flaggy.NewSubcommand("uninstall")
 	fc.Description = "Uninstall components installed using the install sub-command"
-	fc.StringSlice(&cmd.skipPhases, "s", "skip", "phases of uninstall you want to skip")
+	fc.AdditionalHelpAppend = uninstallHelpText
+	fc.StringSlice(&cmd.skipPhases, "s", "skip", "Phases of uninstall you want to skip.")
 	cmd.flaggy = fc
 
 	return &cmd

--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -31,7 +31,7 @@ const uninstallHelpText = `Examples:
   # Uninstall all components
   nodeadm uninstall
 
-  # Uninstall all components except pod-validation and node-validation
+  # Uninstall all components and skip pod-validation and node-validation pre-flight validation
   nodeadm uninstall --skip node-validation,pod-validation
 
 Documentation:

--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -35,7 +35,7 @@ const uninstallHelpText = `Examples:
   nodeadm uninstall --skip node-validation,pod-validation
 
 Documentation:
-  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html#_uninstall`
 
 func NewCommand() cli.Command {
 	cmd := command{}

--- a/cmd/nodeadm/upgrade/upgrade.go
+++ b/cmd/nodeadm/upgrade/upgrade.go
@@ -31,6 +31,16 @@ const (
 	initNodePreflightCheck = "init-validation"
 )
 
+const upgradeHelpText = `Examples:
+  # Upgrade all components
+  nodeadm upgrade 1.31 --config-source file:///root/nodeConfig.yaml
+
+  # Upgrade all components with a maximum timeout
+  nodeadm upgrade 1.31 --config-source file:///root/nodeConfig.yaml --timeout 1h23s
+
+Documentation:
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+
 func NewUpgradeCommand() cli.Command {
 	cmd := command{
 		timeout: 20 * time.Minute,
@@ -38,9 +48,10 @@ func NewUpgradeCommand() cli.Command {
 
 	fc := flaggy.NewSubcommand("upgrade")
 	fc.Description = "Upgrade components installed using the install sub-command"
+	fc.AdditionalHelpAppend = upgradeHelpText
 	fc.AddPositionalValue(&cmd.kubernetesVersion, "KUBERNETES_VERSION", 1, true, "The major[.minor[.patch]] version of Kubernetes to install")
 	fc.String(&cmd.configSource, "c", "config-source", "Source of node configuration. The format is a URI with supported schemes: [file, imds].")
-	fc.StringSlice(&cmd.skipPhases, "s", "skip", "phases of the upgrade you want to skip")
+	fc.StringSlice(&cmd.skipPhases, "s", "skip", "Phases of the upgrade you want to skip.")
 	fc.Duration(&cmd.timeout, "t", "timeout", "Maximum upgrade command duration. Input follows duration format. Example: 1h23s")
 	cmd.flaggy = fc
 	return &cmd

--- a/cmd/nodeadm/upgrade/upgrade.go
+++ b/cmd/nodeadm/upgrade/upgrade.go
@@ -35,7 +35,7 @@ const upgradeHelpText = `Examples:
   # Upgrade all components
   nodeadm upgrade 1.31 --config-source file:///root/nodeConfig.yaml
 
-  # Upgrade all components with a maximum timeout
+  # Upgrade all components with a custom timeout
   nodeadm upgrade 1.31 --config-source file:///root/nodeConfig.yaml --timeout 1h23s
 
 Documentation:

--- a/cmd/nodeadm/upgrade/upgrade.go
+++ b/cmd/nodeadm/upgrade/upgrade.go
@@ -39,7 +39,7 @@ const upgradeHelpText = `Examples:
   nodeadm upgrade 1.31 --config-source file:///root/nodeConfig.yaml --timeout 1h23s
 
 Documentation:
-  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html`
+  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html#_upgrade`
 
 func NewUpgradeCommand() cli.Command {
 	cmd := command{

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,0 +1,36 @@
+package cli
+
+// Template for CLI help output
+const HelpTemplate = `{{.CommandName}}{{if .Description}} - {{.Description}}
+{{end}}
+{{- if .PrependMessage}}
+{{.PrependMessage}}
+{{end}}
+{{- if .UsageString}}
+Usage:
+  {{if ne .CommandName "nodeadm"}}nodeadm {{end}}{{.UsageString}}
+{{end}}
+{{- if .Positionals}}
+Positional Variables:
+{{- range .Positionals}}
+  {{.Name}}  {{.Spacer}}{{if .Description}} {{.Description}}{{end}}{{if .DefaultValue}} (default: {{.DefaultValue}}){{else}}{{if .Required}} (Required){{end}}{{end}}
+{{- end}}
+{{end}}
+{{- if .Subcommands}}
+Subcommands:
+{{- range .Subcommands}}
+  {{.LongName}}{{if .ShortName}} ({{.ShortName}}){{end}}{{if .Position}}{{if gt .Position 1}}  (position {{.Position}}){{end}}{{end}}{{if .Description}}   {{.Spacer}}{{.Description}}{{end}}
+{{- end}}
+{{end}}
+{{- if (gt (len .Flags) 0)}}
+Flags:
+{{- range .Flags}}
+  {{if .ShortName}}-{{.ShortName}} {{else}}   {{end}}{{if .LongName}}--{{.LongName}}{{end}}{{if .Description}}   {{.Spacer}}{{.Description}}{{if .DefaultValue}} (default: {{.DefaultValue}}){{end}}{{end}}
+{{- end}}
+{{end}}
+{{- if .AppendMessage}}
+{{.AppendMessage}}
+{{end}}
+{{- if .Message}}
+{{.Message}}
+{{- end}}`


### PR DESCRIPTION
_Issue #, if available:_ 2817

_Description of changes:_

For each nodeadm command, add example usage and link to nodeadm documentation when using --help.

_Testing (if applicable):_

Validated output for all CLI commands.

_Documentation added/planned (if applicable):_ 

Example:

```
> nodeadm install -h
install - Install components required to join an EKS cluster

Usage:
  nodeadm install [KUBERNETES_VERSION]

Positional Variables:
  KUBERNETES_VERSION   The major[.minor[.patch]] version of Kubernetes to install (Required)

Flags:
     --version               Displays the program version string.
  -h --help                  Displays help with available flag, subcommand, and positional value parameters.
  -p --credential-provider   Credential process to install. Allowed values are ssm & iam-ra.
  -s --containerd-source     Source for containerd artifact. Allowed values are none, distro & docker.
  -t --timeout               Maximum install command duration. Input follows duration format. Example: 1h23s (default: 20m0s)
  -d --development           Enable development mode for logging.

Examples:
  # Install Kubernetes version 1.31 with AWS Systems Manager (SSM) as the credential provider
  nodeadm install 1.31 --credential-provider ssm

  # Install Kubernetes version 1.31 with AWS IAM Roles Anywhere as the credential provider and Docker as the containerd source
  nodeadm install 1.31 --credential-provider ssm --containerd-source docker

Documentation:
  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html
```

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

