### PR TITLE
Create test pod to verify it can access AWS resources with pod identity add-on

### DIFF
--- a/example/hybrid-ira-cfn.yaml
+++ b/example/hybrid-ira-cfn.yaml
@@ -48,7 +48,8 @@ Resources:
     Properties:
       RoleName: !Ref RoleName
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly'
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy
       Policies:
         - PolicyName: EKSDescribeCluster
           PolicyDocument:

--- a/example/hybrid-ira-cfn.yaml
+++ b/example/hybrid-ira-cfn.yaml
@@ -49,7 +49,6 @@ Resources:
       RoleName: !Ref RoleName
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly
-        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy
       Policies:
         - PolicyName: EKSDescribeCluster
           PolicyDocument:

--- a/example/hybrid-ssm-cfn.yaml
+++ b/example/hybrid-ssm-cfn.yaml
@@ -71,7 +71,6 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly
-        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy
 
 Outputs:
   EKSHybridNodesRoleName:

--- a/example/hybrid-ssm-cfn.yaml
+++ b/example/hybrid-ssm-cfn.yaml
@@ -71,6 +71,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy
 
 Outputs:
   EKSHybridNodesRoleName:

--- a/hybrid-nodes-cdk/lib/nodeadm-stack.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm-stack.ts
@@ -427,7 +427,9 @@ export class NodeadmBuildStack extends cdk.Stack {
             's3:PutBucketTagging',
             's3:GetBucketTagging',
             's3:ListBucket',
-            's3:PutObject*'],
+            's3:PutObject*',
+            's3:DeleteObject',
+          ],
           resources: [`arn:aws:s3:::${podIdentityS3BucketPrefix}-${this.account}-${this.region}-*`]
         }),
         new iam.PolicyStatement({

--- a/hybrid-nodes-cdk/lib/nodeadm-stack.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm-stack.ts
@@ -19,6 +19,7 @@ export class NodeadmBuildStack extends cdk.Stack {
 
     const testClusterTagKey = "Nodeadm-E2E-Tests-Cluster"
     const testClusterPrefix = "nodeadm-e2e-tests"
+    const podIdentityS3BucketPrefix = "podidentitys3bucket"
     const requestTagCondition = {
       StringLike: {
         [`aws:RequestTag/${testClusterTagKey}`]: `${testClusterPrefix}-*`
@@ -427,7 +428,7 @@ export class NodeadmBuildStack extends cdk.Stack {
             's3:GetBucketTagging',
             's3:ListBucket',
             's3:PutObject*'],
-          resources: ['arn:aws:s3:::ekshybridci-arch-*']
+          resources: [`arn:aws:s3:::${podIdentityS3BucketPrefix}-${this.account}-${this.region}-*`]
         }),
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,

--- a/hybrid-nodes-cdk/lib/nodeadm-stack.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm-stack.ts
@@ -421,6 +421,24 @@ export class NodeadmBuildStack extends cdk.Stack {
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
           actions: [
+            's3:CreateBucket',
+            's3:DeleteBucket',
+            's3:PutBucketTagging',
+            's3:GetBucketTagging',
+            's3:ListBucket',
+            's3:PutObject*'],
+          resources: ['arn:aws:s3:::ekshybridci-arch-*']
+        }),
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: [
+            's3:ListAllMyBuckets',
+          ],
+          resources: ['*']
+        }),
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: [
             'eks:CreateAccessEntry',
             'eks:DescribeCluster',
             'eks:ListClusters',
@@ -458,7 +476,7 @@ export class NodeadmBuildStack extends cdk.Stack {
         }),
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
-          actions: ['eks:CreateAddon'],
+          actions: ['eks:CreateAddon', 'eks:CreatePodIdentityAssociation'],
           resources: [`arn:aws:eks:${this.region}:${this.account}:cluster/*`]
         }),
         new iam.PolicyStatement({
@@ -471,6 +489,7 @@ export class NodeadmBuildStack extends cdk.Stack {
           actions: [
             'cloudformation:DescribeStackEvents',
             'cloudformation:DescribeStacks',
+            'cloudformation:DescribeStackResource',
             'cloudformation:UpdateStack',
           ],
           resources: [`arn:aws:cloudformation:${this.region}:${this.account}:stack/*`],

--- a/test/e2e/addon/addon.go
+++ b/test/e2e/addon/addon.go
@@ -2,14 +2,13 @@ package addon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/go-logr/logr"
-
-	"github.com/aws/eks-hybrid/test/e2e/errors"
 )
 
 type Addon struct {
@@ -33,7 +32,7 @@ func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logge
 
 	_, err := client.CreateAddon(ctx, params)
 
-	if err != nil && errors.IsType(err, &types.ResourceInUseException{}) {
+	if err == nil || errors.Is(err, &types.ResourceInUseException{}) {
 		// Ignore if add-on is already created
 		return nil
 	}

--- a/test/e2e/addon/addon.go
+++ b/test/e2e/addon/addon.go
@@ -33,7 +33,7 @@ func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logge
 
 	_, err := client.CreateAddon(ctx, params)
 
-	if err != nil && !errors.IsType(err, &types.ResourceInUseException{}) {
+	if err != nil && errors.IsType(err, &types.ResourceInUseException{}) {
 		// Ignore if add-on is already created
 		return nil
 	}

--- a/test/e2e/addon/podidentityaddon.go
+++ b/test/e2e/addon/podidentityaddon.go
@@ -21,13 +21,14 @@ type PodIdentityAddon struct {
 const (
 	podIdentityServiceAccount = "pod-identity-sa"
 	namespace                 = "default"
+	podIdentityAgent          = "eks-pod-identity-agent"
 )
 
-func NewPodIdentityAddon(cluster, name, roleArn string) PodIdentityAddon {
+func NewPodIdentityAddon(cluster, roleArn string) PodIdentityAddon {
 	return PodIdentityAddon{
 		Addon: Addon{
 			Cluster:       cluster,
-			Name:          name,
+			Name:          podIdentityAgent,
 			Configuration: "{\"daemonsets\":{\"hybrid\":{\"create\": true}}}",
 		},
 		roleArn: roleArn,

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
@@ -25,6 +26,8 @@ const (
 	policyName           = "pod-identity-association-role-policy"
 	PodIdentityS3Bucket  = "PodIdentityS3Bucket"
 )
+
+var PodIdentityS3BucketPrefix = strings.ToLower(PodIdentityS3Bucket)
 
 type VerifyPodIdentityAddon struct {
 	Cluster             string

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -77,17 +77,6 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 	}
 	v.Logger.Info("Get S3 Bucket for pod identity add-on test", "S3 bucket", bucket)
 
-	bucketObjectKey := "test"
-	bucketObjectContent := "RANDOM-WORD"
-	if _, err := v.S3Client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(bucketObjectKey),
-		Body:   strings.NewReader(bucketObjectContent),
-	}); err != nil {
-		return err
-	}
-	v.Logger.Info("Upload text file to S3 bucket", "key", bucketObjectKey, "content", bucketObjectContent)
-
 	// Deploy a pod with service account then run aws cli to access aws resources
 	node, err := kubernetes.WaitForNode(ctx, v.K8S, v.NodeIP, v.Logger)
 	if err != nil {
@@ -109,7 +98,7 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 					Command: []string{
 						"/bin/bash",
 						"-c",
-						"sleep 1h",
+						"sleep infinity",
 					},
 				},
 			},

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -3,26 +3,52 @@ package addon
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientgo "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 )
 
 const (
 	getAddonTimeout      = 2 * time.Minute
-	podIdentityAgent     = "eks-pod-identity-agent"
 	podIdentityDaemonSet = "eks-pod-identity-agent-hybrid"
+	podIdentityToken     = "eks-pod-identity-token"
+	policyName           = "pod-identity-association-role-policy"
 )
 
 type VerifyPodIdentityAddon struct {
 	Cluster   string
+	NodeIP    string
 	K8S       *clientgo.Clientset
-	Logger    logr.Logger
 	EKSClient *eks.Client
+	IAMClient *iam.Client
+	S3Client  *s3.Client
+	Logger    logr.Logger
+	K8SConfig *rest.Config
+}
+
+type PolicyDocument struct {
+	Version   string
+	Statement []StatementEntry
+}
+
+type StatementEntry struct {
+	Effect   string
+	Action   []string
+	Resource []string
 }
 
 func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
@@ -45,7 +71,170 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 		return err
 	}
 
-	// TODO: Deploy a pod with service account to verify the pod identity token section is populated in pod manifest files
+	bucket, err := getBucketNameFromPodIdentityAssociation(ctx, v.Cluster, v.EKSClient, v.IAMClient)
+	if err != nil {
+		return err
+	}
+	v.Logger.Info("Get S3 Bucket for pod identity add-on test", "S3 bucket", bucket)
+
+	bucketObjectKey := "test"
+	bucketObjectContent := "RANDOM-WORD"
+	if _, err := v.S3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(bucketObjectKey),
+		Body:   strings.NewReader(bucketObjectContent),
+	}); err != nil {
+		return err
+	}
+	v.Logger.Info("Upload text file to S3 bucket", "key", bucketObjectKey, "content", bucketObjectContent)
+
+	// Deploy a pod with service account then run aws cli to access aws resources
+	node, err := kubernetes.WaitForNode(ctx, v.K8S, v.NodeIP, v.Logger)
+	if err != nil {
+		return err
+	}
+
+	podName := "awscli"
+	v.Logger.Info("Creating a test pod on the hybrid node for pod identity add-on to access aws resources")
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  podName,
+					Image: "public.ecr.aws/aws-cli/aws-cli",
+					Command: []string{
+						"/bin/bash",
+						"-c",
+						"sleep 1h",
+					},
+				},
+			},
+			// schedule the pod on the specific node using nodeSelector
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": node.Name,
+			},
+			ServiceAccountName: podIdentityServiceAccount,
+		},
+	}
+	if err = kubernetes.CreatePod(ctx, v.K8S, pod, v.Logger); err != nil {
+		return err
+	}
+
+	execCommand := []string{
+		"bash", "-c", fmt.Sprintf("aws s3 cp s3://%s/%s . > /dev/null && cat ./%s", bucket, bucketObjectKey, bucketObjectKey),
+	}
+	stdout, _, err := kubernetes.ExecPodWithRetries(ctx, v.K8SConfig, v.K8S, podName, namespace, execCommand...)
+	if err != nil {
+		return err
+	}
+	v.Logger.Info("Check output from exec pod with command", "output", stdout)
+
+	if stdout != bucketObjectContent {
+		return fmt.Errorf("failed to get object %s from S3 bucket %s", bucketObjectKey, bucket)
+	}
 
 	return nil
+}
+
+func getBucketNameFromPodIdentityAssociation(ctx context.Context, cluster string, eksClient *eks.Client, iamClient *iam.Client) (string, error) {
+	// The idea behind this function is
+	// 1. it gets role ARN from pod identity association for a given service account,
+	// 2. it retrieves policy document given role ARN and inline policy name,
+	// 3. it parses policy document to get S3 bucket name
+
+	var err error
+	roleName, err := getAssociatedRoleName(ctx, cluster, eksClient)
+	if err != nil {
+		return "", err
+	}
+
+	getRolePolicyOutput, err := iamClient.GetRolePolicy(ctx, &iam.GetRolePolicyInput{
+		RoleName:   aws.String(roleName),
+		PolicyName: aws.String(policyName),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	policyDocument, err := unmarshallPolicyDocument(*getRolePolicyOutput.PolicyDocument)
+	if err != nil {
+		return "", err
+	}
+
+	// see policyDocument defined in setup-cfn.yaml::PodIdentityAssociationRole
+	for _, resource := range policyDocument.Statement[0].Resource {
+		if !strings.HasPrefix(resource, "arn:aws:s3::") {
+			continue
+		}
+
+		// Sample S3 bucket ARN
+		// "arn:aws:s3:::ekshybridci-arch-nodeadm-e2e-t-podidentitys3bucket-coydlns2q8if",
+		// "arn:aws:s3:::ekshybridci-arch-nodeadm-e2e-t-podidentitys3bucket-coydlns2q8if/*"
+		bucket := lastSegment(strings.Split(resource, "/")[0], ":")
+		return bucket, nil
+	}
+
+	return "", fmt.Errorf("failed to find S3 bucket")
+}
+
+func getAssociatedRoleName(ctx context.Context, cluster string, eksClient *eks.Client) (string, error) {
+	var err error
+	out, err := eksClient.ListPodIdentityAssociations(ctx, &eks.ListPodIdentityAssociationsInput{
+		ClusterName: &cluster,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var associationId *string
+	for _, association := range out.Associations {
+		if association.Namespace == nil || *association.Namespace != namespace {
+			continue
+		}
+
+		if association.ServiceAccount == nil || *association.ServiceAccount != podIdentityServiceAccount {
+			continue
+		}
+
+		// there is at most one association for a service account
+		associationId = association.AssociationId
+		break
+	}
+
+	if associationId == nil {
+		return "", fmt.Errorf("failed to find pod identity association for service account %s in namespace %s", podIdentityServiceAccount, namespace)
+	}
+
+	describePodIdentityAssociationInput := &eks.DescribePodIdentityAssociationInput{
+		AssociationId: associationId,
+		ClusterName:   &cluster,
+	}
+	if out, err := eksClient.DescribePodIdentityAssociation(ctx, describePodIdentityAssociationInput); err != nil {
+		return "", err
+	} else {
+		// sample role ARN
+		// arn:aws:iam::1234567890:role/EKSHybridCI-Arch-nodeadm-e2e-tests-ClusterRole-E0hZO1KMNC3v
+		return lastSegment(*out.Association.RoleArn, "/"), nil
+	}
+}
+
+func lastSegment(str, sep string) string {
+	return str[strings.LastIndex(str, sep)+1:]
+}
+
+func unmarshallPolicyDocument(document string) (*PolicyDocument, error) {
+	var policyDocument PolicyDocument
+	documentUnencoded, err := url.QueryUnescape(document)
+	if err != nil {
+		return &PolicyDocument{}, err
+	}
+	err = json.Unmarshal([]byte(documentUnencoded), &policyDocument)
+	if err != nil {
+		return &PolicyDocument{}, err
+	}
+	return &policyDocument, nil
 }

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
@@ -20,14 +19,13 @@ import (
 )
 
 const (
-	getAddonTimeout      = 2 * time.Minute
-	podIdentityDaemonSet = "eks-pod-identity-agent-hybrid"
-	podIdentityToken     = "eks-pod-identity-token"
-	policyName           = "pod-identity-association-role-policy"
-	PodIdentityS3Bucket  = "PodIdentityS3Bucket"
+	getAddonTimeout           = 2 * time.Minute
+	podIdentityDaemonSet      = "eks-pod-identity-agent-hybrid"
+	podIdentityToken          = "eks-pod-identity-token"
+	policyName                = "pod-identity-association-role-policy"
+	PodIdentityS3Bucket       = "PodIdentityS3Bucket"
+	PodIdentityS3BucketPrefix = "podidentitys3bucket"
 )
-
-var PodIdentityS3BucketPrefix = strings.ToLower(PodIdentityS3Bucket)
 
 type VerifyPodIdentityAddon struct {
 	Cluster             string

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -422,3 +422,7 @@ Outputs:
   PodIdentityAssociationRoleARN:
     Description: The role ARN of PodIdentityAssociationRole
     Value: !GetAtt PodIdentityAssociationRole.Arn
+
+  PodIdentityS3BucketName:
+    Description: The bucket name for pod identity S3 bucket
+    Value: !Ref PodIdentityS3Bucket

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -370,6 +370,7 @@ Resources:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
+      # use a predictable prefix for PodIdentity S3 bucket while maintaining uniqueness requirement for S3 bucket name
       BucketName:
         Fn::Join:
         - '-'

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -42,6 +42,10 @@ Parameters:
     Type: String
     Description: Tag key of all the resources
 
+  PodIdentityS3BucketPrefix:
+    Type: String
+    Description: Prefix for pod identity S3 bucket
+
 Resources:
   ClusterRole:
     Type: AWS::IAM::Role
@@ -366,9 +370,26 @@ Resources:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
+      BucketName:
+        Fn::Join:
+        - '-'
+        - - !Ref PodIdentityS3BucketPrefix
+          - !Ref AWS::AccountId
+          - !Ref AWS::Region
+          - Fn::Select:
+            - 0
+            - Fn::Split:
+              - '-'
+              - Fn::Select:
+                - 2
+                - Fn::Split:
+                  - /
+                  - !Ref AWS::StackId
       Tags:
         - Key: !Ref TestClusterTagKey
           Value: !Ref ClusterName
+        - Key: !Ref PodIdentityS3BucketPrefix
+          Value: true
 
   PodIdentityAssociationRole:
     Type: AWS::IAM::Role

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -362,6 +362,14 @@ Resources:
                 path: /root/download-private-key.sh
                 permissions: "0755"
 
+  PodIdentityS3Bucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    Properties:
+      Tags:
+        - Key: !Ref TestClusterTagKey
+          Value: !Ref ClusterName
+
   PodIdentityAssociationRole:
     Type: AWS::IAM::Role
     Properties:
@@ -380,8 +388,12 @@ Resources:
             Version: '2012-10-17'
             Statement:
               - Effect: Allow
-                Action: s3:GetObject
-                Resource: arn:aws:s3:::RANDOM_NON_EXISTENT_BUCKET
+                Action:
+                  - s3:Get*
+                  - s3:List*
+                Resource:
+                  - !Sub arn:aws:s3:::${PodIdentityS3Bucket}
+                  - !Sub arn:aws:s3:::${PodIdentityS3Bucket}/*
       Tags:
         - Key: !Ref TestClusterTagKey
           Value: !Ref ClusterName

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -38,9 +38,8 @@ type NetworkConfig struct {
 }
 
 const (
-	ciliumCni            = "cilium"
-	calicoCni            = "calico"
-	podIdentityAddonName = "eks-pod-identity-agent"
+	ciliumCni = "cilium"
+	calicoCni = "calico"
 )
 
 type Create struct {
@@ -106,7 +105,7 @@ func (c *Create) Run(ctx context.Context, test TestResources) error {
 		return fmt.Errorf("creating kubernetes client: %w", err)
 	}
 
-	podIdentityAddon := addon.NewPodIdentityAddon(hybridCluster.Name, podIdentityAddonName, stackOut.podIdentityRoleArn)
+	podIdentityAddon := addon.NewPodIdentityAddon(hybridCluster.Name, stackOut.podIdentityRoleArn)
 
 	err = podIdentityAddon.Create(ctx, c.logger, c.eks, k8sClient)
 	if err != nil {

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -116,7 +116,7 @@ func (c *Create) Run(ctx context.Context, test TestResources) error {
 	}
 
 	// upload test file to pod identity S3 bucket
-	err = podIdentityAddon.Upload(ctx, c.logger, c.s3, stackOut.podIdentity.s3Bucket)
+	err = podIdentityAddon.UploadFileForVerification(ctx, c.logger, c.s3, stackOut.podIdentity.s3Bucket)
 	if err != nil {
 		return fmt.Errorf("uploading test file to s3 bucket: %s", stackOut.podIdentity.s3Bucket)
 	}

--- a/test/e2e/cluster/delete.go
+++ b/test/e2e/cluster/delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/go-logr/logr"
 
 	"github.com/aws/eks-hybrid/test/e2e"
@@ -44,6 +45,7 @@ func NewDelete(aws aws.Config, logger logr.Logger, endpoint string) Delete {
 			cfn:       cloudformation.NewFromConfig(aws),
 			ec2Client: ec2.NewFromConfig(aws),
 			logger:    logger,
+			s3Client:  s3.NewFromConfig(aws),
 		},
 	}
 }

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmTypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/go-logr/logr"
@@ -37,10 +39,15 @@ type vpcConfig struct {
 	securityGroup string
 }
 
+type podIdentity struct {
+	roleArn  string
+	s3Bucket string
+}
+
 type resourcesStackOutput struct {
-	clusterRole        string
-	clusterVpcConfig   vpcConfig
-	podIdentityRoleArn string
+	clusterRole      string
+	clusterVpcConfig vpcConfig
+	podIdentity      podIdentity
 }
 
 type stack struct {
@@ -48,6 +55,7 @@ type stack struct {
 	cfn       *cloudformation.Client
 	ssmClient *ssm.Client
 	ec2Client *ec2.Client
+	s3Client  *s3.Client
 }
 
 func (s *stack) deploy(ctx context.Context, test TestResources) (*resourcesStackOutput, error) {
@@ -181,7 +189,9 @@ func (s *stack) deploy(ctx context.Context, test TestResources) (*resourcesStack
 		case "ClusterSecurityGroup":
 			result.clusterVpcConfig.securityGroup = *output.OutputValue
 		case "PodIdentityAssociationRoleARN":
-			result.podIdentityRoleArn = *output.OutputValue
+			result.podIdentity.roleArn = *output.OutputValue
+		case "PodIdentityS3BucketName":
+			result.podIdentity.s3Bucket = *output.OutputValue
 		}
 	}
 
@@ -265,7 +275,22 @@ func waitForStackOperation(ctx context.Context, client *cloudformation.Client, s
 func (s *stack) delete(ctx context.Context, clusterName string) error {
 	stackName := stackName(clusterName)
 	s.logger.Info("Deleting E2E test cluster stack", "stackName", stackName)
-	_, err := s.cfn.DeleteStack(ctx, &cloudformation.DeleteStackInput{
+
+	var output *cloudformation.DescribeStackResourceOutput
+	output, err := s.cfn.DescribeStackResource(ctx, &cloudformation.DescribeStackResourceInput{
+		LogicalResourceId: aws.String("PodIdentityS3Bucket"),
+		StackName:         aws.String(stackName),
+	})
+	if err != nil {
+		return err
+	}
+
+	s.logger.Info("Empty pod identity s3 bucket", "bucket", output.StackResourceDetail.PhysicalResourceId)
+	if err = emptyS3Bucket(ctx, s.s3Client, output.StackResourceDetail.PhysicalResourceId); err != nil {
+		return err
+	}
+
+	_, err = s.cfn.DeleteStack(ctx, &cloudformation.DeleteStackInput{
 		StackName: aws.String(stackName),
 	})
 	if err != nil {
@@ -278,6 +303,40 @@ func (s *stack) delete(ctx context.Context, clusterName string) error {
 	}
 
 	s.logger.Info("E2E test cluster stack deleted successfully", "stackName", stackName)
+	return nil
+}
+
+func emptyS3Bucket(ctx context.Context, client *s3.Client, bucket *string) error {
+	var err error
+
+	output, err := client.ListObjects(ctx, &s3.ListObjectsInput{
+		Bucket: bucket,
+	})
+	if err != nil {
+		return err
+	}
+
+	if output.Contents == nil || len(output.Contents) == 0 {
+		// no S3 objects to delete
+		return nil
+	}
+
+	var s3Objects []s3types.ObjectIdentifier
+	for _, content := range output.Contents {
+		s3Objects = append(s3Objects, s3types.ObjectIdentifier{
+			Key: content.Key,
+		})
+	}
+
+	if _, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+		Bucket: bucket,
+		Delete: &s3types.Delete{
+			Objects: s3Objects,
+		},
+	}); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -316,7 +316,7 @@ func emptyS3Bucket(ctx context.Context, client *s3.Client, bucket *string) error
 		return err
 	}
 
-	if output.Contents == nil || len(output.Contents) == 0 {
+	if len(output.Contents) == 0 {
 		// no S3 objects to delete
 		return nil
 	}

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/aws/eks-hybrid/test/e2e/addon"
 	"github.com/aws/eks-hybrid/test/e2e/constants"
 	"github.com/aws/eks-hybrid/test/e2e/errors"
 	"github.com/aws/eks-hybrid/test/e2e/peered"
@@ -276,9 +277,8 @@ func (s *stack) delete(ctx context.Context, clusterName string) error {
 	stackName := stackName(clusterName)
 	s.logger.Info("Deleting E2E test cluster stack", "stackName", stackName)
 
-	var output *cloudformation.DescribeStackResourceOutput
 	output, err := s.cfn.DescribeStackResource(ctx, &cloudformation.DescribeStackResourceInput{
-		LogicalResourceId: aws.String("PodIdentityS3Bucket"),
+		LogicalResourceId: aws.String(addon.PodIdentityS3Bucket),
 		StackName:         aws.String(stackName),
 	})
 	if err != nil {
@@ -307,7 +307,9 @@ func (s *stack) delete(ctx context.Context, clusterName string) error {
 }
 
 func emptyS3Bucket(ctx context.Context, client *s3.Client, bucket *string) error {
-	var err error
+	if bucket == nil {
+		return nil
+	}
 
 	output, err := client.ListObjects(ctx, &s3.ListObjectsInput{
 		Bucket: bucket,

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -109,6 +109,10 @@ func (s *stack) deploy(ctx context.Context, test TestResources) (*resourcesStack
 			ParameterKey:   aws.String("TestClusterTagKey"),
 			ParameterValue: aws.String(constants.TestClusterTagKey),
 		},
+		{
+			ParameterKey:   aws.String("PodIdentityS3BucketPrefix"),
+			ParameterValue: aws.String(strings.ToLower(addon.PodIdentityS3Bucket)),
+		},
 	}
 
 	if resp == nil || resp.Stacks == nil {

--- a/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
+++ b/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
@@ -55,6 +55,7 @@ Resources:
       ManagedPolicyArns: 
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy
       Tags: 
         - Key: Name
           Value: !Sub '${AWS::StackName}'
@@ -87,6 +88,7 @@ Resources:
       RoleName: !Sub '${AWS::StackName}-ira'
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy
       Policies:
         - PolicyName: EKSDescribeCluster
           PolicyDocument:

--- a/test/e2e/kubernetes/kubernetes.go
+++ b/test/e2e/kubernetes/kubernetes.go
@@ -214,19 +214,26 @@ func CreateNginxPodInNode(ctx context.Context, k8s *kubernetes.Clientset, nodeNa
 		},
 	}
 
+	return CreatePod(ctx, k8s, pod, logger)
+}
+
+func CreatePod(ctx context.Context, k8s *kubernetes.Clientset, pod *corev1.Pod, logger logr.Logger) error {
+	podName := pod.ObjectMeta.Name
+	namespace := pod.ObjectMeta.Namespace
+
 	_, err := k8s.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("creating the test pod: %w", err)
 	}
 
-	err = waitForPodToBeRunning(ctx, k8s, podName, namespace, nodeName, logger)
+	err = waitForPodToBeRunning(ctx, k8s, podName, namespace, logger)
 	if err != nil {
 		return fmt.Errorf("waiting for test pod to be running: %w", err)
 	}
 	return nil
 }
 
-func waitForPodToBeRunning(ctx context.Context, k8s *kubernetes.Clientset, name, namespace, nodeName string, logger logr.Logger) error {
+func waitForPodToBeRunning(ctx context.Context, k8s *kubernetes.Clientset, name, namespace string, logger logr.Logger) error {
 	consecutiveErrors := 0
 	return wait.PollUntilContextTimeout(ctx, nodePodDelayInterval, nodePodWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		pod, err := k8s.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/eks-hybrid/test/e2e/addon"
 	"github.com/aws/eks-hybrid/test/e2e/cluster"
 	"github.com/aws/eks-hybrid/test/e2e/commands"
+	"github.com/aws/eks-hybrid/test/e2e/constants"
 	"github.com/aws/eks-hybrid/test/e2e/credentials"
 	"github.com/aws/eks-hybrid/test/e2e/ec2"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
@@ -96,6 +97,8 @@ type peeredVPCTest struct {
 	publicKey string
 
 	remoteCommandRunner commands.RemoteCommandRunner
+
+	podIdentityS3Bucket string
 }
 
 var _ = SynchronizedBeforeSuite(
@@ -440,6 +443,14 @@ func buildPeeredVPCTestForSuite(ctx context.Context, suite *suiteConfiguration) 
 	}
 	test.nodeadmURLs = *urls
 
+	test.podIdentityS3Bucket, err = getPodIdentityS3Bucket(ctx, test.cluster.Name, test.s3Client)
+	if err != nil {
+		return nil, err
+	}
+
+	if test.podIdentityS3Bucket == "" {
+		return nil, fmt.Errorf("s3 bucket for pod identity not found")
+	}
 	return test, nil
 }
 
@@ -509,14 +520,15 @@ func (t *peeredVPCTest) instanceName(testName string, os e2e.NodeadmOS, provider
 
 func (t *peeredVPCTest) newVerifyPodIdentityAddon(nodeIP string) *addon.VerifyPodIdentityAddon {
 	return &addon.VerifyPodIdentityAddon{
-		Cluster:   t.cluster.Name,
-		NodeIP:    nodeIP,
-		K8S:       t.k8sClient,
-		EKSClient: t.eksClient,
-		IAMClient: t.iamClient,
-		S3Client:  t.s3Client,
-		Logger:    t.logger,
-		K8SConfig: t.k8sClientConfig,
+		Cluster:             t.cluster.Name,
+		NodeIP:              nodeIP,
+		PodIdentityS3Bucket: t.podIdentityS3Bucket,
+		K8S:                 t.k8sClient,
+		EKSClient:           t.eksClient,
+		IAMClient:           t.iamClient,
+		S3Client:            t.s3Client,
+		Logger:              t.logger,
+		K8SConfig:           t.k8sClientConfig,
 	}
 }
 
@@ -527,4 +539,38 @@ func newLoggerForTests() e2e.PausableLogger {
 		cfg.NoColor = true
 	}
 	return e2e.NewPausableLogger(cfg)
+}
+
+func getPodIdentityS3Bucket(ctx context.Context, cluster string, client *s3v2.Client) (string, error) {
+	listBucketsOutput, err := client.ListBuckets(ctx, &s3v2.ListBucketsInput{
+		Prefix: aws.String("ekshybridci-arch-"),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	for _, bucket := range listBucketsOutput.Buckets {
+		getBucketTaggingOutput, err := client.GetBucketTagging(ctx, &s3v2.GetBucketTaggingInput{
+			Bucket: bucket.Name,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		var foundClusterTag, foundPodIdentityTag bool
+		for _, tag := range getBucketTaggingOutput.TagSet {
+			if *tag.Key == constants.TestClusterTagKey && *tag.Value == cluster {
+				foundClusterTag = true
+			}
+
+			if *tag.Key == "aws:cloudformation:logical-id" && *tag.Value == addon.PodIdentityS3Bucket {
+				foundPodIdentityTag = true
+			}
+
+			if foundClusterTag && foundPodIdentityTag {
+				return *bucket.Name, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("S3 bucket for pod identity not found")
 }

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -448,9 +449,6 @@ func buildPeeredVPCTestForSuite(ctx context.Context, suite *suiteConfiguration) 
 		return nil, err
 	}
 
-	if test.podIdentityS3Bucket == "" {
-		return nil, fmt.Errorf("s3 bucket for pod identity not found")
-	}
 	return test, nil
 }
 
@@ -543,7 +541,7 @@ func newLoggerForTests() e2e.PausableLogger {
 
 func getPodIdentityS3Bucket(ctx context.Context, cluster string, client *s3v2.Client) (string, error) {
 	listBucketsOutput, err := client.ListBuckets(ctx, &s3v2.ListBucketsInput{
-		Prefix: aws.String("ekshybridci-arch-"),
+		Prefix: aws.String(strings.ToLower(addon.PodIdentityS3Bucket)),
 	})
 	if err != nil {
 		return "", err
@@ -563,7 +561,7 @@ func getPodIdentityS3Bucket(ctx context.Context, cluster string, client *s3v2.Cl
 				foundClusterTag = true
 			}
 
-			if *tag.Key == "aws:cloudformation:logical-id" && *tag.Value == addon.PodIdentityS3Bucket {
+			if *tag.Key == strings.ToLower(addon.PodIdentityS3Bucket) && *tag.Value == "true" {
 				foundPodIdentityTag = true
 			}
 

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -541,7 +540,7 @@ func newLoggerForTests() e2e.PausableLogger {
 
 func getPodIdentityS3Bucket(ctx context.Context, cluster string, client *s3v2.Client) (string, error) {
 	listBucketsOutput, err := client.ListBuckets(ctx, &s3v2.ListBucketsInput{
-		Prefix: aws.String(strings.ToLower(addon.PodIdentityS3Bucket)),
+		Prefix: aws.String(addon.PodIdentityS3BucketPrefix),
 	})
 	if err != nil {
 		return "", err
@@ -561,7 +560,7 @@ func getPodIdentityS3Bucket(ctx context.Context, cluster string, client *s3v2.Cl
 				foundClusterTag = true
 			}
 
-			if *tag.Key == strings.ToLower(addon.PodIdentityS3Bucket) && *tag.Value == "true" {
+			if *tag.Key == addon.PodIdentityS3BucketPrefix && *tag.Value == "true" {
 				foundPodIdentityTag = true
 			}
 

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Hybrid Nodes", func() {
 							Expect(verifyNode.Run(ctx)).To(Succeed(), "node should be fully functional")
 
 							test.logger.Info("Testing Pod Identity add-on functionality")
-							verifyPodIdentityAddon := test.newVerifyPodIdentityAddon()
+							verifyPodIdentityAddon := test.newVerifyPodIdentityAddon(instance.IP)
 							Expect(verifyPodIdentityAddon.Run(ctx)).To(Succeed(), "pod identity add-on should be created successfully")
 
 							test.logger.Info("Resetting hybrid node...")
@@ -507,12 +507,16 @@ func (t *peeredVPCTest) instanceName(testName string, os e2e.NodeadmOS, provider
 	)
 }
 
-func (t *peeredVPCTest) newVerifyPodIdentityAddon() *addon.VerifyPodIdentityAddon {
+func (t *peeredVPCTest) newVerifyPodIdentityAddon(nodeIP string) *addon.VerifyPodIdentityAddon {
 	return &addon.VerifyPodIdentityAddon{
 		Cluster:   t.cluster.Name,
+		NodeIP:    nodeIP,
 		K8S:       t.k8sClient,
-		Logger:    t.logger,
 		EKSClient: t.eksClient,
+		IAMClient: t.iamClient,
+		S3Client:  t.s3Client,
+		Logger:    t.logger,
+		K8SConfig: t.k8sClientConfig,
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
This is part 3 of setting up E2E tests for pod identity. 
[part 1](https://github.com/aws/eks-hybrid/pull/282)
[part 2](https://github.com/aws/eks-hybrid/pull/329)

*Description of changes:*
This PR would create a test pod with a service account, which is associated with pod identity. It then downloads test file from S3 bucket within the test pod. 

[Ref doc](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-how-it-works.html)


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

