### PR TITLE
Respect no-color option in e2e test logger

### DIFF
--- a/test/e2e/logger.go
+++ b/test/e2e/logger.go
@@ -9,9 +9,28 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func NewLogger() logr.Logger {
+type LoggerConfig struct {
+	NoColor bool
+}
+
+func (c LoggerConfig) Apply(opts *LoggerConfig) {
+	opts.NoColor = c.NoColor
+}
+
+type LoggerOption interface {
+	Apply(*LoggerConfig)
+}
+
+func NewLogger(opts ...LoggerOption) logr.Logger {
+	cfg := &LoggerConfig{}
+	for _, opt := range opts {
+		opt.Apply(cfg)
+	}
+
 	encoderCfg := zap.NewDevelopmentEncoderConfig()
-	encoderCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	if !cfg.NoColor {
+		encoderCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	}
 
 	consoleEncoder := zapcore.NewConsoleEncoder(encoderCfg)
 	core := zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), zapcore.DebugLevel)

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -120,7 +120,7 @@ var _ = SynchronizedBeforeSuite(
 		config, err := readTestConfig(filePath)
 		Expect(err).NotTo(HaveOccurred(), "should read valid test configuration")
 
-		logger := e2e.NewLogger()
+		logger := newLoggerForTests()
 		aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.ClusterRegion))
 		Expect(err).NotTo(HaveOccurred())
 
@@ -350,7 +350,7 @@ func readTestConfig(configPath string) (*TestConfig, error) {
 func buildPeeredVPCTestForSuite(ctx context.Context, suite *suiteConfiguration) (*peeredVPCTest, error) {
 	test := &peeredVPCTest{
 		stackOut:               suite.CredentialsStackOutput,
-		logger:                 e2e.NewLogger(),
+		logger:                 newLoggerForTests(),
 		logsBucket:             suite.TestConfig.LogsBucket,
 		overrideNodeK8sVersion: suite.TestConfig.NodeK8sVersion,
 		publicKey:              suite.PublicKey,
@@ -476,4 +476,13 @@ func (t *peeredVPCTest) newVerifyPodIdentityAddon() *addon.VerifyPodIdentityAddo
 		Logger:    t.logger,
 		EKSClient: t.eksClient,
 	}
+}
+
+func newLoggerForTests() logr.Logger {
+	_, reporter := GinkgoConfiguration()
+	cfg := e2e.LoggerConfig{}
+	if reporter.NoColor {
+		cfg.NoColor = true
+	}
+	return e2e.NewLogger(cfg)
 }


### PR DESCRIPTION
*Description of changes:*
We use the ginkgo no-color option when running tests on CI. This avoids terminal control characters to appear in the logs. However, this only controls the logs emitted by ginkgo and not the one we print. As a result, all the "INFO" log lines showed up mangled in CI logs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

