### PR TITLE
improves context usage for e2e tests

### DIFF
--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -137,7 +137,9 @@ func (c Node) Create(ctx context.Context, spec *NodeSpec) (ec2.Instance, error) 
 
 // Cleanup collects logs and deletes the EC2 instance and Node object.
 func (c *Node) Cleanup(ctx context.Context, instance ec2.Instance) error {
-	err := c.collectLogs(ctx, "bundle", instance)
+	logCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	err := c.collectLogs(logCtx, "bundle", instance)
 	if err != nil {
 		c.Logger.Error(err, "issue collecting logs")
 	}

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -37,6 +38,8 @@ import (
 	"github.com/aws/eks-hybrid/test/e2e/s3"
 	"github.com/aws/eks-hybrid/test/e2e/ssm"
 )
+
+const deferCleanupTimeout = 5 * time.Minute
 
 var (
 	filePath string
@@ -131,7 +134,7 @@ var _ = SynchronizedBeforeSuite(
 				return
 			}
 			Expect(infra.Teardown(ctx)).To(Succeed(), "should teardown e2e resources")
-		})
+		}, NodeTimeout(deferCleanupTimeout))
 
 		suiteJson, err := yaml.Marshal(
 			&suiteConfiguration{
@@ -237,7 +240,7 @@ var _ = Describe("Hybrid Nodes", func() {
 							Expect(err).NotTo(HaveOccurred(), "EC2 Instance should have been created successfully")
 							DeferCleanup(func(ctx context.Context) {
 								Expect(peeredNode.Cleanup(ctx, instance)).To(Succeed())
-							})
+							}, NodeTimeout(deferCleanupTimeout))
 
 							verifyNode := test.newVerifyNode(instance.IP)
 							Expect(verifyNode.Run(ctx)).To(
@@ -261,7 +264,7 @@ var _ = Describe("Hybrid Nodes", func() {
 
 							Expect(cleanNode.Run(ctx)).To(Succeed(), "node should have been reset successfully")
 						},
-						Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), context.Background(), os, provider, Label(os.Name(), string(provider.Name()), "simpleflow", "init")),
+						Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), os, provider, Label(os.Name(), string(provider.Name()), "simpleflow", "init")),
 					)
 
 					DescribeTable("Upgrade nodeadm flow",
@@ -292,7 +295,7 @@ var _ = Describe("Hybrid Nodes", func() {
 							Expect(err).NotTo(HaveOccurred(), "EC2 Instance should have been created successfully")
 							DeferCleanup(func(ctx context.Context) {
 								Expect(peeredNode.Cleanup(ctx, instance)).To(Succeed())
-							})
+							}, NodeTimeout(deferCleanupTimeout))
 
 							verifyNode := test.newVerifyNode(instance.IP)
 							Expect(verifyNode.Run(ctx)).To(
@@ -310,7 +313,7 @@ var _ = Describe("Hybrid Nodes", func() {
 								Succeed(), "node should have been reset successfully",
 							)
 						},
-						Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), context.Background(), os, provider, Label(os.Name(), string(provider.Name()), "upgradeflow")),
+						Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), os, provider, Label(os.Name(), string(provider.Name()), "upgradeflow")),
 					)
 				}
 			}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When ctrl-c cancelling a ginkgo run, it was not properly cancelling the running actions because the context we passed to the test was new per test. This change uses the ginkgo ctx which allows for running actions to know that the ctx was cancelled.  This also sets the timeout on the defercleanup and the log collecting.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

