### PR TITLE
logs the cluster on failure

### DIFF
--- a/test/e2e/cluster/cluster.go
+++ b/test/e2e/cluster/cluster.go
@@ -69,12 +69,14 @@ func (h *hybridCluster) create(ctx context.Context, client *eks.Client, logger l
 
 	logger.Info("Waiting for cluster to be active", "cluster", h.Name)
 	cluster, err := waitForActiveCluster(ctx, client, h.Name)
+	if cluster != nil {
+		logger.Info(awsutil.Prettify(cluster))
+	}
 	if err != nil {
 		return err
 	}
 
 	logger.Info("Successfully started EKS hybrid cluster")
-	logger.Info(awsutil.Prettify(cluster))
 
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In cases where the cluster status goes to failed it would be helpful to get the describe cluster output to see if that leads us to any potential root causes/fixes.  We already return the cluster from waitFor even when there is an error.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

