### PR TITLE
refactor: validate containerd daemon during init, not install

### DIFF
--- a/cmd/nodeadm/init/init.go
+++ b/cmd/nodeadm/init/init.go
@@ -2,6 +2,7 @@ package init
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/integrii/flaggy"
@@ -9,6 +10,7 @@ import (
 	"k8s.io/utils/strings/slices"
 
 	"github.com/aws/eks-hybrid/internal/cli"
+	"github.com/aws/eks-hybrid/internal/containerd"
 	"github.com/aws/eks-hybrid/internal/flows"
 	"github.com/aws/eks-hybrid/internal/logger"
 	"github.com/aws/eks-hybrid/internal/node"
@@ -71,6 +73,10 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 			return nil
 		} else if err != nil {
 			return err
+		}
+
+		if err := containerd.ValidateSystemdUnitFile(); err != nil {
+			return fmt.Errorf("a systemd unit file for containerd is required to init the node: %w", err)
 		}
 	}
 

--- a/internal/flows/install.go
+++ b/internal/flows/install.go
@@ -59,10 +59,6 @@ func (i *Installer) installDistroPackages(ctx context.Context) error {
 		return err
 	}
 
-	if err := containerd.ValidateSystemdUnitFile(); err != nil {
-		return fmt.Errorf("please install systemd unit file for containerd: %v", err)
-	}
-
 	i.Logger.Info("Installing iptables...")
 	return iptables.Install(ctx, i.Tracker, i.PackageManager)
 }


### PR DESCRIPTION
*Issue #, if available:*

Unable to run `nodeadm install` within a docker container. D-Bus connection fails due to lack of fully operational systemd:
```
INFO {“level”:“fatal”,“ts”:1736533734.779155,“caller”:“./main.go:53”,“msg”:“Command failed”,“error”:“please install systemd unit file for containerd: dial unix /run/systemd/private: connect: no such file or directory”,“stacktrace”:“main.main\n\t./main.go:53\nruntime.main\n\truntime/proc.go:272”}
INFO The command ‘/bin/sh -c /opt/nodeadmutil/bin/nodeadm install -p iam-ra 1.31.0’ returned a non-zero code: 1
```

*Description of changes:*

Relocate containerd validation from `nodeadm install` to `nodeadm init`.

*Testing (if applicable):*

N/A

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.