### PR TITLE
fix: always configure package manager prior to package install

### DIFF
--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -101,12 +101,6 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
-	log.Info("Setting package manager config", zap.Reflect("containerd source", string(containerdSource)))
-	log.Info("Configuring package manager. This might take a while...")
-	if err := packageManager.Configure(ctx); err != nil {
-		return err
-	}
-
 	log.Info("Validating Kubernetes version", zap.Reflect("kubernetes version", c.kubernetesVersion))
 	// Create a Source for all AWS managed artifacts.
 	awsSource, err := aws.GetLatestSource(ctx, c.kubernetesVersion)

--- a/internal/flows/install.go
+++ b/internal/flows/install.go
@@ -37,6 +37,13 @@ func (i *Installer) Run(ctx context.Context) error {
 		return err
 	}
 
+	// temporary fix to re-configure package manager during upgrade which currently does full uninstall and re-install
+	// TODO: move Configure() back to install command when upgrade flow is changed
+	i.Logger.Info("Configuring package manager. This might take a while...")
+	if err := i.PackageManager.Configure(ctx); err != nil {
+		return err
+	}
+
 	if err := i.installDistroPackages(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A new change caused the package manager configuration for the containerd docker repo to be removed upon uninstallation. Since the upgrade process runs the uninstall process and then the install process, this led to the upgrade process no longer being able to find the containerd package using the docker source, as the package manager was only configured on nodeadm install command and not as part of the install flow. 

**Note that the timeout no longer applies to this process of installing/configuring the docker repo for the package manager; this should be changed in the future.**

*Testing (if applicable):*

Tested on an Ubuntu hybrid node and verified install, init, upgrade, and uninstall commands work as intended.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

