### PR TITLE
moves jumpbox private key fetch and validation

### DIFF
--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -348,10 +348,19 @@ Resources:
                   Host *
                     StrictHostKeyChecking no
                     UserKnownHostsFile=/dev/null
-                path: /root/.ssh/config                
-            runcmd:
-              - aws ssm get-parameter --name /ec2/keypair/${JumpboxKeyPair.KeyPairId} --with-decryption --query Parameter.Value --output text > /root/.ssh/id_rsa
-              - chmod 0600 /root/.ssh/id_rsa
+                path: /root/.ssh/config
+              - content: |
+                  #!/usr/bin/env bash
+
+                  if ! aws ssm get-parameter --name /ec2/keypair/${JumpboxKeyPair.KeyPairId} --with-decryption --query Parameter.Value --output text > /root/.ssh/id_rsa ||
+                    ! openssl rsa -in /root/.ssh/id_rsa -pubout; then
+                    echo "Problem downloading private key from ssm!"
+                    cat /root/.ssh/id_rsa
+                    exit 1
+                  fi
+                  chmod 0600 /root/.ssh/id_rsa
+                path: /root/download-private-key.sh
+                permissions: "0755"
 
 Outputs:
   ClusterRole:

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/aws/eks-hybrid/test/e2e/constants"
 	"github.com/aws/eks-hybrid/test/e2e/errors"
+	e2eSSM "github.com/aws/eks-hybrid/test/e2e/ssm"
 )
 
 //go:embed cfn-templates/setup-cfn.yaml
@@ -207,6 +208,15 @@ func (s *stack) deploy(ctx context.Context, test TestResources) (*resourcesStack
 	})
 	if err != nil {
 		return nil, fmt.Errorf("tagging private key ssm parameter: %w", err)
+	}
+
+	command := "/root/download-private-key.sh"
+	output, err := e2eSSM.RunCommand(ctx, s.ssmClient, result.jumpboxInstanceId, command, s.logger)
+	if err != nil {
+		return nil, fmt.Errorf("jumpbox getting private key from ssm: %w", err)
+	}
+	if output.Status != "Success" {
+		return nil, fmt.Errorf("jumpbox getting private key from ssm")
 	}
 
 	s.logger.Info("E2E resources stack deployed successfully", "stackName", stackName)

--- a/test/e2e/ssm/command.go
+++ b/test/e2e/ssm/command.go
@@ -36,30 +36,34 @@ func NewSSHOnSSMCommandRunner(client *ssm.Client, jumpboxInstanceId string, logg
 
 func (s *SSHOnSSM) Run(ctx context.Context, ip string, commands []string) (e2eCommands.RemoteCommandOutput, error) {
 	command := makeSshCommand(ip, commands)
-	s.logger.Info(fmt.Sprintf("Running command: %v\n", command))
+	return RunCommand(ctx, s.client, s.jumpboxInstanceId, command, s.logger)
+}
+
+func RunCommand(ctx context.Context, client *ssm.Client, instanceId, command string, logger logr.Logger) (e2eCommands.RemoteCommandOutput, error) {
+	logger.Info(fmt.Sprintf("Running command: %v\n", command))
 	input := &ssm.SendCommandInput{
 		DocumentName: aws.String("AWS-RunShellScript"),
 		Parameters: map[string][]string{
 			"commands": {command},
 		},
-		InstanceIds: []string{s.jumpboxInstanceId},
+		InstanceIds: []string{instanceId},
 	}
 	optsFn := func(opts *ssm.Options) {
 		opts.RetryMode = aws.RetryModeAdaptive
 		opts.RetryMaxAttempts = 60
 	}
-	output, err := s.client.SendCommand(ctx, input, optsFn)
+	output, err := client.SendCommand(ctx, input, optsFn)
 	if err != nil {
 		return e2eCommands.RemoteCommandOutput{}, fmt.Errorf("got an error calling SendCommand: %w", err)
 	}
 	invocationInput := &ssm.GetCommandInvocationInput{
 		CommandId:  output.Command.CommandId,
-		InstanceId: aws.String(s.jumpboxInstanceId),
+		InstanceId: aws.String(instanceId),
 	}
-	waiter := ssm.NewCommandExecutedWaiter(s.client)
+	waiter := ssm.NewCommandExecutedWaiter(client)
 	// Will wait on Pending, InProgress, or Cancelling until we reach a terminal status of Success, Cancelled, Failed, TimedOut
 	_ = waiter.Wait(ctx, invocationInput, commandTimeout)
-	invocationOutput, err := s.client.GetCommandInvocation(ctx, invocationInput, optsFn)
+	invocationOutput, err := client.GetCommandInvocation(ctx, invocationInput, optsFn)
 	if err != nil {
 		return e2eCommands.RemoteCommandOutput{}, fmt.Errorf("got an error calling GetCommandInvocation: %w", err)
 	}
@@ -71,10 +75,10 @@ func (s *SSHOnSSM) Run(ctx context.Context, ip string, commands []string) (e2eCo
 		Status:         string(invocationOutput.Status),
 	}
 
-	s.logger.Info(fmt.Sprintf("Status: %s", commandOutput.Status))
-	s.logger.Info(fmt.Sprintf("ResponseCode: %d", commandOutput.ResponseCode))
-	s.logger.Info(fmt.Sprintf("Stdout: %s", commandOutput.StandardOutput))
-	s.logger.Info(fmt.Sprintf("Stderr: %s", commandOutput.StandardError))
+	logger.Info(fmt.Sprintf("Status: %s", commandOutput.Status))
+	logger.Info(fmt.Sprintf("ResponseCode: %d", commandOutput.ResponseCode))
+	logger.Info(fmt.Sprintf("Stdout: %s", commandOutput.StandardOutput))
+	logger.Info(fmt.Sprintf("Stderr: %s", commandOutput.StandardError))
 
 	return commandOutput, nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This moves the ssm get-parameter for the private ssh key on the jumpbox from cloud-init to ssm runCommand after stack is created. This allows us to better capture the logs in case this fails for any reason.  Also adds a "validation" by using openssl to generate the public key from the downloaded private key.  If the private key is for whatever reason malformed, this command will fail.

We have seen an issue due to the private key only once in CI so for now this just adds better logging and validation.  A future improvement, depending on if we see this more and why we see, we could add retires to getting the param.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

