### PR TITLE
breaks e2e test case into mulitiple It blocks to support flakeattempts

### DIFF
--- a/test/e2e/suite/cleanup.go
+++ b/test/e2e/suite/cleanup.go
@@ -1,0 +1,44 @@
+package suite
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+const deferCleanupTimeout = 5 * time.Minute
+
+// TestCleanup is a helper for our use of DeferCleanup in our e2e tests
+// to support retrying EC2 instance creation
+// The cleanup runs after the test itself, just like the default DeferCleanup
+// but it only executes the cleanup if the test was a failure since otherwise
+// we want the instance to stay around for future tests
+// In the BeforeAll TestCleanup.DeferAll is called to register a defer cleanup
+// which runs all registered cleanups from our test methods after all tests
+// are complete
+type TestCleanup struct {
+	cleanups []func(context.Context)
+}
+
+func (t *TestCleanup) Register(f func(context.Context)) {
+	index := len(t.cleanups)
+	t.cleanups = append(t.cleanups, f)
+	DeferCleanup(func(ctx context.Context) {
+		if CurrentSpecReport().Failed() {
+			// remove cleanup if runs due to a test case failure so it does
+			// run again in the deferall
+			t.cleanups = append(t.cleanups[:index], t.cleanups[index+1:]...)
+			f(ctx)
+		}
+	}, NodeTimeout(deferCleanupTimeout))
+}
+
+func (t *TestCleanup) DeferAll() {
+	DeferCleanup(func(ctx context.Context) {
+		for i := len(t.cleanups) - 1; i >= 0; i-- {
+			f := t.cleanups[i]
+			f(ctx)
+		}
+	}, NodeTimeout(deferCleanupTimeout))
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This better utilizes the ginkgo test structure by breaking the various parts of the tests into different "nodes".  This also breaks the ec2 creation part of the test out so that it can be retried using FlakeAttempts if for some reason it never goes to running.  This required introducing a new defercleanup strategy to support keeping the instance around between different "tests" but still cleaning it up when appropriate. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

