### PR TITLE
Add option for no color in debug command output

### DIFF
--- a/cmd/nodeadm/debug/debug.go
+++ b/cmd/nodeadm/debug/debug.go
@@ -33,6 +33,7 @@ func NewCommand() cli.Command {
 	debug := debug{}
 	debug.cmd = flaggy.NewSubcommand("debug")
 	debug.cmd.String(&debug.nodeConfigSource, "c", "config-source", "Source of node configuration. The format is a URI with supported schemes: [file, imds].")
+	debug.cmd.Bool(&debug.noColor, "", "no-color", "If set, suppresses color output.")
 	debug.cmd.Description = "Debug the node registration process"
 	debug.cmd.AdditionalHelpPrepend = debugHelpText
 	return &debug
@@ -41,6 +42,7 @@ func NewCommand() cli.Command {
 type debug struct {
 	cmd              *flaggy.Subcommand
 	nodeConfigSource string
+	noColor          bool
 }
 
 func (c *debug) Flaggy() *flaggy.Subcommand {
@@ -70,7 +72,7 @@ func (c *debug) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return err
 	}
 
-	printer := validation.NewPrinterWithStdCapture("stderr")
+	printer := validation.NewPrinterWithStdCapture("stderr", c.noColor)
 	if err := printer.Init(); err != nil {
 		return err
 	}

--- a/internal/validation/reader.go
+++ b/internal/validation/reader.go
@@ -116,11 +116,16 @@ type PrinterWithStdCapture struct {
 }
 
 // NewPrinterWithStdCapture returns a new PrinterWithStdCapture.
-func NewPrinterWithStdCapture(stdName string) *PrinterWithStdCapture {
+func NewPrinterWithStdCapture(stdName string, noColor bool) *PrinterWithStdCapture {
 	out := make(chan string, 100)
-	printer := NewPrinter(
+	opts := []PrinterOpt{
 		WithExternalLogs(NewChannelReader(out, stdName)),
-	)
+	}
+	if noColor {
+		opts = append(opts, WithNoColor())
+	}
+
+	printer := NewPrinter(opts...)
 	newStderr := NewFileCapture(out)
 
 	return &PrinterWithStdCapture{


### PR DESCRIPTION
*Description of changes:*
This is useful when running it in some automated/background process where there is no terminal to interpret the escape sequences and ends up obfuscating the output.

once this is released, we'll update the scripts we run in the e2e test nodes to use this flag and get a cleaner output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

