### PR TITLE
changes e2e setup stack to not rely on cfn outputs

### DIFF
--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -382,31 +382,3 @@ Outputs:
   ClusterSecurityGroup:
     Description: The ID of the EKS Hybrid Cluster Security Group.
     Value: !GetAtt ClusterVPC.DefaultSecurityGroup
-
-  HybridNodeVPC:
-    Description: The ID of the EC2 hybrid node VPC.
-    Value: !Ref HybridNodeVPC
-
-  HybridNodeVPCPublicSubnet:
-    Description: The ID of the EC2 Hybrid Node VPC Public Subnet.
-    Value: !Ref HybridNodeVPCPublicSubnet
-
-  HybridNodeVPCPrivateSubnet:
-    Description: The ID of the EC2 Hybrid Node VPC Private Subnet.
-    Value: !Ref HybridNodeVPCPrivateSubnet
-
-  HybridNodeSecurityGroup:
-    Description: The ID of the EC2 Hybrid Node Security Group.
-    Value: !GetAtt HybridNodeVPC.DefaultSecurityGroup
-
-  VPCPeeringConnection:
-    Description: The ID of the VPC Peering Connection.
-    Value: !Ref VPCPeeringConnection
-
-  JumpboxInstanceId:
-    Description: Instance ID of Jumpbox.
-    Value: !Ref Jumpbox
-  
-  JumpboxKeyPairSSMParameter:
-    Description: SSM parameter storing key pair private key
-    Value: !Sub /ec2/keypair/${JumpboxKeyPair.KeyPairId}

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/go-logr/logr"
@@ -48,6 +49,7 @@ func NewCreate(aws aws.Config, logger logr.Logger) Create {
 		eks:    eks.NewFromConfig(aws),
 		stack: &stack{
 			cfn:       cloudformation.NewFromConfig(aws),
+			ec2Client: ec2.NewFromConfig(aws),
 			logger:    logger,
 			ssmClient: ssm.NewFromConfig(aws),
 		},

--- a/test/e2e/cluster/delete.go
+++ b/test/e2e/cluster/delete.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/go-logr/logr"
@@ -32,8 +33,9 @@ func NewDelete(aws aws.Config, logger logr.Logger) Delete {
 		logger: logger,
 		eks:    eks.NewFromConfig(aws),
 		stack: &stack{
-			cfn:    cloudformation.NewFromConfig(aws),
-			logger: logger,
+			cfn:       cloudformation.NewFromConfig(aws),
+			ec2Client: ec2.NewFromConfig(aws),
+			logger:    logger,
 		},
 	}
 }

--- a/test/e2e/peered/keypair.go
+++ b/test/e2e/peered/keypair.go
@@ -1,0 +1,32 @@
+package peered
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/aws/eks-hybrid/test/e2e/constants"
+)
+
+// KeyPair returns the keypair for the given cluster.
+func KeyPair(ctx context.Context, client *ec2.Client, clusterName string) (*types.KeyPairInfo, error) {
+	keypair, err := client.DescribeKeyPairs(ctx, &ec2.DescribeKeyPairsInput{
+		IncludePublicKey: aws.Bool(true),
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("tag:" + constants.TestClusterTagKey),
+				Values: []string{clusterName},
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(keypair.KeyPairs) == 0 {
+		return nil, fmt.Errorf("no key pair found for cluster %s", clusterName)
+	}
+	return &keypair.KeyPairs[0], nil
+}

--- a/test/e2e/peered/setup.go
+++ b/test/e2e/peered/setup.go
@@ -2,14 +2,11 @@ package peered
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/go-logr/logr"
 
-	"github.com/aws/eks-hybrid/test/e2e/constants"
 	"github.com/aws/eks-hybrid/test/e2e/credentials"
 )
 
@@ -34,26 +31,15 @@ func Setup(ctx context.Context, logger logr.Logger, config aws.Config, clusterNa
 		return nil, err
 	}
 
-	keypair, err := ec2Client.DescribeKeyPairs(ctx, &ec2.DescribeKeyPairsInput{
-		IncludePublicKey: aws.Bool(true),
-		Filters: []types.Filter{
-			{
-				Name:   aws.String("tag:" + constants.TestClusterTagKey),
-				Values: []string{clusterName},
-			},
-		},
-	})
+	keypair, err := KeyPair(ctx, ec2Client, clusterName)
 	if err != nil {
 		return nil, err
-	}
-	if len(keypair.KeyPairs) == 0 {
-		return nil, fmt.Errorf("no key pair found for cluster %s", clusterName)
 	}
 
 	return &Infrastructure{
 		Credentials:       *credsInfra,
 		JumpboxInstanceId: *jumpbox.InstanceId,
-		NodesPublicSSHKey: *keypair.KeyPairs[0].PublicKey,
+		NodesPublicSSHKey: *keypair.PublicKey,
 	}, nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Noticed a couple odd failures today in differnet regions due to cfn outputs.  I dont know for sure that cfn is the issue, but weve one like this before so im assuming a bit here.  Either way, this change pulls the jumpboxid and keypairid using the api instead of relying on them from cfn outputs.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

