### PR TITLE
adds retry to test stack deployment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/eks-hybrid
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.55.5


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We noticed a case where the cloudformation stack failed to create because the anywhere profile creation appears to take a bit longer than ssm gives to try and get the tags for that profile.  The current method was already idempotent so this adds 1 retry to attempt to resolve the issue without failing the test.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

