### PR TITLE
Cleanup e2e test specs

### DIFF
--- a/test/e2e/ec2/instance.go
+++ b/test/e2e/ec2/instance.go
@@ -33,8 +33,9 @@ type InstanceConfig struct {
 }
 
 type Instance struct {
-	ID string
-	IP string
+	ID   string
+	Name string
+	IP   string
 }
 
 func (e *InstanceConfig) Create(ctx context.Context, ec2Client *ec2.Client, ssmClient *ssm.Client) (Instance, error) {
@@ -132,7 +133,11 @@ func (e *InstanceConfig) Create(ctx context.Context, ec2Client *ec2.Client, ssmC
 		return Instance{}, fmt.Errorf("could not create hybrid EC2 instance: %w", err)
 	}
 
-	return Instance{ID: *runResult.Instances[0].InstanceId, IP: *runResult.Instances[0].PrivateIpAddress}, nil
+	return Instance{
+		ID:   *runResult.Instances[0].InstanceId,
+		Name: e.InstanceName,
+		IP:   *runResult.Instances[0].PrivateIpAddress,
+	}, nil
 }
 
 func DeleteEC2Instance(ctx context.Context, client *ec2.Client, instanceID string) error {

--- a/test/e2e/kubernetes/verify.go
+++ b/test/e2e/kubernetes/verify.go
@@ -1,0 +1,81 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	clientgo "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	testPodNamespace = "default"
+)
+
+// VerifyNode checks that a node is healthy, can run pods, extract logs and run commands on them.
+type VerifyNode struct {
+	ClientConfig *rest.Config
+	K8s          *clientgo.Clientset
+	Logger       logr.Logger
+	Region       string
+
+	NodeIPAddress string
+}
+
+func (t VerifyNode) Run(ctx context.Context) error {
+	// get the hybrid node registered using nodeadm by the internal IP of an EC2 Instance
+	node, err := WaitForNode(ctx, t.K8s, t.NodeIPAddress, t.Logger)
+	if err != nil {
+		return err
+	}
+	if node == nil {
+		return fmt.Errorf("returned node is nil")
+	}
+
+	nodeName := node.Name
+
+	t.Logger.Info("Waiting for hybrid node to be ready...")
+	if err = WaitForHybridNodeToBeReady(ctx, t.K8s, nodeName, t.Logger); err != nil {
+		return err
+	}
+
+	t.Logger.Info("Creating a test pod on the hybrid node...")
+	podName := GetNginxPodName(nodeName)
+	if err = CreateNginxPodInNode(ctx, t.K8s, nodeName, testPodNamespace, t.Region, t.Logger); err != nil {
+		return err
+	}
+	t.Logger.Info(fmt.Sprintf("Pod %s created and running on node %s", podName, nodeName))
+
+	t.Logger.Info("Exec-ing nginx -version", "pod", podName)
+	stdout, stderr, err := ExecPod(ctx, t.ClientConfig, t.K8s, podName, testPodNamespace, "/sbin/nginx", "-version")
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(stdout, "nginx") {
+		return fmt.Errorf("pod exec stdout does not contain expected value %s: %s", stdout, "nginx")
+	}
+	if stderr != "" {
+		return fmt.Errorf("pod exec stderr should be empty %s", stderr)
+	}
+	t.Logger.Info("Successfully exec'd nginx -version", "pod", podName)
+
+	t.Logger.Info("Checking logs for nginx output", "pod", podName)
+	logs, err := GetPodLogs(ctx, t.K8s, podName, testPodNamespace)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(logs, "nginx") {
+		return fmt.Errorf("pod log does not contain expected value %s: %s", logs, "nginx")
+	}
+	t.Logger.Info("Successfully validated log output", "pod", podName)
+
+	t.Logger.Info("Deleting test pod", "pod", podName)
+	if err = DeletePod(ctx, t.K8s, podName, testPodNamespace); err != nil {
+		return err
+	}
+	t.Logger.Info("Pod deleted successfully", "pod", podName)
+
+	return nil
+}

--- a/test/e2e/nodeadm/uninstall.go
+++ b/test/e2e/nodeadm/uninstall.go
@@ -1,0 +1,71 @@
+package nodeadm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	clientgo "k8s.io/client-go/kubernetes"
+
+	"github.com/aws/eks-hybrid/test/e2e/commands"
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+)
+
+// CleanNode runs the process to unregister a node from the cluster and uninstall all the installed kubernetes dependencies.
+type CleanNode struct {
+	K8s                 *clientgo.Clientset
+	RemoteCommandRunner commands.RemoteCommandRunner
+	Verifier            UninstallVerifier
+	Logger              logr.Logger
+
+	NodeIP string
+}
+
+// UninstallVerifier checks if nodeadm uninstall process was successful in a node.
+type UninstallVerifier interface {
+	VerifyUninstall(ctx context.Context, nodeName string) error
+}
+
+func (u CleanNode) Run(ctx context.Context) error {
+	node, err := kubernetes.WaitForNode(ctx, u.K8s, u.NodeIP, u.Logger)
+	if err != nil {
+		return err
+	}
+	if node == nil {
+		return fmt.Errorf("returned node is nil")
+	}
+
+	u.Logger.Info("Cordoning hybrid node...")
+	err = kubernetes.CordonNode(ctx, u.K8s, node, u.Logger)
+	if err != nil {
+		return err
+	}
+
+	u.Logger.Info("Draining hybrid node...")
+	err = kubernetes.DrainNode(ctx, u.K8s, node)
+	if err != nil {
+		return err
+	}
+
+	if err = RunNodeadmUninstall(ctx, u.RemoteCommandRunner, u.NodeIP); err != nil {
+		return err
+	}
+	u.Logger.Info("Waiting for hybrid node to be not ready...")
+	if err = kubernetes.WaitForHybridNodeToBeNotReady(ctx, u.K8s, node.Name, u.Logger); err != nil {
+		return err
+	}
+
+	u.Logger.Info("Deleting hybrid node from the cluster", "hybrid node", node.Name)
+	if err = kubernetes.DeleteNode(ctx, u.K8s, node.Name); err != nil {
+		return err
+	}
+	u.Logger.Info("Node deleted successfully", "node", node.Name)
+
+	u.Logger.Info("Waiting for node to be unregistered", "node", node.Name)
+	if err = u.Verifier.VerifyUninstall(ctx, node.Name); err != nil {
+		return nil
+	}
+	u.Logger.Info("Node unregistered successfully", "node", node.Name)
+
+	return nil
+}

--- a/test/e2e/nodeadm/upgrade.go
+++ b/test/e2e/nodeadm/upgrade.go
@@ -1,0 +1,66 @@
+package nodeadm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	clientgo "k8s.io/client-go/kubernetes"
+
+	"github.com/aws/eks-hybrid/test/e2e/commands"
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+)
+
+// UpgradeNode runs the process to upgrade the k8s version in a node in the cluster.
+// This assumes the current node's version meets the version skew policy and it can actually
+// be upgraded to the target version.
+type UpgradeNode struct {
+	K8s                 *clientgo.Clientset
+	RemoteCommandRunner commands.RemoteCommandRunner
+	Logger              logr.Logger
+
+	NodeIP           string
+	TargetK8sVersion string
+}
+
+func (u UpgradeNode) Run(ctx context.Context) error {
+	node, err := kubernetes.WaitForNode(ctx, u.K8s, u.NodeIP, u.Logger)
+	if err != nil {
+		return err
+	}
+
+	nodeName := node.Name
+	u.Logger.Info("Cordoning hybrid node...")
+	err = kubernetes.CordonNode(ctx, u.K8s, node, u.Logger)
+	if err != nil {
+		return err
+	}
+
+	u.Logger.Info("Draining hybrid node...")
+	err = kubernetes.DrainNode(ctx, u.K8s, node)
+	if err != nil {
+		return err
+	}
+
+	u.Logger.Info("Upgrading hybrid node...")
+	if err = RunNodeadmUpgrade(ctx, u.RemoteCommandRunner, u.NodeIP, u.TargetK8sVersion); err != nil {
+		return err
+	}
+
+	u.Logger.Info("Uncordoning hybrid node...")
+	err = kubernetes.UncordonNode(ctx, u.K8s, node)
+	if err != nil {
+		return err
+	}
+
+	node, err = kubernetes.WaitForNodeToHaveVersion(ctx, u.K8s, node.Name, u.TargetK8sVersion, u.Logger)
+	if err != nil {
+		return err
+	}
+
+	if node.Name != nodeName {
+		return fmt.Errorf("node name should not have changed during upgrade %s : %s", nodeName, node.Name)
+	}
+
+	return nil
+}

--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -1,0 +1,178 @@
+package peered
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
+	s3sdk "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/go-logr/logr"
+	clientgo "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-hybrid/test/e2e"
+	"github.com/aws/eks-hybrid/test/e2e/commands"
+	"github.com/aws/eks-hybrid/test/e2e/ec2"
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+	"github.com/aws/eks-hybrid/test/e2e/nodeadm"
+	"github.com/aws/eks-hybrid/test/e2e/os"
+	"github.com/aws/eks-hybrid/test/e2e/s3"
+)
+
+const (
+	ec2VolumeSize = int32(30)
+)
+
+// Node represents is a Hybrid node running as an EC2 instance in a peered VPC.
+type Node struct {
+	AWS                 aws.Config
+	Cluster             *HybridCluster
+	EC2                 *ec2sdk.Client
+	SSM                 *ssm.Client
+	S3                  *s3sdk.Client
+	K8s                 *clientgo.Clientset
+	RemoteCommandRunner commands.RemoteCommandRunner
+	Logger              logr.Logger
+	SkipDelete          bool
+	SetRootPassword     bool
+
+	LogsBucket  string
+	NodeadmURLs e2e.NodeadmURLs
+	PublicKey   string
+}
+
+// NodeSpec configures the Hybrid Node.
+type NodeSpec struct {
+	InstanceName       string
+	InstanceProfileARN string
+	NodeK8sVersion     string
+	NodeNamePrefix     string
+	OS                 e2e.NodeadmOS
+	Provider           e2e.NodeadmCredentialsProvider
+}
+
+// Create spins up an EC2 instance with the proper user data to join as a Hybrid node to the cluster.
+func (c Node) Create(ctx context.Context, spec *NodeSpec) (ec2.Instance, error) {
+	if c.LogsBucket != "" {
+		c.Logger.Info(fmt.Sprintf("Logs bucket: https://%s.console.aws.amazon.com/s3/buckets/%s?prefix=%s/", c.Cluster.Region, c.LogsBucket, c.logsPrefix(spec.InstanceName)))
+	}
+
+	nodeSpec := e2e.NodeSpec{
+		OS:         spec.OS,
+		NamePrefix: spec.NodeNamePrefix,
+		Cluster: &e2e.Cluster{
+			Name:   c.Cluster.Name,
+			Region: c.Cluster.Region,
+		},
+		Provider: spec.Provider,
+	}
+
+	files, err := spec.Provider.FilesForNode(nodeSpec)
+	if err != nil {
+		return ec2.Instance{}, err
+	}
+
+	nodeadmConfig, err := spec.Provider.NodeadmConfig(ctx, nodeSpec)
+	if err != nil {
+		return ec2.Instance{}, fmt.Errorf("expected to build nodeconfig: %w", err)
+	}
+
+	nodeadmConfigYaml, err := yaml.Marshal(&nodeadmConfig)
+	if err != nil {
+		return ec2.Instance{}, fmt.Errorf("expected to successfully marshal nodeadm config to YAML: %w", err)
+	}
+
+	var rootPasswordHash string
+	if c.SetRootPassword {
+		var rootPassword string
+		rootPassword, rootPasswordHash, err = os.GenerateOSPassword()
+		if err != nil {
+			return ec2.Instance{}, fmt.Errorf("expected to successfully generate root password: %w", err)
+		}
+		c.Logger.Info(fmt.Sprintf("Instance Root Password: %s", rootPassword))
+	}
+
+	userdata, err := spec.OS.BuildUserData(e2e.UserDataInput{
+		KubernetesVersion: spec.NodeK8sVersion,
+		NodeadmUrls:       c.NodeadmURLs,
+		NodeadmConfigYaml: string(nodeadmConfigYaml),
+		Provider:          string(spec.Provider.Name()),
+		RootPasswordHash:  rootPasswordHash,
+		Files:             files,
+		PublicKey:         c.PublicKey,
+	})
+	if err != nil {
+		return ec2.Instance{}, fmt.Errorf("expected to successfully build user data: %w", err)
+	}
+
+	amiId, err := spec.OS.AMIName(ctx, c.AWS)
+	if err != nil {
+		return ec2.Instance{}, fmt.Errorf("expected to successfully retrieve ami id: %w", err)
+	}
+
+	ec2Input := ec2.InstanceConfig{
+		ClusterName:        c.Cluster.Name,
+		InstanceName:       spec.InstanceName,
+		AmiID:              amiId,
+		InstanceType:       spec.OS.InstanceType(c.Cluster.Region),
+		VolumeSize:         ec2VolumeSize,
+		SubnetID:           c.Cluster.SubnetID,
+		SecurityGroupID:    c.Cluster.SecurityGroupID,
+		UserData:           userdata,
+		InstanceProfileARN: spec.InstanceProfileARN,
+	}
+
+	c.Logger.Info("Creating a hybrid EC2 Instance...")
+	instance, err := ec2Input.Create(ctx, c.EC2, c.SSM)
+	if err != nil {
+		return ec2.Instance{}, fmt.Errorf("EC2 Instance should have been created successfully: %w", err)
+	}
+	c.Logger.Info(fmt.Sprintf("EC2 Instance Connect: https://%s.console.aws.amazon.com/ec2-instance-connect/ssh?connType=serial&instanceId=%s&region=%s&serialPort=0", c.Cluster.Region, instance.ID, c.Cluster.Region))
+
+	return instance, nil
+}
+
+// Cleanup collects logs and deletes the EC2 instance and Node object.
+func (c *Node) Cleanup(ctx context.Context, instance ec2.Instance) error {
+	err := c.collectLogs(ctx, "bundle", instance)
+	if err != nil {
+		c.Logger.Error(err, "issue collecting logs")
+	}
+	if c.SkipDelete {
+		c.Logger.Info("Skipping EC2 Instance deletion", "instanceID", instance.ID)
+		return nil
+	}
+	c.Logger.Info("Deleting EC2 Instance", "instanceID", instance.ID)
+	if err := ec2.DeleteEC2Instance(ctx, c.EC2, instance.ID); err != nil {
+		return fmt.Errorf("deleting EC2 Instance: %w", err)
+	}
+	c.Logger.Info("Successfully deleted EC2 Instance", "instanceID", instance.ID)
+	if err := kubernetes.EnsureNodeWithIPIsDeleted(ctx, c.K8s, instance.IP); err != nil {
+		return fmt.Errorf("deleting node for instance %s: %w", instance.ID, err)
+	}
+
+	return nil
+}
+
+func (c Node) logsPrefix(instanceName string) string {
+	return fmt.Sprintf("logs/%s/%s", c.Cluster.Name, instanceName)
+}
+
+func (c Node) collectLogs(ctx context.Context, bundleName string, instance ec2.Instance) error {
+	if c.LogsBucket == "" {
+		return nil
+	}
+	key := fmt.Sprintf("%s/%s.tar.gz", c.logsPrefix(instance.Name), bundleName)
+	url, err := s3.GeneratePutLogsPreSignedURL(ctx, c.S3, c.LogsBucket, key, 5*time.Minute)
+	if err != nil {
+		return err
+	}
+	err = nodeadm.RunLogCollector(ctx, c.RemoteCommandRunner, instance.IP, url)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -38,11 +38,6 @@ import (
 	"github.com/aws/eks-hybrid/test/e2e/ssm"
 )
 
-const (
-	ec2VolumeSize = int32(30)
-	podNamespace  = "default"
-)
-
 var (
 	filePath string
 	suite    *suiteConfiguration

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -224,11 +224,7 @@ var _ = Describe("Hybrid Nodes", func() {
 							Expect(os).NotTo(BeNil())
 							Expect(provider).NotTo(BeNil())
 
-							instanceName := fmt.Sprintf("EKSHybridCI-%s-%s-%s",
-								e2e.SanitizeForAWSName(test.cluster.Name),
-								e2e.SanitizeForAWSName(os.Name()),
-								e2e.SanitizeForAWSName(string(provider.Name())),
-							)
+							instanceName := test.instanceName("init", os, provider)
 
 							k8sVersion := test.cluster.KubernetesVersion
 							if test.overrideNodeK8sVersion != "" {
@@ -285,11 +281,7 @@ var _ = Describe("Hybrid Nodes", func() {
 								Skip(fmt.Sprintf("Skipping upgrade test as minimum k8s version is %s", kubernetes.MinimumVersion))
 							}
 
-							instanceName := fmt.Sprintf("EKSHybridCI-upgrade-%s-%s-%s",
-								e2e.SanitizeForAWSName(test.cluster.Name),
-								e2e.SanitizeForAWSName(os.Name()),
-								e2e.SanitizeForAWSName(string(provider.Name())),
-							)
+							instanceName := test.instanceName("upgrade", os, provider)
 
 							nodeKubernetesVersion, err := kubernetes.PreviousVersion(test.cluster.KubernetesVersion)
 							Expect(err).NotTo(HaveOccurred(), "expected to get previous k8s version")
@@ -457,4 +449,13 @@ func (t *peeredVPCTest) newUpgradeNode(nodeIP string) *nodeadm.UpgradeNode {
 		NodeIP:              nodeIP,
 		TargetK8sVersion:    t.cluster.KubernetesVersion,
 	}
+}
+
+func (t *peeredVPCTest) instanceName(testName string, os e2e.NodeadmOS, provider e2e.NodeadmCredentialsProvider) string {
+	return fmt.Sprintf("EKSHybridCI-%s-%s-%s-%s",
+		testName,
+		e2e.SanitizeForAWSName(t.cluster.Name),
+		e2e.SanitizeForAWSName(os.Name()),
+		e2e.SanitizeForAWSName(string(provider.Name())),
+	)
 }

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -266,7 +266,7 @@ var _ = Describe("Hybrid Nodes", func() {
 
 							Expect(cleanNode.Run(ctx)).To(Succeed(), "node should have been reset successfully")
 						},
-						Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), context.Background(), os, provider, Label(os.Name(), string(provider.Name()), "simpleflow")),
+						Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), context.Background(), os, provider, Label(os.Name(), string(provider.Name()), "simpleflow", "init")),
 					)
 
 					DescribeTable("Upgrade nodeadm flow",


### PR DESCRIPTION
## Description of changes
This cleans up a bit the test specs by moving some of the previously called `***Test` "services" out of the suite package. The goal is to make the tests easier to follow (by hiding the low level details of how each action is executed) and even more importantly, to make this actions reusable from other tests/suites.

I renamed them a bit, switching the abstraction from "tests" to "actions". They live in `kubernetes`, `nodeadm` or `peered` depending if the action is purely a kubernetes API based process or if it includes running nodeadm commands/flows or if is specific to running in a peered VPC.

*Testing (if applicable):*
Ran this manually for one provider-os with the init and upgrade flows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

