### PR TITLE
Print S3 logs URL when tests fail at init or upgrade

### DIFF
--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -57,7 +57,7 @@ type NodeSpec struct {
 // Create spins up an EC2 instance with the proper user data to join as a Hybrid node to the cluster.
 func (c Node) Create(ctx context.Context, spec *NodeSpec) (ec2.Instance, error) {
 	if c.LogsBucket != "" {
-		c.Logger.Info(fmt.Sprintf("Logs bucket: https://%s.console.aws.amazon.com/s3/buckets/%s?prefix=%s/", c.Cluster.Region, c.LogsBucket, c.logsPrefix(spec.InstanceName)))
+		c.Logger.Info("Instance logs will be collected in S3", "url", c.S3LogsURL(spec.InstanceName))
 	}
 
 	nodeSpec := e2e.NodeSpec{
@@ -160,6 +160,10 @@ func (c *Node) Cleanup(ctx context.Context, instance ec2.Instance) error {
 	}
 
 	return nil
+}
+
+func (c Node) S3LogsURL(instanceName string) string {
+	return fmt.Sprintf("https://%s.console.aws.amazon.com/s3/buckets/%s?prefix=%s/", c.Cluster.Region, c.LogsBucket, c.logsPrefix(instanceName))
 }
 
 func (c Node) logsPrefix(instanceName string) string {

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -268,7 +268,8 @@ var _ = Describe("Hybrid Nodes", func() {
 
 							verifyNode := test.newVerifyNode(instance.IP)
 							Expect(verifyNode.Run(ctx)).To(
-								Succeed(), "node should have joined the cluster successfully",
+								Succeed(), "node should have joined the cluster successfully"+
+									". You can access the collected node logs at: %s", peeredNode.S3LogsURL(instance.Name),
 							)
 
 							test.logger.Info("Testing Pod Identity add-on functionality")
@@ -284,7 +285,10 @@ var _ = Describe("Hybrid Nodes", func() {
 							Expect(nodeadm.RebootInstance(ctx, test.remoteCommandRunner, instance.IP)).NotTo(HaveOccurred(), "EC2 Instance should have rebooted successfully")
 							test.logger.Info("EC2 Instance rebooted successfully.")
 
-							Expect(verifyNode.Run(ctx)).To(Succeed(), "node should have re-joined, there must be a problem with uninstall")
+							Expect(verifyNode.Run(ctx)).To(Succeed(),
+								"node should have re-joined, there must be a problem with uninstall"+
+									". You can access the collected node logs at: %s", peeredNode.S3LogsURL(instance.Name),
+							)
 
 							if test.skipCleanup {
 								test.logger.Info("Skipping nodeadm uninstall from the hybrid node...")
@@ -328,11 +332,13 @@ var _ = Describe("Hybrid Nodes", func() {
 
 							verifyNode := test.newVerifyNode(instance.IP)
 							Expect(verifyNode.Run(ctx)).To(
-								Succeed(), "node should have joined the cluster successfully",
+								Succeed(), "node should have joined the cluster successfully"+
+									". You can access the collected node logs at: %s", peeredNode.S3LogsURL(instance.Name),
 							)
 
 							Expect(test.newUpgradeNode(instance.IP).Run(ctx)).To(
-								Succeed(), "node should have upgraded successfully",
+								Succeed(), "node should have upgraded successfully"+
+									". You can access the collected node logs at: %s", peeredNode.S3LogsURL(instance.Name),
 							)
 
 							Expect(verifyNode.Run(ctx)).To(Succeed(), "node should have joined the cluster successfully after nodeadm upgrade")


### PR DESCRIPTION
*Description of changes:*
Quality of life improvement when debugging tests. The URl was already printed at the top of the test, but this just also puts it close to the error itself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

