### PR TITLE
Improve error handling for node drained validation

### DIFF
--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -94,7 +94,9 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		if kubeletStatus == daemon.DaemonStatusRunning {
 			if !slices.Contains(c.skipPhases, skipPodPreflightCheck) {
 				log.Info("Validating if node has been drained...")
-				if err := node.IsDrained(ctx); err != nil {
+				if drained, err := node.IsDrained(ctx); err != nil {
+					return fmt.Errorf("validating if node has been drained: %w", err)
+				} else if !drained {
 					return fmt.Errorf("only static pods and pods controlled by daemon-sets can be running on the node. Please move pods " +
 						"to different node or use --skip pod-validation")
 				}
@@ -102,7 +104,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 			if !slices.Contains(c.skipPhases, skipNodePreflightCheck) {
 				log.Info("Validating if node has been marked unschedulable...")
 				if err := node.IsUnscheduled(ctx); err != nil {
-					return fmt.Errorf("please drain or cordon node to mark it unschedulable or use --skip node-validation. %v", err)
+					return fmt.Errorf("please drain or cordon node to mark it unschedulable or use --skip node-validation: %w", err)
 				}
 			}
 		}

--- a/cmd/nodeadm/upgrade/upgrade.go
+++ b/cmd/nodeadm/upgrade/upgrade.go
@@ -154,7 +154,9 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		if kubeletStatus == daemon.DaemonStatusRunning {
 			if !slices.Contains(c.skipPhases, skipPodPreflightCheck) {
 				log.Info("Validating if node has been drained...")
-				if err := node.IsDrained(ctx); err != nil {
+				if drained, err := node.IsDrained(ctx); err != nil {
+					return fmt.Errorf("validating if node has been drained: %w", err)
+				} else if !drained {
 					return fmt.Errorf("only static pods and pods controlled by daemon-sets can be running on the node. Please move pods " +
 						"to different node or use --skip pod-validation")
 				}
@@ -162,7 +164,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 			if !slices.Contains(c.skipPhases, skipNodePreflightCheck) {
 				log.Info("Validating if node has been marked unschedulable...")
 				if err := node.IsUnscheduled(ctx); err != nil {
-					return fmt.Errorf("please drain or cordon node to mark it unschedulable or use --skip node-validation. %v", err)
+					return fmt.Errorf("please drain or cordon node to mark it unschedulable or use --skip node-validation: %w", err)
 				}
 			}
 		}

--- a/internal/node/pods.go
+++ b/internal/node/pods.go
@@ -86,18 +86,12 @@ func getStaticPodsOnNode() ([]string, error) {
 	return staticPodNames, nil
 }
 
-func getPodsOnNode() ([]corev1.Pod, error) {
-	nodeName, err := kubelet.GetNodeName()
-	if err != nil {
-		return nil, err
-	}
-
+func getPodsOnNode(ctx context.Context, nodeName string) ([]corev1.Pod, error) {
 	clientset, err := kubelet.GetKubeClientFromKubeConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create kubernetes client")
 	}
 
-	ctx := context.Background()
 	pods, err := clientset.CoreV1().Pods("").List(ctx,
 		metav1.ListOptions{
 			FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),

--- a/internal/node/validations_wb_test.go
+++ b/internal/node/validations_wb_test.go
@@ -1,0 +1,57 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/aws/smithy-go/ptr"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_isDrained(t *testing.T) {
+	testCases := []struct {
+		name string
+		pods []corev1.Pod
+		want bool
+	}{
+		{
+			name: "drained: no pods",
+			want: true,
+		},
+		{
+			name: "drained: all pods are daemonsets",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind:       "DaemonSet",
+								Controller: ptr.Bool(true),
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "not drained",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isDrained(tc.pods)).To(Equal(tc.want))
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
We were hiding the real error and assuming that if failed, it meant there were not drained pods. Now he handle differently execution errors from the node not being drained, and return a different error depending on the case.

*Testing (if applicable):*
Tested with e2e upgrade test for al23 and iam-ra

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

