### PR TITLE
retries cni manifests creation in e2e

### DIFF
--- a/test/e2e/cni/calico.go
+++ b/test/e2e/cni/calico.go
@@ -69,5 +69,5 @@ func (c Calico) Deploy(ctx context.Context) error {
 
 	fmt.Println("Applying calico installation")
 
-	return upsertManifests(ctx, c.K8s, objs)
+	return upsertManifestsWithRetries(ctx, c.K8s, objs)
 }

--- a/test/e2e/cni/cilium.go
+++ b/test/e2e/cni/cilium.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/aws/eks-hybrid/test/e2e/constants"
 )
@@ -61,34 +62,49 @@ func (c Cilium) Deploy(ctx context.Context) error {
 
 	fmt.Println("Applying cilium installation")
 
-	return upsertManifests(ctx, c.k8s, objs)
+	return upsertManifestsWithRetries(ctx, c.k8s, objs)
 }
 
-func upsertManifests(ctx context.Context, k8s dynamic.Interface, manifests []unstructured.Unstructured) error {
+// Creates, or Updates existing CR, foreach manifest
+// Retries each up to 5 times
+func upsertManifestsWithRetries(ctx context.Context, k8s dynamic.Interface, manifests []unstructured.Unstructured) error {
 	for _, obj := range manifests {
-		o := obj
-		groupVersion := o.GroupVersionKind()
-		resource := schema.GroupVersionResource{
-			Group:    groupVersion.Group,
-			Version:  groupVersion.Version,
-			Resource: strings.ToLower(groupVersion.Kind + "s"),
-		}
-		k8s := k8s.Resource(resource).Namespace(obj.GetNamespace())
-		if _, err := k8s.Get(ctx, obj.GetName(), metav1.GetOptions{}); apierrors.IsNotFound(err) {
-			fmt.Printf("Creating custom object %s (%s)\n", o.GetName(), groupVersion)
-			_, err := k8s.Create(ctx, &obj, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("creating custom object %s (%s): %w", o.GetName(), groupVersion, err)
-			}
-		} else if err != nil {
-			return fmt.Errorf("reading custom object %s (%s): %w", o.GetName(), groupVersion, err)
-		} else {
-			fmt.Printf("Updating custom object %s (%s)\n", o.GetName(), groupVersion)
-			_, err := k8s.Update(ctx, &obj, metav1.UpdateOptions{})
-			if err != nil {
-				return fmt.Errorf("updating custom object %s (%s): %w", o.GetName(), groupVersion, err)
-			}
+		err := retry.OnError(retry.DefaultRetry, func(err error) bool {
+			// Retry any error type
+			return true
+		}, func() error {
+			return upsertManifest(ctx, k8s, obj)
+		})
+		if err != nil {
+			return err
 		}
 	}
+	return nil
+}
+
+func upsertManifest(ctx context.Context, k8s dynamic.Interface, obj unstructured.Unstructured) error {
+	groupVersion := obj.GroupVersionKind()
+	resource := schema.GroupVersionResource{
+		Group:    groupVersion.Group,
+		Version:  groupVersion.Version,
+		Resource: strings.ToLower(groupVersion.Kind + "s"),
+	}
+	k8sResource := k8s.Resource(resource).Namespace(obj.GetNamespace())
+	if _, err := k8sResource.Get(ctx, obj.GetName(), metav1.GetOptions{}); apierrors.IsNotFound(err) {
+		fmt.Printf("Creating custom object %s (%s)\n", obj.GetName(), groupVersion)
+		_, err := k8sResource.Create(ctx, &obj, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("creating custom object %s (%s): %w", obj.GetName(), groupVersion, err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("reading custom object %s (%s): %w", obj.GetName(), groupVersion, err)
+	} else {
+		fmt.Printf("Updating custom object %s (%s)\n", obj.GetName(), groupVersion)
+		_, err := k8sResource.Update(ctx, &obj, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("updating custom object %s (%s): %w", obj.GetName(), groupVersion, err)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Saw a handful of errors relating to creating the CNI manifests. This adds retries using the client-go retry util.  All errors are intentionally retried, using the DefaultRetry config, which is up to 5 times.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

