### PR TITLE
statically compiles ginkgo for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ $(LOCALBIN)/%/ginkgo: CROSS_ARCH_INSTALL_FILE=$(GOPATH)/bin/linux_$(GOARCH)/$(@F
 $(LOCALBIN)/%/ginkgo: NATIVE_INSTALL_FILE=$(GOPATH)/bin/$(@F)
 $(LOCALBIN)/%/ginkgo:
 	mkdir -p $(@D)
-	GOOS=linux GOARCH=$(GOARCH) $(GO) install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) $(GO) install -ldflags "-extldflags -static" github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
 	if [ -f $(CROSS_ARCH_INSTALL_FILE) ]; then cp $(CROSS_ARCH_INSTALL_FILE) $@; else cp $(NATIVE_INSTALL_FILE) $@; fi
 
 .PHONY: update-deps


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Avoid glibc version mismatches between al2 and al23.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

