### PR TITLE
Don't define e2e specs for not supported configs

### DIFF
--- a/hack/SKIPPED_TESTS.yaml
+++ b/hack/SKIPPED_TESTS.yaml
@@ -1,8 +1,4 @@
 skipped_tests:
-  - "ubuntu2004-amd64.*iam-ra"
-  - "rhel8-amd64.*iam-ra"
-  - "ubuntu2004-arm64.*iam-ra"
-  - "rhel8-arm64.*iam-ra"
   - "ubuntu2004-amd64-docker.*"
   - "ubuntu2204-amd64-docker.*"
   - "ubuntu2404-amd64-docker.*"

--- a/test/e2e/credentials/rolesanywhere.go
+++ b/test/e2e/credentials/rolesanywhere.go
@@ -76,3 +76,8 @@ func (i *IamRolesAnywhereProvider) FilesForNode(spec e2e.NodeSpec) ([]e2e.File, 
 		},
 	}, nil
 }
+
+// IsIAMRolesAnywhere returns true if the given CredentialProvider is IAM Roles Anywhere.
+func IsIAMRolesAnywhere(name creds.CredentialProvider) bool {
+	return name == creds.IamRolesAnywhereCredentialProvider
+}

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -221,3 +221,8 @@ func findLatestImage(ctx context.Context, client *ec2.Client, amiPrefix, arch st
 func paginationDone(in *ec2.DescribeImagesInput, out *ec2.DescribeImagesOutput) bool {
 	return (in.NextToken != nil && in.NextToken == out.NextToken) || len(out.Images) == 0
 }
+
+// IsRHEL8 returns true if the given name is a RHEL 8 OS name.
+func IsRHEL8(name string) bool {
+	return strings.HasPrefix(name, "rhel8")
+}

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -245,3 +245,8 @@ func (u Ubuntu2404) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, erro
 
 	return executeTemplate(ubuntu2404CloudInit, data)
 }
+
+// IsUbuntu2004 returns true if the given name is an Ubuntu 2004 OS name.
+func IsUbuntu2004(name string) bool {
+	return strings.HasPrefix(name, "ubuntu2004")
+}

--- a/test/e2e/suite/matcher.go
+++ b/test/e2e/suite/matcher.go
@@ -1,0 +1,23 @@
+package suite
+
+import "github.com/aws/eks-hybrid/internal/creds"
+
+type nodeadmConfigMatcher struct {
+	matchOS            func(name string) bool
+	matchCredsProvider func(name creds.CredentialProvider) bool
+}
+
+func (m nodeadmConfigMatcher) matches(osName string, creds creds.CredentialProvider) bool {
+	return m.matchOS(osName) && m.matchCredsProvider(creds)
+}
+
+type nodeadmConfigMatchers []nodeadmConfigMatcher
+
+func (m nodeadmConfigMatchers) matches(osName string, creds creds.CredentialProvider) bool {
+	for _, matcher := range m {
+		if matcher.matches(osName, creds) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
*Description of changes:*
Combinations like ubuntu 2004 or RHEL8 and IAM-RA are not supported. Instead of requiring those test to be skipped (they will always fail), we just don't define the test at all.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

