### PR TITLE
Add command to ssh into e2e peered nodes

### DIFF
--- a/cmd/e2e-test/cleanup/cleanup.go
+++ b/cmd/e2e-test/cleanup/cleanup.go
@@ -1,4 +1,4 @@
-package cmd
+package cleanup
 
 import (
 	"context"

--- a/cmd/e2e-test/main.go
+++ b/cmd/e2e-test/main.go
@@ -4,8 +4,9 @@ import (
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 
-	cleanup "github.com/aws/eks-hybrid/cmd/e2e-test/cleanup"
-	setup "github.com/aws/eks-hybrid/cmd/e2e-test/setup"
+	"github.com/aws/eks-hybrid/cmd/e2e-test/cleanup"
+	"github.com/aws/eks-hybrid/cmd/e2e-test/setup"
+	"github.com/aws/eks-hybrid/cmd/e2e-test/ssh"
 	"github.com/aws/eks-hybrid/internal/cli"
 )
 
@@ -16,6 +17,7 @@ func main() {
 	cmds := []cli.Command{
 		setup.NewCommand(),
 		cleanup.NewCommand(),
+		ssh.NewCommand(),
 	}
 
 	for _, cmd := range cmds {

--- a/cmd/e2e-test/setup/setup.go
+++ b/cmd/e2e-test/setup/setup.go
@@ -1,4 +1,4 @@
-package cmd
+package setup
 
 import (
 	"context"

--- a/cmd/e2e-test/ssh/ssh.go
+++ b/cmd/e2e-test/ssh/ssh.go
@@ -1,0 +1,101 @@
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/integrii/flaggy"
+	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/cli"
+	"github.com/aws/eks-hybrid/test/e2e/constants"
+	"github.com/aws/eks-hybrid/test/e2e/peered"
+)
+
+type command struct {
+	flaggy     *flaggy.Subcommand
+	instanceID string
+}
+
+func NewCommand() cli.Command {
+	cmd := command{}
+
+	setupCmd := flaggy.NewSubcommand("ssh")
+	setupCmd.Description = "SSH into a E2E Hybrid Node running in the peered VPC through the jumpbox"
+	setupCmd.AddPositionalValue(&cmd.instanceID, "INSTANCE_ID", 1, true, "The instance ID of the node to SSH into")
+
+	cmd.flaggy = setupCmd
+
+	return &cmd
+}
+
+func (c *command) Flaggy() *flaggy.Subcommand {
+	return c.flaggy
+}
+
+func (s *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+	ctx := context.Background()
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("reading AWS configuration: %w", err)
+	}
+
+	ec2Client := ec2.NewFromConfig(cfg)
+
+	instances, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{s.instanceID},
+	})
+	if err != nil {
+		return fmt.Errorf("describing instance %s: %w", s.instanceID, err)
+	}
+
+	if len(instances.Reservations) == 0 || len(instances.Reservations[0].Instances) == 0 {
+		return fmt.Errorf("no instance found with ID %s", s.instanceID)
+	}
+
+	targetInstance := instances.Reservations[0].Instances[0]
+
+	var clusterName string
+	for _, tag := range targetInstance.Tags {
+		if *tag.Key == constants.TestClusterTagKey {
+			clusterName = *tag.Value
+			break
+		}
+	}
+
+	if clusterName == "" {
+		return fmt.Errorf("no cluster name found in instance %s tags", s.instanceID)
+	}
+
+	jumpbox, err := peered.JumpboxInstance(ctx, ec2Client, clusterName)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.CommandContext(ctx,
+		"aws",
+		"ssm",
+		"start-session",
+		"--document",
+		"AWS-StartInteractiveCommand",
+		"--parameters",
+		fmt.Sprintf("{\"command\":[\"sudo ssh %s\"]}", *targetInstance.PrivateIpAddress),
+		"--target",
+		*jumpbox.InstanceId,
+	)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("running ssm start-session command: %w", err)
+	}
+
+	return nil
+}

--- a/test/e2e/peered/jumpbox.go
+++ b/test/e2e/peered/jumpbox.go
@@ -1,0 +1,40 @@
+package peered
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/aws/eks-hybrid/test/e2e/constants"
+)
+
+// JumpboxInstance returns the jumpbox ec2 instance for the given cluster.
+func JumpboxInstance(ctx context.Context, client *ec2.Client, clusterName string) (*types.Instance, error) {
+	instances, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("tag:" + constants.TestClusterTagKey),
+				Values: []string{clusterName},
+			},
+			{
+				Name:   aws.String("tag:Jumpbox"),
+				Values: []string{"true"},
+			},
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []string{"running"},
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(instances.Reservations) == 0 || len(instances.Reservations[0].Instances) == 0 {
+		return nil, fmt.Errorf("no jumpbox instance found for cluster %s", clusterName)
+	}
+
+	return &instances.Reservations[0].Instances[0], nil
+}


### PR DESCRIPTION
## Description of changes
This just leverages the mechanism used by the e2e tests themselves to get a shell into a e2e node. In order to not expose SSH to the internet in those nodes and since SSM is not reliable, we leverage SSM in a separate machine and use to jump to the target machine.

```
❯ ./_bin/e2e-test ssh -h
ssh - SSH into a E2E Hybrid Node running in the peered VPC

  Usage:
    ssh [INSTANCE_ID]

  Positional Variables:
    INSTANCE_ID   The instance ID of the node to SSH into (Required)
  Flags:
       --version   Displays the program version string.
    -h --help      Displays help with available flag, subcommand, and positional value parameters.
```

```
❯ ./_bin/e2e-test ssh i-0b123c4z90db123cf

Starting session with SessionId: mysession
Warning: Permanently added '10.1.1.127' (ED25519) to the list of known hosts.
   ,     #_
   ~\_  ####_        Amazon Linux 2023
  ~~  \_#####\
  ~~     \###|
  ~~       \#/ ___   https://aws.amazon.com/linux/amazon-linux-2023
   ~~       V~' '->
    ~~~         /
      ~~._.   _/
         _/ _/
       _/m/'
Last login: Thu Jan 16 21:12:50 2025 from 10.1.1.214
[root@ip-10-1-1-127 ~]#
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

