### PR TITLE
Add region flag to install

### DIFF
--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -37,6 +37,7 @@ func NewCommand() cli.Command {
 	fc.AddPositionalValue(&cmd.kubernetesVersion, "KUBERNETES_VERSION", 1, true, "The major[.minor[.patch]] version of Kubernetes to install.")
 	fc.String(&cmd.credentialProvider, "p", "credential-provider", "Credential process to install. Allowed values: [ssm, iam-ra].")
 	fc.String(&cmd.containerdSource, "s", "containerd-source", "Source for containerd artifact. Allowed values: [none, distro, docker].")
+	fc.String(&cmd.region, "r", "region", "AWS region for downloading regional artifacts.")
 	fc.Duration(&cmd.timeout, "t", "timeout", "Maximum install command duration. Input follows duration format. Example: 1h23s")
 	cmd.flaggy = fc
 
@@ -48,15 +49,8 @@ type command struct {
 	kubernetesVersion  string
 	credentialProvider string
 	containerdSource   string
+	region             string
 	timeout            time.Duration
-}
-
-type Config struct {
-	AwsSource          aws.Source
-	ContainerdSource   containerd.SourceName
-	CredentialProvider creds.CredentialProvider
-	Log                *zap.Logger
-	DownloadTimeout    time.Duration
 }
 
 func (c *command) Flaggy() *flaggy.Subcommand {
@@ -113,6 +107,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		AwsSource:          awsSource,
 		PackageManager:     packageManager,
 		ContainerdSource:   containerdSource,
+		SsmRegion:          c.region,
 		CredentialProvider: credentialProvider,
 		Logger:             log,
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws/eks-hybrid
 go 1.22
 
 require (
-	github.com/aws/aws-sdk-go v1.55.5
+	github.com/aws/aws-sdk-go v1.55.6
 	github.com/aws/aws-sdk-go-v2/config v1.26.6
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.56.1
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.4
-	github.com/aws/smithy-go v1.22.1
+	github.com/aws/smithy-go v1.22.2
 	github.com/containerd/containerd v1.7.13
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/go-ini/ini v1.67.0
@@ -68,7 +68,7 @@ require (
 require (
 	dario.cat/mergo v1.0.1 // direct
 	github.com/Microsoft/go-winio v0.6.1 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.32.7
+	github.com/aws/aws-sdk-go-v2 v1.34.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.7 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.26 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.26 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,10 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
-github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
-github.com/aws/aws-sdk-go-v2 v1.32.7 h1:ky5o35oENWi0JYWUZkB7WYvVPP+bcRF5/Iq7JWSb5Rw=
-github.com/aws/aws-sdk-go-v2 v1.32.7/go.mod h1:P5WJBrYqqbWVaOxgH0X/FYYD47/nooaPOZPlQdmiN2U=
+github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
+github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
+github.com/aws/aws-sdk-go-v2 v1.34.0/go.mod h1:JgstGg0JjWU1KpVJjD5H0y0yyAIpSdKEq556EI6yOOM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 h1:lL7IfaFzngfx0ZwUGOZdsFFnQ5uLvR0hWqqhyE7Q9M8=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7/go.mod h1:QraP0UcVlQJsmHfioCrveWOC1nbiWUl3ej08h4mXWoc=
 github.com/aws/aws-sdk-go-v2/config v1.26.6 h1:Z/7w9bUqlRI0FFQpetVuFYEsjzE3h7fpU6HuGmfPL/o=
@@ -60,8 +60,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.2 h1:pi0Skl6mNl2w8qWZXcdOyg19
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.2/go.mod h1:JYzLoEVeLXk+L4tn1+rrkfhkxl6mLDEVaDSvGq9og90=
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.4 h1:Ppup1nVNAOWbBOrcoOxaxPeEnSFB2RnnQdguhXpmeQk=
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.4/go.mod h1:+K1rNPVyGxkRuv9NNiaZ4YhBFuyw2MMA9SlIJ1Zlpz8=
-github.com/aws/smithy-go v1.22.1 h1:/HPHZQ0g7f4eUeK6HKglFz8uwVfZKgoI25rb/J+dnro=
-github.com/aws/smithy-go v1.22.1/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
+github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/internal/flows/install.go
+++ b/internal/flows/install.go
@@ -26,6 +26,7 @@ type Installer struct {
 	ContainerdSource   containerd.SourceName
 	PackageManager     *packagemanager.DistroPackageManager
 	CredentialProvider creds.CredentialProvider
+	SsmRegion          string
 	Tracker            *tracker.Tracker
 	Logger             *zap.Logger
 }
@@ -78,9 +79,8 @@ func (i *Installer) installCredentialProcess(ctx context.Context) error {
 			return err
 		}
 	case creds.SsmCredentialProvider:
-		ssmInstaller := ssm.NewSSMInstaller(ssm.DefaultSsmInstallerRegion)
+		ssmInstaller := ssm.NewSSMInstaller(i.SsmRegion, i.Logger)
 
-		i.Logger.Info("Installing SSM agent installer...")
 		if err := ssm.Install(ctx, i.Tracker, ssmInstaller); err != nil {
 			return err
 		}

--- a/internal/ssm/source.go
+++ b/internal/ssm/source.go
@@ -49,8 +49,8 @@ func (s ssmInstallerSource) GetSSMInstaller(ctx context.Context) (io.ReadCloser,
 
 	obj, err := util.GetHttpFileReader(ctx, endpoint)
 	if err != nil {
-		obj.Close()
-		return nil, err
+		return nil, fmt.Errorf("unable to download SSM installer from region %s: "+
+			"please check SSM is available on the requested region (valid example: us-west-2)", s.region)
 	}
 	return obj, nil
 }

--- a/internal/ssm/source.go
+++ b/internal/ssm/source.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"runtime"
 
+	"go.uber.org/zap"
+
 	"github.com/aws/eks-hybrid/internal/util"
 )
 
@@ -17,14 +19,24 @@ const DefaultSsmInstallerRegion = "us-west-2"
 
 // SSMInstaller provides a Source that retrieves the SSM installer from the official
 // release endpoint.
-func NewSSMInstaller(region string) Source {
+func NewSSMInstaller(region string, logger *zap.Logger) Source {
+	if region == "" {
+		region = DefaultSsmInstallerRegion
+	}
+
 	return ssmInstallerSource{
 		region: region,
+		logger: logger,
 	}
 }
 
 type ssmInstallerSource struct {
 	region string
+	logger *zap.Logger
+}
+
+func (s ssmInstallerSource) GetSSMRegion() string {
+	return s.region
 }
 
 func (s ssmInstallerSource) GetSSMInstaller(ctx context.Context) (io.ReadCloser, error) {
@@ -32,6 +44,9 @@ func (s ssmInstallerSource) GetSSMInstaller(ctx context.Context) (io.ReadCloser,
 	if err != nil {
 		return nil, err
 	}
+
+	s.logger.Info("Downloading SSM installer...", zap.String("region", s.region), zap.String("url", endpoint))
+
 	obj, err := util.GetHttpFileReader(ctx, endpoint)
 	if err != nil {
 		obj.Close()

--- a/test/integration/cases/install-with-region/expected-nodeadm-tracker
+++ b/test/integration/cases/install-with-region/expected-nodeadm-tracker
@@ -1,0 +1,10 @@
+Artifacts:
+  CniPlugins: true
+  Containerd: distro
+  IamAuthenticator: true
+  IamRolesAnywhere: false
+  ImageCredentialProvider: true
+  Iptables: true
+  Kubectl: true
+  Kubelet: true
+  Ssm: true

--- a/test/integration/cases/install-with-region/run.sh
+++ b/test/integration/cases/install-with-region/run.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+wait::dbus-ready
+
+# remove previously installed containerd to test installation via nodeadm
+dnf remove -y containerd
+
+declare SUPPORTED_VERSIONS=(1.26 1.27 1.28 1.29 1.30)
+
+for VERSION in ${SUPPORTED_VERSIONS}
+do
+
+    nodeadm install $VERSION --credential-provider ssm --region us-east-1
+
+    assert::path-exists /usr/bin/containerd
+    assert::path-exists /usr/sbin/iptables
+    assert::path-exists /usr/bin/kubelet
+    assert::path-exists /usr/local/bin/kubectl
+    VERSION_INFO=$(/usr/local/bin/kubectl version || true)
+    assert::is-substring "$VERSION_INFO" "v$VERSION"
+    assert::path-exists /opt/cni/bin/
+    assert::path-exists /etc/eks/image-credential-provider/ecr-credential-provider
+    assert::path-exists /usr/local/bin/aws-iam-authenticator
+
+    assert::path-exists /opt/ssm/ssm-setup-cli
+    assert::path-exists /usr/bin/amazon-ssm-agent
+
+    assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
+
+    nodeadm uninstall --skip node-validation,pod-validation
+
+    assert::path-not-exist /usr/bin/containerd
+    assert::path-not-exist /usr/sbin/iptables
+    assert::path-not-exist /usr/bin/kubelet
+    assert::path-not-exist /usr/local/bin/kubectl
+    assert::path-not-exist /opt/cni/bin/
+    assert::path-not-exist /etc/eks/image-credential-provider/ecr-credential-provider
+    assert::path-not-exist /usr/local/bin/aws-iam-authenticator
+    assert::path-not-exist /usr/bin/containerd
+    assert::path-not-exist /opt/ssm/ssm-setup-cli
+    assert::path-not-exist /usr/bin/amazon-ssm-agent
+    assert::path-not-exist /opt/nodeadm/tracker
+
+    assert::install-fails-with-region $VERSION "bad-region-name"
+done

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -153,6 +153,21 @@ function assert::file-permission-matches() {
   fi
 }
 
+function assert::install-fails-with-region() {
+    if [ "$#" -ne 2 ]; then
+        echo "Usage: assert::install_fails_with_region [version] [region]"
+        exit 1
+    fi
+
+    local VERSION=$1
+    local REGION=$2
+
+    if nodeadm install $VERSION --credential-provider ssm --region $REGION >/dev/null 2>&1; then
+        echo "Install unexpectedly succeeded with region '$REGION'"
+        exit 1
+    fi
+}
+
 # Check if a non-json file exists and verify its permission, if a 3rd argument is provided, also check file content
 function validate-file() {
   if [[ "$#" -ne 2 && "$#" -ne 3 ]]; then


### PR DESCRIPTION
*Issue #, if available:* 2906

*Description of changes:*

Add a --region flag to `nodeadm install`, which will determine which region the SSM installer is downloaded from. 

*Testing (if applicable):*

Tested on ubuntu hybrid node and verified :

- original behavior unchanged when no --region flag used
- region flag changes download location (verified through logging output)
- error is handled appropriately for bad region input by checking download url

*Documentation added/planned (if applicable):*

Flag will be added to public documentation ahead of nodeadm release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

