### PR TITLE
Upgrade improvements - Only upgrade artifacts and services if there is an upgrade avilable

### DIFF
--- a/internal/artifact/install.go
+++ b/internal/artifact/install.go
@@ -1,16 +1,12 @@
 package artifact
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path"
-	"time"
-
-	"github.com/aws/eks-hybrid/internal/util/cmd"
 )
 
 // DefaultDirPerms are the permissions assigned to a directory when an Install* func is called
@@ -53,16 +49,4 @@ func InstallTarGz(dst, src string) error {
 		return err
 	}
 	return nil
-}
-
-// InstallPackageWithRetries installs a package and retries errors until the context is
-// cancelled. The backoff duration is the time to wait between retries.
-func InstallPackageWithRetries(ctx context.Context, pkgSource Package, backoff time.Duration) error {
-	return cmd.Retry(ctx, pkgSource.InstallCmd, backoff)
-}
-
-// UninstallPackageWithRetries uninstalls a package and retries errors until the context is
-// cancelled. The backoff duration is the time to wait between retries.
-func UninstallPackageWithRetries(ctx context.Context, pkgSource Package, backoff time.Duration) error {
-	return cmd.Retry(ctx, pkgSource.UninstallCmd, backoff)
 }

--- a/internal/artifact/package.go
+++ b/internal/artifact/package.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Package interface defines a package source
-// It defines the install and uninstall command to be executed
+// It defines the install, uninstall & upgrade commands to be executed
 type Package interface {
 	// InstallCmd returns the command to install the package.
 	// Every invocation guarantees a new command.
@@ -14,11 +14,15 @@ type Package interface {
 	// UninstallCmd returns the command to uninstall the package.
 	// Every invocation guarantees a new command.
 	UninstallCmd(context.Context) *exec.Cmd
+	// UpgradeCmd return the command to upgrade the package
+	// Every invocation guarantees a new command.
+	UpgradeCmd(ctx context.Context) *exec.Cmd
 }
 
 type packageSource struct {
 	installCmd   Cmd
 	uninstallCmd Cmd
+	upgradeCmd   Cmd
 }
 
 // Cmd represents a command to be executed.
@@ -40,10 +44,11 @@ func NewCmd(path string, args ...string) Cmd {
 	}
 }
 
-func NewPackageSource(installCmd, uninstallCmd Cmd) Package {
+func NewPackageSource(installCmd, uninstallCmd, upgradeCmd Cmd) Package {
 	return &packageSource{
 		installCmd:   installCmd,
 		uninstallCmd: uninstallCmd,
+		upgradeCmd:   upgradeCmd,
 	}
 }
 
@@ -53,4 +58,8 @@ func (ps *packageSource) InstallCmd(ctx context.Context) *exec.Cmd {
 
 func (ps *packageSource) UninstallCmd(ctx context.Context) *exec.Cmd {
 	return ps.uninstallCmd.Command(ctx)
+}
+
+func (ps *packageSource) UpgradeCmd(ctx context.Context) *exec.Cmd {
+	return ps.upgradeCmd.Command(ctx)
 }

--- a/internal/artifact/testdata/dummyfile
+++ b/internal/artifact/testdata/dummyfile
@@ -1,0 +1,1 @@
+hello world

--- a/internal/artifact/upgrade.go
+++ b/internal/artifact/upgrade.go
@@ -1,0 +1,52 @@
+package artifact
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// checksumMatch compares the checksum of the installed artifact with the expected checksum
+// A mismatch of checksum indicates installed artifacts are due for an upgrade
+func checksumMatch(installedArtifactPath string, src Source) (bool, error) {
+	fh, err := os.Open(installedArtifactPath)
+	if err != nil {
+		return false, errors.Wrap(err, "checking for checksum match")
+	}
+	defer fh.Close()
+
+	digest := sha256.New()
+	if _, err = io.Copy(digest, fh); err != nil {
+		return false, errors.Wrapf(err, "calculating sha256 for %s", installedArtifactPath)
+	}
+	return bytes.Equal(digest.Sum(nil), src.ExpectedChecksum()), nil
+}
+
+// Upgrade upgrades an artifact from the source only if the expected checksum doesn't match with the
+// checksum of artifact already installed.
+func Upgrade(artifactName, path string, source Source, perms fs.FileMode, log *zap.Logger) error {
+	match, err := checksumMatch(path, source)
+	if err != nil {
+		return err
+	}
+
+	if !match {
+		if err := InstallFile(path, source, perms); err != nil {
+			return errors.Wrapf(err, "installing %s", artifactName)
+		}
+
+		if !source.VerifyChecksum() {
+			return errors.Wrapf(NewChecksumError(source), "verifying checksum post installing %s", artifactName)
+		}
+		log.Info("Upgraded", zap.String("artifact", artifactName))
+	} else {
+		log.Info(fmt.Sprintf("No new version found for artifact %s. Skipping upgrade.", artifactName))
+	}
+	return nil
+}

--- a/internal/artifact/upgrade_test.go
+++ b/internal/artifact/upgrade_test.go
@@ -1,0 +1,120 @@
+package artifact
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+)
+
+func TestUpgradeAvailable(t *testing.T) {
+	dummyFilePath := "testdata/dummyfile"
+	dummyFh, err := os.Open(dummyFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileChecksum := []byte("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  internal/artifact/testdata/dummyfile")
+	wrongChecksum := []byte("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7acabcdcde9 randomfile/path")
+
+	testcases := []struct {
+		name           string
+		filePath       string
+		sourceChecksum []byte
+		checksumMatch  bool
+		wantErr        error
+	}{
+		{
+			name:           "Upgrade available",
+			filePath:       dummyFilePath,
+			sourceChecksum: wrongChecksum,
+			checksumMatch:  false,
+			wantErr:        nil,
+		},
+		{
+			name:           "Upgrade not available",
+			filePath:       dummyFilePath,
+			sourceChecksum: fileChecksum,
+			checksumMatch:  true,
+			wantErr:        nil,
+		},
+		{
+			name:           "File not installed",
+			filePath:       "wrong/path",
+			sourceChecksum: wrongChecksum,
+			checksumMatch:  false,
+			wantErr:        fmt.Errorf("checking for checksum match: open wrong/path: no such file or directory"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			src, err := WithChecksum(dummyFh, sha256.New(), tc.sourceChecksum)
+			if err != nil {
+				g.Expect(err).To(BeNil())
+			}
+			available, err := checksumMatch(tc.filePath, src)
+			if err != nil {
+				g.Expect(err.Error()).To(Equal(tc.wantErr.Error()))
+			}
+			g.Expect(available).To(Equal(tc.checksumMatch))
+		})
+	}
+}
+
+func TestUpgrade(t *testing.T) {
+	g := NewGomegaWithT(t)
+	installedFileData := "hello world"
+	fileChecksum := []byte("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9 -")
+
+	upgradedFileData := "random text data"
+	upgradedChecksum := []byte("2ea385d95836d380760082c32f7e2a76d0a00a6e4864cb2a5b534e3a6750c0ab -")
+
+	testcases := []struct {
+		name           string
+		installedData  string
+		upgradedData   string
+		sourceChecksum []byte
+	}{
+		{
+			name:           "Same file, nothing to upgrade",
+			installedData:  installedFileData,
+			upgradedData:   installedFileData,
+			sourceChecksum: fileChecksum,
+		},
+		{
+			name:           "Upgrade available, should upgrade",
+			installedData:  installedFileData,
+			upgradedData:   upgradedFileData,
+			sourceChecksum: upgradedChecksum,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			artifact, err := os.CreateTemp(tmpDir, "installedArtifact")
+			g.Expect(err).To(BeNil())
+			_, err = artifact.WriteString(tt.installedData)
+			g.Expect(err).To(BeNil())
+
+			source, err := WithChecksum(io.NopCloser(bytes.NewBufferString(tt.upgradedData)), sha256.New(), tt.sourceChecksum)
+			g.Expect(err).To(BeNil())
+
+			err = Upgrade("dummyArtifact", artifact.Name(), source, 0o755, zap.NewNop())
+			g.Expect(err).To(BeNil())
+
+			// Check upgraded written data
+			fileData, err := os.ReadFile(artifact.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			g.Expect(fileData).To(Equal([]byte(tt.upgradedData)))
+		})
+	}
+}

--- a/internal/cni/install.go
+++ b/internal/cni/install.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/aws/eks-hybrid/internal/artifact"
 	"github.com/aws/eks-hybrid/internal/tracker"
@@ -17,6 +18,8 @@ const (
 
 	// TgzPath is the path to install the cni-plugins tgz file
 	TgzPath = "/opt/cni/plugins/cni-plugins.tgz"
+
+	artifactName = "cni-plugins"
 )
 
 // Source represents a source that serves a cni plugins binary.
@@ -24,11 +27,18 @@ type Source interface {
 	GetCniPlugins(context.Context) (artifact.Source, error)
 }
 
-func NoOp() error {
+func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
+	if err := installFromSource(ctx, src); err != nil {
+		return err
+	}
+	if err := tracker.Add(artifact.CniPlugins); err != nil {
+		return err
+	}
+
 	return nil
 }
 
-func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
+func installFromSource(ctx context.Context, src Source) error {
 	cniPlugins, err := src.GetCniPlugins(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cni-plugins source")
@@ -36,22 +46,30 @@ func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
 	defer cniPlugins.Close()
 
 	if err := artifact.InstallFile(TgzPath, cniPlugins, 0o755); err != nil {
-		return errors.Wrap(err, "failed to install cni-plugins archive")
+		return errors.Wrap(err, "installing cni-plugins archive")
 	}
 
 	if !cniPlugins.VerifyChecksum() {
 		return errors.Errorf("cni-plugins checksum mismatch: %v", artifact.NewChecksumError(cniPlugins))
 	}
-	if err = tracker.Add(artifact.CniPlugins); err != nil {
-		return err
-	}
 
 	if err := artifact.InstallTarGz(BinPath, TgzPath); err != nil {
-		return errors.Wrap(err, "failed to extract and install cni-plugins")
+		return errors.Wrap(err, "extracting and install cni-plugins")
 	}
 	return nil
 }
 
 func Uninstall() error {
 	return os.RemoveAll(rootDir)
+}
+
+// Upgrade re-installs the cni-plugins available from the source
+// Since cni-plugins is delivered as a tarball, its not possible to check if they are due for an upgrade
+// todo: (@vignesh-goutham) check if we can publish cni-plugins independently with their checksum on our manifest
+func Upgrade(ctx context.Context, src Source, log *zap.Logger) error {
+	if err := installFromSource(ctx, src); err != nil {
+		return errors.Wrapf(err, "upgrading cni-plugins")
+	}
+	log.Info("Upgraded", zap.String("artifact", artifactName))
+	return nil
 }

--- a/internal/flows/upgrade.go
+++ b/internal/flows/upgrade.go
@@ -2,22 +2,132 @@ package flows
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/aws"
+	"github.com/aws/eks-hybrid/internal/cni"
+	"github.com/aws/eks-hybrid/internal/containerd"
+	"github.com/aws/eks-hybrid/internal/creds"
+	"github.com/aws/eks-hybrid/internal/daemon"
+	"github.com/aws/eks-hybrid/internal/iamauthenticator"
+	"github.com/aws/eks-hybrid/internal/iamrolesanywhere"
+	"github.com/aws/eks-hybrid/internal/imagecredentialprovider"
+	"github.com/aws/eks-hybrid/internal/iptables"
+	"github.com/aws/eks-hybrid/internal/kubectl"
+	"github.com/aws/eks-hybrid/internal/kubelet"
+	"github.com/aws/eks-hybrid/internal/nodeprovider"
+	"github.com/aws/eks-hybrid/internal/packagemanager"
+	"github.com/aws/eks-hybrid/internal/ssm"
+	"github.com/aws/eks-hybrid/internal/tracker"
 )
 
 type Upgrader struct {
-	*Uninstaller
-	*Installer
-	*Initer
+	NodeProvider       nodeprovider.NodeProvider
+	AwsSource          aws.Source
+	PackageManager     *packagemanager.DistroPackageManager
+	CredentialProvider creds.CredentialProvider
+	Artifacts          *tracker.InstalledArtifacts
+	DaemonManager      daemon.DaemonManager
+	SkipPhases         []string
+	Logger             *zap.Logger
 }
 
 func (u *Upgrader) Run(ctx context.Context) error {
-	if err := u.Uninstaller.Run(ctx); err != nil {
+	if err := u.upgradeDistroPackages(ctx); err != nil {
 		return err
 	}
 
-	if err := u.Installer.Run(ctx); err != nil {
+	if err := u.upgradeCredentialProvider(ctx); err != nil {
 		return err
 	}
 
-	return u.Initer.Run(ctx)
+	if err := u.upgradeEksArtifacts(ctx); err != nil {
+		return err
+	}
+
+	if err := u.NodeProvider.ConfigureAws(ctx); err != nil {
+		return err
+	}
+	if err := u.NodeProvider.Enrich(ctx); err != nil {
+		return err
+	}
+	if err := initDaemons(ctx, u.NodeProvider, u.SkipPhases, u.Logger); err != nil {
+		return err
+	}
+
+	return u.NodeProvider.Cleanup()
+}
+
+func (u *Upgrader) upgradeDistroPackages(ctx context.Context) error {
+	u.Logger.Info("Refreshing package manager metadata cache...")
+	if err := u.PackageManager.RefreshMetadataCache(ctx); err != nil {
+		return err
+	}
+	if u.Artifacts.Containerd != string(containerd.ContainerdSourceNone) {
+		u.Logger.Info("Upgrading containerd...")
+		if err := containerd.Upgrade(ctx, u.PackageManager); err != nil {
+			return err
+		}
+	}
+
+	if u.Artifacts.Iptables {
+		u.Logger.Info("Upgrading iptables...")
+		if err := iptables.Upgrade(ctx, u.PackageManager); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (u *Upgrader) upgradeCredentialProvider(ctx context.Context) error {
+	switch u.CredentialProvider {
+	case creds.IamRolesAnywhereCredentialProvider:
+		u.Logger.Info("Upgrading AWS signing helper...")
+		if err := iamrolesanywhere.Upgrade(ctx, u.AwsSource, u.Logger); err != nil {
+			return err
+		}
+	case creds.SsmCredentialProvider:
+		nodeConfig := u.NodeProvider.GetNodeConfig()
+		ssmInstaller := ssm.NewSSMInstaller(u.Logger, nodeConfig.Spec.Cluster.Region)
+
+		u.Logger.Info("Upgrading SSM agent installer...")
+		if err := ssm.Upgrade(ctx, ssm.InstallOptions{
+			Source: ssmInstaller,
+			Logger: u.Logger,
+			Region: nodeConfig.Spec.Cluster.Region,
+		}); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("installed credential provider %s is not supported for upgrade", u.CredentialProvider)
+	}
+	return nil
+}
+
+func (u *Upgrader) upgradeEksArtifacts(ctx context.Context) error {
+	u.Logger.Info("Upgrading kubelet...")
+	if err := kubelet.Upgrade(ctx, u.AwsSource, u.Logger); err != nil {
+		return errors.Wrap(err, "failed to upgrade kubelet")
+	}
+
+	u.Logger.Info("Upgrading kubectl...")
+	if err := kubectl.Upgrade(ctx, u.AwsSource, u.Logger); err != nil {
+		return err
+	}
+
+	u.Logger.Info("Upgrading image credential provider...")
+	if err := imagecredentialprovider.Upgrade(ctx, u.AwsSource, u.Logger); err != nil {
+		return err
+	}
+
+	u.Logger.Info("Upgrading IAM authenticator...")
+	if err := iamauthenticator.Upgrade(ctx, u.AwsSource, u.Logger); err != nil {
+		return err
+	}
+
+	u.Logger.Info("Upgrading cni-plugins...")
+	return cni.Upgrade(ctx, u.AwsSource, u.Logger)
 }

--- a/internal/iptables/iptables.go
+++ b/internal/iptables/iptables.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/eks-hybrid/internal/artifact"
 	"github.com/aws/eks-hybrid/internal/tracker"
+	"github.com/aws/eks-hybrid/internal/util/cmd"
 )
 
 const iptablesBinName = "iptables"
@@ -25,7 +26,7 @@ func Install(ctx context.Context, tracker *tracker.Tracker, source Source) error
 		// Sometimes install fails due to conflicts with other processes
 		// updating packages, specially when automating at machine startup.
 		// We assume errors are transient and just retry for a bit.
-		if err := artifact.InstallPackageWithRetries(ctx, iptablesSrc, 5*time.Second); err != nil {
+		if err := cmd.Retry(ctx, iptablesSrc.InstallCmd, 5*time.Second); err != nil {
 			return errors.Wrap(err, "failed to install iptables")
 		}
 		return tracker.Add(artifact.Iptables)
@@ -37,8 +38,18 @@ func Install(ctx context.Context, tracker *tracker.Tracker, source Source) error
 func Uninstall(ctx context.Context, source Source) error {
 	if isIptablesInstalled() {
 		iptablesSrc := source.GetIptables()
-		if err := artifact.UninstallPackageWithRetries(ctx, iptablesSrc, 5*time.Second); err != nil {
+		if err := cmd.Retry(ctx, iptablesSrc.UninstallCmd, 5*time.Second); err != nil {
 			return errors.Wrap(err, "failed to uninstall iptables")
+		}
+	}
+	return nil
+}
+
+func Upgrade(ctx context.Context, source Source) error {
+	if isIptablesInstalled() {
+		iptablesSrc := source.GetIptables()
+		if err := cmd.Retry(ctx, iptablesSrc.UpgradeCmd, 5*time.Second); err != nil {
+			return errors.Wrap(err, "failed to upgrade iptables")
 		}
 	}
 	return nil

--- a/internal/kubelet/daemon.go
+++ b/internal/kubelet/daemon.go
@@ -52,7 +52,7 @@ func (k *kubelet) Configure() error {
 	return nil
 }
 
-func (k *kubelet) EnsureRunning(_ context.Context) error {
+func (k *kubelet) EnsureRunning(ctx context.Context) error {
 	if err := k.daemonManager.DaemonReload(); err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (k *kubelet) EnsureRunning(_ context.Context) error {
 	if err != nil {
 		return err
 	}
-	return k.daemonManager.StartDaemon(KubeletDaemonName)
+	return k.daemonManager.RestartDaemon(ctx, KubeletDaemonName)
 }
 
 func (k *kubelet) PostLaunch() error {

--- a/internal/ssm/daemon.go
+++ b/internal/ssm/daemon.go
@@ -67,7 +67,7 @@ func (s *ssm) EnsureRunning(ctx context.Context) error {
 
 	s.logger.Info("Restarting SSM agent...")
 	// When the restart operation fails, it's usually because there are many operations running
-	// running for the same service and we get rate limited. That's why we use a big backoff time.
+	// for the same service, and we get rate limited. That's why we use a big backoff time.
 	if err := daemon.RetryOperation(restartCancel, s.daemonManager.RestartDaemon, SsmDaemonName, 20*time.Second); err != nil {
 		return fmt.Errorf("restarting SSM agent: %w", err)
 	}

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -17,6 +17,19 @@ function assert::files-equal() {
   fi
 }
 
+function assert::files-not-equal() {
+  if [ "$#" -ne 2 ]; then
+    echo "Usage: assert::files-equal FILE1 FILE2"
+    exit 1
+  fi
+  local FILE1=$1
+  local FILE2=$2
+  if diff $FILE1 $FILE2; then
+    echo "Files $FILE1 and $FILE2 are equal"
+    exit 1
+  fi
+}
+
 function assert::json-files-equal() {
   if [ "$#" -ne 2 ]; then
     echo "Usage: assert::json-files-equal FILE1 FILE2"
@@ -84,6 +97,36 @@ function assert::file-not-contains() {
     echo ""
     exit 1
   fi
+}
+
+function generate::birth-file() {
+    if [ "$#" -ne 1 ]; then
+      echo "Usage: generate::stat-file INPUT_PATH"
+      exit 1
+    fi
+    local INPUT_PATH=$1
+    rm -rf INPUT_PATH.stat
+    echo $(stat -c %W $INPUT_PATH) > $INPUT_PATH.birth
+}
+
+function assert::birth-match() {
+  if [ "$#" -ne 1 ]; then
+    echo "Usage: assert::stat-match INPUT_PATH"
+    exit 1
+  fi
+  local INPUT_PATH=$1
+  echo $(stat -c %W $INPUT_PATH) > $INPUT_PATH.current.birth
+  assert::files-equal $INPUT_PATH.birth $INPUT_PATH.current.birth
+}
+
+function assert::birth-not-match() {
+  if [ "$#" -ne 1 ]; then
+    echo "Usage: assert::stat-match INPUT_PATH"
+    exit 1
+  fi
+  local INPUT_PATH=$1
+  echo $(stat $INPUT_PATH) > $INPUT_PATH.current.stat
+  assert::files-not-equal $INPUT_PATH.stat $INPUT_PATH.current.stat
 }
 
 function assert::is-substring() {

--- a/test/integration/infra/Dockerfile
+++ b/test/integration/infra/Dockerfile
@@ -49,4 +49,10 @@ RUN touch /etc/eks/image-credential-provider/ecr-credential-provider
 ENV CPU_DIR /sys_devices_system_mock/cpu
 ENV NODE_DIR /sys_devices_system_mock/node
 
+# GPG is invoked by ssm for signature verification under few test scenarios
+# Without tty inside the container, gpg commands fail. With this config gpg ignores tty
+RUN mkdir -p $HOME/.gnupg
+RUN touch $HOME/.gnupg/gpg.conf
+RUN echo "no-tty" >> $HOME/.gnupg/gpg.conf
+
 ENTRYPOINT ["/usr/lib/systemd/systemd","--system"]


### PR DESCRIPTION
*Description of changes:*
Upgrade today runs an uninstall followed by install + init. While this does achieve upgrade this run operations that might not be required. With this change upgrade operation will check if a particular artifact is due for an upgrade and then only upgrade the artifact. 

Callouts with this change
- cni-plugins ship as tarball so its not possible to check if there is really an upgrade for the plugins. We always upgrade the plugins with this change.
- Similar situation with the SSM installer cli, which doesnt publish its checksums in order for us to validate it. (Future task to add checksums to manifest that will enable us to do this. The installer is also regional)
- For packages installed from OS's package manager, we run the yum/apt upgrade command which will only upgrade if there is an upgrade available.

Also added a package manager metadata refresh command. I'll swap yum/apt updates with this command in other places in a following change.
 
*Testing (if applicable):*
Tested with E2E tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

