### PR TITLE
Remove containerd docker repo on uninstall

### DIFF
--- a/cmd/nodeadm/main.go
+++ b/cmd/nodeadm/main.go
@@ -22,6 +22,7 @@ func main() {
 	flaggy.SetDescription("From zero to Node faster than you can say Elastic Kubernetes Service")
 	flaggy.SetVersion(version.GitVersion)
 	flaggy.DefaultParser.AdditionalHelpPrepend = "http://github.com/aws/eks-hybrid"
+	flaggy.DefaultParser.AdditionalHelpAppend = "Documentation:\n  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html"
 	flaggy.DefaultParser.ShowHelpOnUnexpected = true
 	opts := cli.NewGlobalOptions()
 	log := cli.NewLogger(opts)

--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -116,13 +116,6 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return err
 	}
 
-	// Only removes containerd repos installed by nodeadm (tracked in tracker file)
-	if containerdSource == containerd.ContainerdSourceDocker {
-		if err := packageManager.UninstallPackageManagerDockerRepo(); err != nil {
-			return err
-		}
-	}
-
 	uninstaller := &flows.Uninstaller{
 		Artifacts:      installed.Artifacts,
 		DaemonManager:  daemonManager,

--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -116,6 +116,13 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return err
 	}
 
+	// Only removes containerd repos installed by nodeadm (tracked in tracker file)
+	if containerdSource == containerd.ContainerdSourceDocker {
+		if err := packageManager.UninstallPackageManagerDockerRepo(); err != nil {
+			return err
+		}
+	}
+
 	uninstaller := &flows.Uninstaller{
 		Artifacts:      installed.Artifacts,
 		DaemonManager:  daemonManager,

--- a/internal/flows/uninstall.go
+++ b/internal/flows/uninstall.go
@@ -137,7 +137,7 @@ func (u *Uninstaller) uninstallBinaries(ctx context.Context) error {
 
 // cleanup removes directories or files that are not individually owned by single component
 func (u *Uninstaller) cleanup() error {
-	if err := u.PackageManager.CleanupPackageManagerInstallArtifacts(); err != nil {
+	if err := u.PackageManager.Cleanup(); err != nil {
 		return err
 	}
 

--- a/internal/flows/uninstall.go
+++ b/internal/flows/uninstall.go
@@ -137,5 +137,13 @@ func (u *Uninstaller) uninstallBinaries(ctx context.Context) error {
 
 // cleanup removes directories or files that are not individually owned by single component
 func (u *Uninstaller) cleanup() error {
-	return os.RemoveAll(eksConfigDir)
+	if err := u.PackageManager.CleanupPackageManagerInstallArtifacts(); err != nil {
+		return err
+	}
+
+	if err := os.RemoveAll(eksConfigDir); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/packagemanager/packagemanager.go
+++ b/internal/packagemanager/packagemanager.go
@@ -158,7 +158,7 @@ func (pm *DistroPackageManager) configureAptPackageManagerWithDockerRepo(ctx con
 }
 
 // UninstallPackageManagerDockerRepo uninstalls docker repos installed by package managers when containerd source is docker
-func (pm *DistroPackageManager) uninstallPackageManagerDockerRepo() error {
+func (pm *DistroPackageManager) uninstallDockerRepo() error {
 	removeRepoFile := func(path, pkgType string) error {
 		_, err := os.Stat(path)
 

--- a/internal/packagemanager/packagemanager.go
+++ b/internal/packagemanager/packagemanager.go
@@ -262,7 +262,7 @@ func (pm *DistroPackageManager) runcPackage() artifact.Package {
 }
 
 // CleanupPackageManagerInstallArtifacts cleans up any artifacts used by package manager during nodeadm install process
-func (pm *DistroPackageManager) CleanupPackageManagerInstallArtifacts() error {
+func (pm *DistroPackageManager) Cleanup() error {
 	// Removes docker repos if installed by nodeadm ("Containerd: docker" was set in tracker file)
 	if pm.dockerRepo != "" {
 		if err := pm.uninstallPackageManagerDockerRepo(); err != nil {

--- a/internal/packagemanager/packagemanager.go
+++ b/internal/packagemanager/packagemanager.go
@@ -159,7 +159,7 @@ func (pm *DistroPackageManager) configureAptPackageManagerWithDockerRepo(ctx con
 
 // UninstallPackageManagerDockerRepo uninstalls docker repos installed by package managers when containerd source is docker
 func (pm *DistroPackageManager) UninstallPackageManagerDockerRepo() error {
-	removeRepoFile := func(path string, pkgType string) error {
+	removeRepoFile := func(path, pkgType string) error {
 		_, err := os.Stat(path)
 
 		if os.IsNotExist(err) {

--- a/internal/packagemanager/packagemanager.go
+++ b/internal/packagemanager/packagemanager.go
@@ -157,7 +157,7 @@ func (pm *DistroPackageManager) configureAptPackageManagerWithDockerRepo(ctx con
 	return nil
 }
 
-// UninstallPackageManagerDockerRepo uninstalls docker repos installed by package managers when containerd source is docker
+// uninstallDockerRepo uninstalls docker repos installed by package managers when containerd source is docker
 func (pm *DistroPackageManager) uninstallDockerRepo() error {
 	removeRepoFile := func(path, pkgType string) error {
 		_, err := os.Stat(path)
@@ -261,11 +261,11 @@ func (pm *DistroPackageManager) runcPackage() artifact.Package {
 	)
 }
 
-// CleanupPackageManagerInstallArtifacts cleans up any artifacts used by package manager during nodeadm install process
+// Cleanup cleans up any artifacts used by package manager during nodeadm install process
 func (pm *DistroPackageManager) Cleanup() error {
 	// Removes docker repos if installed by nodeadm ("Containerd: docker" was set in tracker file)
 	if pm.dockerRepo != "" {
-		if err := pm.uninstallPackageManagerDockerRepo(); err != nil {
+		if err := pm.uninstallDockerRepo(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:* 2746

*Description of changes:* 

Removes the docker repo fetched by the package manager upon uninstall when the original containerd-source was 'docker'. 

*Testing (if applicable):*

Tested on Ubuntu for apt and CentOS for yum. 

- Verified that repo is correctly deleted and `apt install containerd.io` and `yum install containerd.io` no longer finds package after nodeadm uninstall.
- Checked that the docker repo is untouched upon uninstall if not originally installed by nodeadm

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

