### PR TITLE
retries exec and logs in e2e test

### DIFF
--- a/test/e2e/kubernetes/kubernetes.go
+++ b/test/e2e/kubernetes/kubernetes.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubectl/pkg/drain"
 
 	"github.com/aws/eks-hybrid/test/e2e/constants"
@@ -441,7 +442,21 @@ func nodeCordon(node *corev1.Node) bool {
 	return false
 }
 
-func GetPodLogs(ctx context.Context, k8s *kubernetes.Clientset, name, namespace string) (string, error) {
+// Retries up to 5 times to avoid connection errors
+func GetPodLogsWithRetries(ctx context.Context, k8s *kubernetes.Clientset, name, namespace string) (logs string, err error) {
+	err = retry.OnError(retry.DefaultRetry, func(err error) bool {
+		// Retry any error type
+		return true
+	}, func() error {
+		var err error
+		logs, err = getPodLogs(ctx, k8s, name, namespace)
+		return err
+	})
+
+	return logs, err
+}
+
+func getPodLogs(ctx context.Context, k8s *kubernetes.Clientset, name, namespace string) (string, error) {
 	req := k8s.CoreV1().Pods(namespace).GetLogs(name, &corev1.PodLogOptions{})
 	podLogs, err := req.Stream(ctx)
 	if err != nil {
@@ -457,7 +472,21 @@ func GetPodLogs(ctx context.Context, k8s *kubernetes.Clientset, name, namespace 
 	return buf.String(), nil
 }
 
-func ExecPod(ctx context.Context, config *restclient.Config, k8s *kubernetes.Clientset, name, namespace string, cmd ...string) (stdout, stderr string, err error) {
+// Retries up to 5 times to avoid connection errors
+func ExecPodWithRetries(ctx context.Context, config *restclient.Config, k8s *kubernetes.Clientset, name, namespace string, cmd ...string) (stdout, stderr string, err error) {
+	err = retry.OnError(retry.DefaultRetry, func(err error) bool {
+		// Retry any error type
+		return true
+	}, func() error {
+		var err error
+		stdout, stderr, err = execPod(ctx, config, k8s, name, namespace, cmd...)
+		return err
+	})
+
+	return stdout, stderr, err
+}
+
+func execPod(ctx context.Context, config *restclient.Config, k8s *kubernetes.Clientset, name, namespace string, cmd ...string) (stdout, stderr string, err error) {
 	req := k8s.CoreV1().RESTClient().Post().Resource("pods").Name(name).Namespace(namespace).SubResource("exec")
 	req.VersionedParams(
 		&v1.PodExecOptions{

--- a/test/e2e/kubernetes/verify.go
+++ b/test/e2e/kubernetes/verify.go
@@ -49,7 +49,7 @@ func (t VerifyNode) Run(ctx context.Context) error {
 	t.Logger.Info(fmt.Sprintf("Pod %s created and running on node %s", podName, nodeName))
 
 	t.Logger.Info("Exec-ing nginx -version", "pod", podName)
-	stdout, stderr, err := ExecPod(ctx, t.ClientConfig, t.K8s, podName, testPodNamespace, "/sbin/nginx", "-version")
+	stdout, stderr, err := ExecPodWithRetries(ctx, t.ClientConfig, t.K8s, podName, testPodNamespace, "/sbin/nginx", "-version")
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (t VerifyNode) Run(ctx context.Context) error {
 	t.Logger.Info("Successfully exec'd nginx -version", "pod", podName)
 
 	t.Logger.Info("Checking logs for nginx output", "pod", podName)
-	logs, err := GetPodLogs(ctx, t.K8s, podName, testPodNamespace)
+	logs, err := GetPodLogsWithRetries(ctx, t.K8s, podName, testPodNamespace)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We saw a few connection timeout errors when trying to exec and get pod logs.  Adding retries, with default retry config (5 retries, 10ms backoff).

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

