### PR TITLE
Set up pod identity association in E2E tests

### DIFF
--- a/test/e2e/addon/addon.go
+++ b/test/e2e/addon/addon.go
@@ -8,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/go-logr/logr"
+
+	"github.com/aws/eks-hybrid/test/e2e/errors"
 )
 
 type Addon struct {
@@ -31,6 +33,10 @@ func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logge
 
 	_, err := client.CreateAddon(ctx, params)
 
+	if err != nil && !errors.IsType(err, &types.ResourceInUseException{}) {
+		// Ignore if add-on is already created
+		return nil
+	}
 	return err
 }
 

--- a/test/e2e/addon/podidentityaddon.go
+++ b/test/e2e/addon/podidentityaddon.go
@@ -1,0 +1,53 @@
+package addon
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/go-logr/logr"
+	clientgo "k8s.io/client-go/kubernetes"
+
+	"github.com/aws/eks-hybrid/test/e2e/errors"
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+)
+
+type PodIdentityAddon struct {
+	Addon
+	Kubernetes         *clientgo.Clientset
+	IAMClient          *iam.Client
+	PodIdentityRoleArn string
+}
+
+const (
+	podIdentityServiceAccount = "pod-identity-sa"
+	namespace                 = "default"
+)
+
+func (p PodIdentityAddon) Create(ctx context.Context, client *eks.Client, logger logr.Logger) error {
+	if err := p.Addon.Create(ctx, client, logger); err != nil {
+		return err
+	}
+
+	// Provision PodIdentity addon related resources
+	// Create service account in kubernetes
+	if err := kubernetes.NewServiceAccount(ctx, logger, p.Kubernetes, namespace, podIdentityServiceAccount); err != nil {
+		return err
+	}
+
+	createPodIdentityAssociationInput := &eks.CreatePodIdentityAssociationInput{
+		ClusterName:    &p.Cluster,
+		Namespace:      aws.String(namespace),
+		RoleArn:        &p.PodIdentityRoleArn,
+		ServiceAccount: aws.String(podIdentityServiceAccount),
+	}
+
+	_, err := client.CreatePodIdentityAssociation(ctx, createPodIdentityAssociationInput)
+	if err != nil && !errors.IsType(err, &types.ResourceInUseException{}) {
+		return err
+	}
+
+	return nil
+}

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -36,8 +36,7 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, getAddonTimeout)
 	defer cancel()
 
-	var err error
-	if err = podIdentityAddon.WaitUtilActive(timeoutCtx, v.EKSClient, v.Logger); err != nil {
+	if err := podIdentityAddon.WaitUtilActive(timeoutCtx, v.EKSClient, v.Logger); err != nil {
 		return err
 	}
 

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"context"
+	_ "embed"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
@@ -27,19 +28,27 @@ type VerifyPodIdentityAddon struct {
 func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 	v.Logger.Info("Verify pod identity add-on is installed")
 
-	podIdentityAddon := Addon{
-		Name:    podIdentityAgent,
-		Cluster: v.Cluster,
+	podIdentityAddon := PodIdentityAddon{
+		Addon: Addon{
+			Name:    podIdentityAgent,
+			Cluster: v.Cluster,
+		},
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, getAddonTimeout)
 	defer cancel()
 
-	if err := podIdentityAddon.WaitUtilActive(timeoutCtx, v.EKSClient, v.Logger); err != nil {
+	var err error
+	if err = podIdentityAddon.WaitUtilActive(timeoutCtx, v.EKSClient, v.Logger); err != nil {
 		return err
 	}
 
 	v.Logger.Info("Check if daemon set exists", "daemonSet", podIdentityDaemonSet)
-	_, err := kubernetes.GetDaemonSet(ctx, v.Logger, v.K8S, "kube-system", podIdentityDaemonSet)
-	return err
+	if _, err := kubernetes.GetDaemonSet(ctx, v.Logger, v.K8S, "kube-system", podIdentityDaemonSet); err != nil {
+		return err
+	}
+
+	// TODO: Deploy a pod with service account to verify the pod identity token section is populated in pod manifest files
+
+	return nil
 }

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -28,11 +28,9 @@ type VerifyPodIdentityAddon struct {
 func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 	v.Logger.Info("Verify pod identity add-on is installed")
 
-	podIdentityAddon := PodIdentityAddon{
-		Addon: Addon{
-			Name:    podIdentityAgent,
-			Cluster: v.Cluster,
-		},
+	podIdentityAddon := Addon{
+		Name:    podIdentityAgent,
+		Cluster: v.Cluster,
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, getAddonTimeout)

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -362,6 +362,30 @@ Resources:
                 path: /root/download-private-key.sh
                 permissions: "0755"
 
+  PodIdentityAssociationRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: 'pods.eks.amazonaws.com'
+            Action:
+              - sts:AssumeRole
+              - sts:TagSession
+      Policies:
+        - PolicyName: pod-identity-association-role-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: arn:aws:s3:::RANDOM_NON_EXISTENT_BUCKET
+      Tags:
+        - Key: !Ref TestClusterTagKey
+          Value: !Ref ClusterName
+
 Outputs:
   ClusterRole:
     Description: The name of the IAM Role for EKS Hybrid Cluster.
@@ -382,3 +406,7 @@ Outputs:
   ClusterSecurityGroup:
     Description: The ID of the EKS Hybrid Cluster Security Group.
     Value: !GetAtt ClusterVPC.DefaultSecurityGroup
+
+  PodIdentityAssociationRoleARN:
+    Description: The role ARN of PodIdentityAssociationRole
+    Value: !GetAtt PodIdentityAssociationRole.Arn

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -114,8 +114,8 @@ func (c *Create) Run(ctx context.Context, test TestResources) error {
 			Name:          podIdentityAddonName,
 			Configuration: "{\"daemonsets\":{\"hybrid\":{\"create\": true}}}",
 		},
-		Kubernetes: k8sClient,
-		IAMClient:  c.iam,
+		Kubernetes:         k8sClient,
+		IAMClient:          c.iam,
 		PodIdentityRoleArn: stackOut.podIdentityRoleArn,
 	}
 

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -9,9 +9,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/aws/eks-hybrid/test/e2e"
@@ -47,6 +49,7 @@ type Create struct {
 	logger logr.Logger
 	eks    *eks.Client
 	stack  *stack
+	iam    *iam.Client
 }
 
 // NewCreate creates a new workflow to create an EKS cluster. The EKS client will use
@@ -63,6 +66,7 @@ func NewCreate(aws aws.Config, logger logr.Logger, endpoint string) Create {
 			logger:    logger,
 			ssmClient: ssm.NewFromConfig(aws),
 		},
+		iam: iam.NewFromConfig(aws),
 	}
 }
 
@@ -88,17 +92,6 @@ func (c *Create) Run(ctx context.Context, test TestResources) error {
 		return fmt.Errorf("creating %s EKS cluster: %w", test.KubernetesVersion, err)
 	}
 
-	podIdentityAddon := addon.Addon{
-		Cluster:       hybridCluster.Name,
-		Name:          podIdentityAddonName,
-		Configuration: "{\"daemonsets\":{\"hybrid\":{\"create\": true}}}",
-	}
-
-	err = podIdentityAddon.Create(ctx, c.eks, c.logger)
-	if err != nil && !errors.IsType(err, &types.ResourceInUseException{}) {
-		return fmt.Errorf("creating add-on %s for EKS cluster: %w", podIdentityAddon, err)
-	}
-
 	kubeconfig := KubeconfigPath(test.ClusterName)
 	err = hybridCluster.UpdateKubeconfig(kubeconfig)
 	if err != nil {
@@ -108,6 +101,27 @@ func (c *Create) Run(ctx context.Context, test TestResources) error {
 	clientConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return fmt.Errorf("loading kubeconfig: %w", err)
+	}
+
+	k8sClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return fmt.Errorf("creating kubernetes client: %w", err)
+	}
+
+	podIdentityAddon := addon.PodIdentityAddon{
+		Addon: addon.Addon{
+			Cluster:       hybridCluster.Name,
+			Name:          podIdentityAddonName,
+			Configuration: "{\"daemonsets\":{\"hybrid\":{\"create\": true}}}",
+		},
+		Kubernetes: k8sClient,
+		IAMClient:  c.iam,
+		PodIdentityRoleArn: stackOut.podIdentityRoleArn,
+	}
+
+	err = podIdentityAddon.Create(ctx, c.eks, c.logger)
+	if err != nil && !errors.IsType(err, &types.ResourceInUseException{}) {
+		return fmt.Errorf("creating add-on %s for EKS cluster: %w", podIdentityAddon.Name, err)
 	}
 
 	dynamicK8s, err := dynamic.NewForConfig(clientConfig)

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -106,9 +106,9 @@ func (c *Create) Run(ctx context.Context, test TestResources) error {
 		return fmt.Errorf("creating kubernetes client: %w", err)
 	}
 
-	podIdentityAddon := addon.NewPodIdentityAddon(hybridCluster.Name, podIdentityAddonName, k8sClient, c.iam, stackOut.podIdentityRoleArn)
+	podIdentityAddon := addon.NewPodIdentityAddon(hybridCluster.Name, podIdentityAddonName, stackOut.podIdentityRoleArn)
 
-	err = podIdentityAddon.Create(ctx, c.eks, c.logger)
+	err = podIdentityAddon.Create(ctx, c.logger, c.eks, k8sClient)
 	if err != nil {
 		return fmt.Errorf("creating add-on %s for EKS cluster: %w", podIdentityAddon.Name, err)
 	}

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -38,8 +38,9 @@ type vpcConfig struct {
 }
 
 type resourcesStackOutput struct {
-	clusterRole      string
-	clusterVpcConfig vpcConfig
+	clusterRole        string
+	clusterVpcConfig   vpcConfig
+	podIdentityRoleArn string
 }
 
 type stack struct {
@@ -179,6 +180,8 @@ func (s *stack) deploy(ctx context.Context, test TestResources) (*resourcesStack
 			result.clusterVpcConfig.privateSubnet = *output.OutputValue
 		case "ClusterSecurityGroup":
 			result.clusterVpcConfig.securityGroup = *output.OutputValue
+		case "PodIdentityAssociationRoleARN":
+			result.podIdentityRoleArn = *output.OutputValue
 		}
 	}
 

--- a/test/e2e/kubernetes/kubernetes.go
+++ b/test/e2e/kubernetes/kubernetes.go
@@ -547,7 +547,7 @@ func GetDaemonSet(ctx context.Context, logger logr.Logger, k8s *kubernetes.Clien
 
 func NewServiceAccount(ctx context.Context, logger logr.Logger, k8s *kubernetes.Clientset, namespace, name string) error {
 	if _, err := k8s.CoreV1().ServiceAccounts(namespace).Get(ctx, name, metav1.GetOptions{}); err == nil {
-		logger.Info("Service account has already been created", "namespace", namespace, name)
+		logger.Info("Service account already exists", "namespace", namespace, "name", name)
 		return nil
 	}
 

--- a/test/e2e/kubernetes/kubernetes.go
+++ b/test/e2e/kubernetes/kubernetes.go
@@ -544,3 +544,27 @@ func GetDaemonSet(ctx context.Context, logger logr.Logger, k8s *kubernetes.Clien
 
 	return foundDaemonSet, nil
 }
+
+func NewServiceAccount(ctx context.Context, logger logr.Logger, k8s *kubernetes.Clientset, namespace, name string) error {
+	if _, err := k8s.CoreV1().ServiceAccounts(namespace).Get(ctx, name, metav1.GetOptions{}); err == nil {
+		logger.Info("Service account has already been created", "namespace", namespace, name)
+		return nil
+	}
+
+	serviceAccount := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+
+	if _, err := k8s.CoreV1().ServiceAccounts(namespace).Create(ctx, serviceAccount, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -255,7 +255,6 @@ var _ = Describe("Hybrid Nodes", func() {
 
 							test.logger.Info("Testing Pod Identity add-on functionality")
 							verifyPodIdentityAddon := test.newVerifyPodIdentityAddon()
-
 							Expect(verifyPodIdentityAddon.Run(ctx)).To(Succeed(), "pod identity add-on should be created successfully")
 
 							test.logger.Info("Resetting hybrid node...")


### PR DESCRIPTION
*Issue #, if available:*
This is part 2 of setting up E2E tests for pod identity. [Part 1 PR](https://github.com/aws/eks-hybrid/pull/282)

*Description of changes:*
This PR covers pod identity association setup. 

*(Since this PR already contains enough changes, I will create another PR to actually deploy pods and verify EKS Pod Identity volume is correctly attached.)*

I followed this [public document](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-association.html#_create_a_pod_identity_association_cli) to set up pod identity association.

In summary, the following is required in order to set up pod identity association.
1. Create IAM role with trust relationship for Pod Identity role. The role should also be able to access some AWS resource.
2. Create a service account dedicated for Pod Identity
3. Associate the IAM role to the service account

---
The creation of service account and pod identity association can only be done after the EKS cluster is provisioned successfully. We can put this into either 
1) the creation of Pod Identity add-on, or
2) during the add-on e2e tests.

Here I choose to put it into creation of pod identity add-on. The reason for it is we don't need to check or set up this association in every `OS/auth provider` combination. It should be a one-time setup for the whole EKS cluster.

---

The creation of IAM role of pod identity can be put into
1) `nodeadm-stack.ts` to provision one IAM role for all `kube/CNI` combination
2) `setup-cfn.yaml` to provision one IAM role for all `OS/Auth provider` under one `kube/CNI` combination
3) during e2e test to check or provision one IAM role for each `OS/Auth provider` 

Option 3 is not applicable for two reasons.
- pod identity association is now done during creation of the add-on, which requires IAM ARN to complete the process
- it's very inefficient to check/provision the IAM role for each `OS/Auth provider`

Option 1 and 2 are both working but I choose option 2 because it makes more sense as the role is tied to one cluster, which the lifecycle is managed by CloudFormation.

---
*Testing (if applicable):*
1. Run e2e test locally
5. Deploy the change to personal dev stack in CodePipeline

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

