### PR TITLE
Validate credential provider during install

### DIFF
--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/eks-hybrid/internal/flows"
 	"github.com/aws/eks-hybrid/internal/logger"
 	"github.com/aws/eks-hybrid/internal/packagemanager"
+	"github.com/aws/eks-hybrid/internal/system"
 )
 
 const installHelpText = `Examples:
@@ -80,6 +81,10 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 	credentialProvider, err := creds.GetCredentialProvider(c.credentialProvider)
 	if err != nil {
+		return err
+	}
+	osName, osVersion := system.GetOsNameWithVersion()
+	if err = creds.ValidateCredentialProvider(credentialProvider, osName, osVersion); err != nil {
 		return err
 	}
 

--- a/internal/creds/validation.go
+++ b/internal/creds/validation.go
@@ -1,11 +1,15 @@
 package creds
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/iamrolesanywhere"
 	"github.com/aws/eks-hybrid/internal/ssm"
+	"github.com/aws/eks-hybrid/internal/system"
 	"github.com/aws/eks-hybrid/internal/validation"
 )
 
@@ -22,4 +26,29 @@ func Validations(config aws.Config, node *api.NodeConfig) []validation.Validatio
 	}
 
 	return nil
+}
+
+func ValidateCredentialProvider(provider CredentialProvider, osName, osVersion string) error {
+	if provider == IamRolesAnywhereCredentialProvider {
+		majorOsVersion, err := getMajorVersion(osVersion)
+		if err != nil {
+			return err
+		}
+
+		// Both RHEL8 and Ubuntu 20 have older version of glibc which iam roles anywhere credential helper doesn't work with
+		// Until we have a fix for that, we will validate and avoid these os version combinations
+		// https://github.com/aws/rolesanywhere-credential-helper/issues/90
+		if (osName == system.RhelOsName && majorOsVersion == "8") || (osName == system.UbuntuOsName && majorOsVersion == "20") {
+			return fmt.Errorf("iam-ra credential provider is not supported on %s %s based operating systems. Please use ssm credential provider", osName, osVersion)
+		}
+	}
+	return nil
+}
+
+func getMajorVersion(version string) (string, error) {
+	parts := strings.Split(version, ".")
+	if len(parts) > 0 {
+		return parts[0], nil
+	}
+	return "", fmt.Errorf("failed to parse input version: %s", version)
 }

--- a/internal/creds/validation_test.go
+++ b/internal/creds/validation_test.go
@@ -1,0 +1,75 @@
+package creds_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-hybrid/internal/creds"
+	"github.com/aws/eks-hybrid/internal/system"
+)
+
+func TestValidateCredentialProvider(t *testing.T) {
+	g := NewGomegaWithT(t)
+	testcases := []struct {
+		name               string
+		credentialProvider creds.CredentialProvider
+		osName             string
+		osVersion          string
+		wantErr            error
+	}{
+		{
+			name:               "SSM provider - happy path",
+			credentialProvider: creds.SsmCredentialProvider,
+			osName:             "random",
+			osVersion:          "randomVersion",
+			wantErr:            nil,
+		},
+		{
+			name:               "IAM RA - RHEL 8",
+			credentialProvider: creds.IamRolesAnywhereCredentialProvider,
+			osName:             system.RhelOsName,
+			osVersion:          "8.10",
+			wantErr:            fmt.Errorf("iam-ra credential provider is not supported on %s %s based operating systems. Please use ssm credential provider", system.RhelOsName, "8.10"),
+		},
+		{
+			name:               "IAM RA - Ubuntu 20",
+			credentialProvider: creds.IamRolesAnywhereCredentialProvider,
+			osName:             system.UbuntuOsName,
+			osVersion:          "20.23",
+			wantErr:            fmt.Errorf("iam-ra credential provider is not supported on %s %s based operating systems. Please use ssm credential provider", system.UbuntuOsName, "20.23"),
+		},
+		{
+			name:               "IAM RA - Happy OSes",
+			credentialProvider: creds.IamRolesAnywhereCredentialProvider,
+			osName:             system.AmazonOsName,
+			osVersion:          "3.2.4",
+			wantErr:            nil,
+		},
+		{
+			name:               "IAM RA - Ubuntu 22",
+			credentialProvider: creds.IamRolesAnywhereCredentialProvider,
+			osName:             system.UbuntuOsName,
+			osVersion:          "22.23",
+			wantErr:            nil,
+		},
+		{
+			name:               "IAM RA - RHEL 9",
+			credentialProvider: creds.IamRolesAnywhereCredentialProvider,
+			osName:             system.RhelOsName,
+			osVersion:          "9.10",
+			wantErr:            nil,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := creds.ValidateCredentialProvider(tc.credentialProvider, tc.osName, tc.osVersion)
+			if tc.wantErr == nil {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).To(Equal(tc.wantErr))
+			}
+		})
+	}
+}

--- a/internal/system/os.go
+++ b/internal/system/os.go
@@ -16,6 +16,12 @@ func GetOsName() string {
 	return cfg.Section("").Key("ID").String()
 }
 
+// GetOsNameWithVersion returns the os name and version on /etc/os-release file
+func GetOsNameWithVersion() (string, string) {
+	cfg, _ := ini.Load("/etc/os-release")
+	return cfg.Section("").Key("ID").String(), cfg.Section("").Key("VERSION_ID").String()
+}
+
 func GetVersionCodeName() string {
 	cfg, _ := ini.Load("/etc/os-release")
 	return cfg.Section("").Key("VERSION_CODENAME").String()

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -219,7 +219,10 @@ func findLatestImage(ctx context.Context, client *ec2.Client, amiPrefix, arch st
 }
 
 func paginationDone(in *ec2.DescribeImagesInput, out *ec2.DescribeImagesOutput) bool {
-	return (in.NextToken != nil && in.NextToken == out.NextToken) || len(out.Images) == 0
+	// When filters are used, they are applied on the client side per page
+	// This function helps go through all the pages to make sure if filtered
+	// result shows up in any one of the pages
+	return out.NextToken == nil || (in.NextToken != nil && in.NextToken == out.NextToken)
 }
 
 // IsRHEL8 returns true if the given name is a RHEL 8 OS name.


### PR DESCRIPTION
*Description of changes:*
Validate the credential provider during install phase. Both Ubuntu 20 and RHEL 8, ship with lower version of GLIBC which doesn't work with iam-roles-anywhere. 

Also has an improvement to the pagination function used with ec2:DescribeImages API in the E2E test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

