### PR TITLE
Add JUnit reports to e2e tests

### DIFF
--- a/buildspecs/test-nodeadm.yml
+++ b/buildspecs/test-nodeadm.yml
@@ -10,3 +10,9 @@ phases:
     commands:
     - SANITIZED_CODEBUILD_BUILD_ID=$(echo $CODEBUILD_BUILD_ID | tr ':' '-')
     - ./hack/run-e2e.sh $SANITIZED_CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/latest-pre/linux/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest-pre/linux/arm64/nodeadm $LOGS_BUCKET $ENDPOINT
+
+reports:
+  e2e-reports:
+    files:
+      - e2e-reports/junit-nodeadm.xml
+    file-format: "JUNITXML"

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -79,9 +79,11 @@ SKIP_FILE=$REPO_ROOT/hack/SKIPPED_TESTS.yaml
 # Extract skipped_tests field from SKIP_FILE file and join entries with ' || '
 skip=$(yq '.skipped_tests | join("|")' ${SKIP_FILE})
 
-# We expliclty specify procs instead of letting ginkgo decide (with -p) because in if not
+mkdir -p e2e-reports
+
+# We explicitly specify procs instead of letting ginkgo decide (with -p) because in if not
 # ginkgo will use all available CPUs, which could be a small number depending
-# on how the CI runner has been configured. However, even if only one CPU is avaialble,
+# on how the CI runner has been configured. However, even if only one CPU is available,
 # there is still value in running the tests in multiple processes, since most of the work is
 # "waiting" for infra to be created and nodes to join the cluster.
-$BIN_DIR/ginkgo --procs 64 -v -tags=e2e --no-color --skip="${skip}" --label-filter="(simpleflow) || (upgradeflow && (ubuntu2204-amd64 || rhel8-amd64 || al23-amd64))" $BIN_DIR/e2e.test -- -filepath=$CONFIG_DIR/e2e-param.yaml
+$BIN_DIR/ginkgo --procs 64 -v -tags=e2e --no-color --skip="${skip}" --label-filter="(simpleflow) || (upgradeflow && (ubuntu2204-amd64 || rhel8-amd64 || al23-amd64))" --junit-report=e2e-reports/junit-nodeadm.xml $BIN_DIR/e2e.test -- -filepath=$CONFIG_DIR/e2e-param.yaml


### PR DESCRIPTION
*Description of changes:*
This makes a bit easier to track the failed tests in the console. It allows to search by status, test name, etc. You can see the logs of each test separately but they tend to be truncated. It might help with metrics as well, but we will see. Either way, it's a cheap change.

This is how it looks:

![Screenshot 2025-01-28 at 17 30 59](https://github.com/user-attachments/assets/2a3c8d1a-18df-4d34-bbdb-024780aaee37)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

