### PR TITLE
Add Bottlerocket to E2E test suite

### DIFF
--- a/cmd/e2e-test/ssh/ssh.go
+++ b/cmd/e2e-test/ssh/ssh.go
@@ -106,7 +106,7 @@ func (s *Command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		"--document",
 		"AWS-StartInteractiveCommand",
 		"--parameters",
-		fmt.Sprintf("{\"command\":[\"sudo ssh %s\"]}", *targetInstance.PrivateIpAddress),
+		fmt.Sprintf("{\"command\":[\"sudo ssh ec2-user@%s\"]}", *targetInstance.PrivateIpAddress),
 		"--target",
 		*jumpbox.InstanceId,
 	)

--- a/test/e2e/addon/podidentityaddon.go
+++ b/test/e2e/addon/podidentityaddon.go
@@ -33,7 +33,7 @@ func NewPodIdentityAddon(cluster, roleArn string) PodIdentityAddon {
 		Addon: Addon{
 			Cluster:       cluster,
 			Name:          podIdentityAgent,
-			Configuration: "{\"daemonsets\":{\"hybrid\":{\"create\": true}}}",
+			Configuration: "{\"daemonsets\":{\"hybrid\":{\"create\": true},\"hybrid-bottlerocket\":{\"create\": true}}}",
 		},
 		roleArn: roleArn,
 	}

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	getAddonTimeout           = 10 * time.Minute
-	podIdentityDaemonSet      = "eks-pod-identity-agent-hybrid"
 	podIdentityToken          = "eks-pod-identity-token"
 	policyName                = "pod-identity-association-role-policy"
 	PodIdentityS3BucketPrefix = "podid"
@@ -66,18 +65,14 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 		return fmt.Errorf("waiting for pod identity add-on to be active: %w", err)
 	}
 
-	v.Logger.Info("Check if daemon set exists", "daemonSet", podIdentityDaemonSet)
-	if _, err := kubernetes.GetDaemonSet(ctx, v.Logger, v.K8S, "kube-system", podIdentityDaemonSet); err != nil {
-		return fmt.Errorf("getting daemon set %s: %w", podIdentityDaemonSet, err)
-	}
-
 	node, err := kubernetes.WaitForNode(ctx, v.K8S, v.NodeName, v.Logger)
 	if err != nil {
 		return fmt.Errorf("waiting for node %s to be ready: %w", v.NodeName, err)
 	}
 
-	if err := kubernetes.WaitForDaemonSetPodToBeRunning(ctx, v.K8S, "kube-system", podIdentityDaemonSet, node.Name, v.Logger); err != nil {
-		return fmt.Errorf("waiting for pod identity daemon set to be running on pod: %w", err)
+	v.Logger.Info("Looking for pod identity pod on target node", "nodeName", node.Name)
+	if err := v.waitForPodIdentityPodOnNode(ctx, node.Name); err != nil {
+		return fmt.Errorf("waiting for pod identity pod to be running on node %s: %w", node.Name, err)
 	}
 
 	podName := fmt.Sprintf("awscli-%s", node.Name)
@@ -146,4 +141,15 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (v VerifyPodIdentityAddon) waitForPodIdentityPodOnNode(ctx context.Context, nodeName string) error {
+	v.Logger.Info("Waiting for pod identity pod on node", "nodeName", nodeName)
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/instance=eks-pod-identity-agent",
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	}
+
+	return kubernetes.WaitForPodsToBeRunning(ctx, v.K8S, listOptions, "kube-system", v.Logger)
 }

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -233,16 +233,16 @@ func SetTestResourcesDefaults(testResources TestResources) TestResources {
 	}
 	if testResources.ClusterNetwork == (NetworkConfig{}) {
 		testResources.ClusterNetwork = NetworkConfig{
-			VpcCidr:           "10.0.0.0/16",
-			PublicSubnetCidr:  "10.0.10.0/24",
-			PrivateSubnetCidr: "10.0.20.0/24",
+			VpcCidr:           "10.20.0.0/16",
+			PublicSubnetCidr:  "10.20.1.0/24",
+			PrivateSubnetCidr: "10.20.2.0/24",
 		}
 	}
 	if testResources.HybridNetwork == (NetworkConfig{}) {
 		testResources.HybridNetwork = NetworkConfig{
-			VpcCidr:          "10.1.0.0/16",
-			PublicSubnetCidr: "10.1.1.0/24",
-			PodCidr:          "10.2.0.0/16",
+			VpcCidr:          "10.80.0.0/16",
+			PublicSubnetCidr: "10.80.1.0/24",
+			PodCidr:          "10.87.0.0/16",
 		}
 	}
 

--- a/test/e2e/constants/constants.go
+++ b/test/e2e/constants/constants.go
@@ -5,6 +5,7 @@ import "time"
 const (
 	CreationTimeTagKey              = "CreationTime"
 	TestClusterTagKey               = "Nodeadm-E2E-Tests-Cluster"
+	OSArchTagKey                    = "OS-Arch"
 	TestRolePathPrefix              = "/NodeadmE2E/"
 	EcrAccounId                     = "381492195191"
 	LogCollectorBundleFileName      = "bundle.tar.gz"
@@ -20,4 +21,7 @@ const (
 	SerialOutputLogFile             = "serial-output.log"
 	TestInstanceNameKubernetesLabel = "test.eks-hybrid.amazonaws.com/node-name"
 	DeferCleanupTimeout             = 5 * time.Minute
+	RolesAnywhereCertPath           = "/etc/roles-anywhere/pki/node.crt"
+	RolesAnywhereKeyPath            = "/etc/roles-anywhere/pki/node.key"
+	BottlerocketOsName              = "bottlerocket"
 )

--- a/test/e2e/credentials/rolesanywhere.go
+++ b/test/e2e/credentials/rolesanywhere.go
@@ -9,11 +9,7 @@ import (
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/creds"
 	"github.com/aws/eks-hybrid/test/e2e"
-)
-
-const (
-	rolesAnywhereCertPath = "/etc/roles-anywhere/pki/node.crt"
-	rolesAnywhereKeyPath  = "/etc/roles-anywhere/pki/node.key"
+	"github.com/aws/eks-hybrid/test/e2e/constants"
 )
 
 type IamRolesAnywhereProvider struct {
@@ -44,8 +40,8 @@ func (i *IamRolesAnywhereProvider) NodeadmConfig(ctx context.Context, node e2e.N
 					RoleARN:         i.RoleARN,
 					TrustAnchorARN:  i.TrustAnchorARN,
 					ProfileARN:      i.ProfileARN,
-					CertificatePath: rolesAnywhereCertPath,
-					PrivateKeyPath:  rolesAnywhereKeyPath,
+					CertificatePath: constants.RolesAnywhereCertPath,
+					PrivateKeyPath:  constants.RolesAnywhereKeyPath,
 				},
 				EnableCredentialsFile: true,
 			},
@@ -65,11 +61,11 @@ func (i *IamRolesAnywhereProvider) FilesForNode(node e2e.NodeSpec) ([]e2e.File, 
 	return []e2e.File{
 		{
 			Content: string(nodeCertificate.CertPEM),
-			Path:    rolesAnywhereCertPath,
+			Path:    constants.RolesAnywhereCertPath,
 		},
 		{
 			Content: string(nodeCertificate.KeyPEM),
-			Path:    rolesAnywhereKeyPath,
+			Path:    constants.RolesAnywhereKeyPath,
 		},
 	}, nil
 }

--- a/test/e2e/ec2/instance.go
+++ b/test/e2e/ec2/instance.go
@@ -33,6 +33,7 @@ type InstanceConfig struct {
 	UserData           []byte
 	SubnetID           string
 	SecurityGroupID    string
+	OS                 string
 }
 
 type Instance struct {
@@ -118,6 +119,10 @@ func (e *InstanceConfig) Create(ctx context.Context, ec2Client *ec2.Client, ssmC
 					{
 						Key:   aws.String(constants.TestClusterTagKey),
 						Value: aws.String(e.ClusterName),
+					},
+					{
+						Key:   aws.String(constants.OSArchTagKey),
+						Value: aws.String(e.OS),
 					},
 				},
 			},

--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -14,7 +14,7 @@ import (
 // NodeadmOS defines an interface for operating system-specific behavior.
 type NodeadmOS interface {
 	Name() string
-	AMIName(ctx context.Context, awsConfig aws.Config) (string, error)
+	AMIName(ctx context.Context, awsConfig aws.Config, kubernetesVersion string) (string, error)
 	BuildUserData(userDataInput UserDataInput) ([]byte, error)
 	InstanceType(region string, instanceSize InstanceSize, computeType ComputeType) string
 }
@@ -38,12 +38,18 @@ type UserDataInput struct {
 	EKSEndpoint       string
 	KubernetesVersion string
 	NodeadmUrls       NodeadmURLs
+	NodeadmConfig     *api.NodeConfig
 	NodeadmConfigYaml string
 	Provider          string
 	PublicKey         string
 	Region            string
 	RootPasswordHash  string
 	Files             []File
+
+	KubernetesAPIServer string
+	HostName            string
+	ClusterName         string
+	ClusterCert         []byte
 }
 
 type NodeadmURLs struct {

--- a/test/e2e/nodeadm/commands.go
+++ b/test/e2e/nodeadm/commands.go
@@ -59,23 +59,6 @@ func RebootInstance(ctx context.Context, runner commands.RemoteCommandRunner, in
 	return nil
 }
 
-func RunLogCollector(ctx context.Context, runner commands.RemoteCommandRunner, instanceIP, logBundleUrl string) error {
-	commands := []string{
-		fmt.Sprintf("/tmp/log-collector.sh '%s'", logBundleUrl),
-	}
-
-	output, err := runner.Run(ctx, instanceIP, commands)
-	if err != nil {
-		return fmt.Errorf("running remote command: %w", err)
-	}
-
-	if output.Status != "Success" {
-		return fmt.Errorf("log collector remote command did not succeed")
-	}
-
-	return nil
-}
-
 func RunNodeadmDebug(ctx context.Context, runner commands.RemoteCommandRunner, instanceIP string) error {
 	commands := []string{
 		"/tmp/nodeadm debug -c file:///nodeadm-config.yaml",

--- a/test/e2e/nodeadm/uninstall.go
+++ b/test/e2e/nodeadm/uninstall.go
@@ -57,6 +57,7 @@ func (u CleanNode) Run(ctx context.Context) error {
 	if err = RunNodeadmUninstall(ctx, u.RemoteCommandRunner, u.NodeIP); err != nil {
 		return err
 	}
+
 	u.Logger.Info("Waiting for hybrid node to be not ready...")
 	if err = kubernetes.WaitForHybridNodeToBeNotReady(ctx, u.K8s, node.Name, u.Logger); err != nil {
 		return err

--- a/test/e2e/os/amazonlinux.go
+++ b/test/e2e/os/amazonlinux.go
@@ -45,12 +45,18 @@ func (a AmazonLinux2023) InstanceType(region string, instanceSize e2e.InstanceSi
 	return getInstanceTypeFromRegionAndArch(region, a.architecture, instanceSize, computeType)
 }
 
-func (a AmazonLinux2023) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {
+func (a AmazonLinux2023) AMIName(ctx context.Context, awsConfig aws.Config, _ string) (string, error) {
 	amiId, err := getAmiIDFromSSM(ctx, ssm.NewFromConfig(awsConfig), "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-"+a.amiArchitecture)
 	return *amiId, err
 }
 
 func (a AmazonLinux2023) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) {
+	nodeadmConfigYaml, err := generateNodeadmConfigYaml(userDataInput.NodeadmConfig)
+	if err != nil {
+		return nil, err
+	}
+	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
+
 	if err := populateBaseScripts(&userDataInput); err != nil {
 		return nil, err
 	}

--- a/test/e2e/os/arch.go
+++ b/test/e2e/os/arch.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"sigs.k8s.io/yaml"
 
+	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/test/e2e"
 )
 
@@ -136,4 +138,13 @@ func getInstanceTypeFromRegionAndArch(_ string, arch architecture, instanceSize 
 		panic(fmt.Errorf("unknown instance size %d for architecture %s", instanceSize, arch))
 	}
 	return instanceType
+}
+
+func generateNodeadmConfigYaml(nodeadmConfig *api.NodeConfig) (string, error) {
+	nodeadmConfigYaml, err := yaml.Marshal(nodeadmConfig)
+	if err != nil {
+		return "", fmt.Errorf("marshalling nodeadm config to YAML: %w", err)
+	}
+
+	return string(nodeadmConfigYaml), nil
 }

--- a/test/e2e/os/bottlerocket.go
+++ b/test/e2e/os/bottlerocket.go
@@ -1,0 +1,126 @@
+package os
+
+import (
+	"context"
+	_ "embed"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+
+	"github.com/aws/eks-hybrid/test/e2e"
+	"github.com/aws/eks-hybrid/test/e2e/constants"
+)
+
+const (
+	sshUser                    = "ec2-user"
+	iamRaSetupBootstrapCommand = "eks-hybrid-iam-ra-setup"
+	iamRaCertificatePath       = "/root/.aws/node.crt"
+	iamRaKeyPath               = "/root/.aws/node.key"
+	ssmSetupBootstrapCommand   = "eks-hybrid-ssm-setup"
+	awsSigningHelperBinary     = "aws_signing_helper"
+)
+
+//go:embed testdata/bottlerocket/settings.toml
+var brSettingsToml []byte
+
+type brSettingsTomlInitData struct {
+	e2e.UserDataInput
+	AdminContainerUserData  string
+	AWSConfig               string
+	ClusterCertificate      string
+	HybridContainerUserData string
+	IamRA                   bool
+}
+
+type BottleRocket struct {
+	amiArchitecture string
+	architecture    architecture
+}
+
+func NewBottleRocket() *BottleRocket {
+	br := new(BottleRocket)
+	br.amiArchitecture = x8664Arch
+	br.architecture = amd64
+	return br
+}
+
+func NewBottleRocketARM() *BottleRocket {
+	br := new(BottleRocket)
+	br.amiArchitecture = arm64Arch
+	br.architecture = arm64
+	return br
+}
+
+func (a BottleRocket) Name() string {
+	return "bottlerocket-" + a.architecture.String()
+}
+
+func (a BottleRocket) InstanceType(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
+	return getInstanceTypeFromRegionAndArch(region, a.architecture, instanceSize, computeType)
+}
+
+func (a BottleRocket) AMIName(ctx context.Context, awsConfig aws.Config, kubernetesVersion string) (string, error) {
+	amiId, err := getAmiIDFromSSM(ctx, ssm.NewFromConfig(awsConfig), fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/%s/latest/image_id", kubernetesVersion, a.amiArchitecture))
+	return *amiId, err
+}
+
+func (a BottleRocket) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) {
+	if err := populateBaseScripts(&userDataInput); err != nil {
+		return nil, err
+	}
+	sshData := map[string]interface{}{
+		"user":          sshUser,
+		"password-hash": userDataInput.RootPasswordHash,
+		"ssh": map[string][]string{
+			"authorized-keys": {
+				strings.TrimSuffix(userDataInput.PublicKey, "\n"),
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(sshData)
+	if err != nil {
+		return nil, err
+	}
+	sshKey := base64.StdEncoding.EncodeToString([]byte(jsonData))
+
+	awsConfig := ""
+	bootstrapContainerCommand := ""
+	if userDataInput.NodeadmConfig.Spec.Hybrid.IAMRolesAnywhere != nil {
+		var certificate, key string
+		for _, file := range userDataInput.Files {
+			if file.Path == constants.RolesAnywhereCertPath {
+				certificate = strings.ReplaceAll(file.Content, "\\n", "\n")
+			}
+			if file.Path == constants.RolesAnywhereKeyPath {
+				key = strings.ReplaceAll(file.Content, "\\n", "\n")
+			}
+		}
+		bootstrapContainerCommand = fmt.Sprintf("%s --certificate='%s' --key='%s'", iamRaSetupBootstrapCommand, certificate, key)
+		awsConfig = fmt.Sprintf(`
+[default]
+credential_process = %s credential-process --certificate %s --private-key %s --profile-arn %s --role-arn %s --trust-anchor-arn %s --role-session-name %s
+`, awsSigningHelperBinary, iamRaCertificatePath, iamRaKeyPath, userDataInput.NodeadmConfig.Spec.Hybrid.IAMRolesAnywhere.ProfileARN, userDataInput.NodeadmConfig.Spec.Hybrid.IAMRolesAnywhere.RoleARN, userDataInput.NodeadmConfig.Spec.Hybrid.IAMRolesAnywhere.TrustAnchorARN, userDataInput.HostName)
+	} else if userDataInput.NodeadmConfig.Spec.Hybrid.SSM != nil {
+		bootstrapContainerCommand = fmt.Sprintf("%s --activation-id=%q --activation-code=%q --region=%q", ssmSetupBootstrapCommand, userDataInput.NodeadmConfig.Spec.Hybrid.SSM.ActivationID, userDataInput.NodeadmConfig.Spec.Hybrid.SSM.ActivationCode, userDataInput.Region)
+	}
+	data := brSettingsTomlInitData{
+		UserDataInput:           userDataInput,
+		AdminContainerUserData:  sshKey,
+		AWSConfig:               base64.StdEncoding.EncodeToString([]byte(awsConfig)),
+		ClusterCertificate:      base64.StdEncoding.EncodeToString(userDataInput.ClusterCert),
+		IamRA:                   userDataInput.NodeadmConfig.Spec.Hybrid.SSM == nil,
+		HybridContainerUserData: base64.StdEncoding.EncodeToString([]byte(bootstrapContainerCommand)),
+	}
+
+	return executeTemplate(brSettingsToml, data)
+}
+
+// IsBottlerocket returns true if the given name is a Bottlerocket OS name.
+func IsBottlerocket(name string) bool {
+	return strings.HasPrefix(name, constants.BottlerocketOsName)
+}

--- a/test/e2e/os/logs.go
+++ b/test/e2e/os/logs.go
@@ -1,0 +1,55 @@
+package os
+
+import (
+	"context"
+
+	"github.com/aws/eks-hybrid/test/e2e/commands"
+)
+
+type NodeLogCollector interface {
+	Run(ctx context.Context, instanceIP, logBundleUrl string) error
+}
+
+type StandardLinuxLogCollector struct {
+	Runner commands.RemoteCommandRunner
+}
+
+type BottlerocketLogCollector struct {
+	Runner commands.RemoteCommandRunner
+}
+
+func (s StandardLinuxLogCollector) Run(ctx context.Context, instanceIP, logBundleUrl string) error {
+	commands := []string{
+		"/tmp/log-collector.sh '" + logBundleUrl + "'",
+	}
+
+	output, err := s.Runner.Run(ctx, instanceIP, commands)
+	if err != nil {
+		return err
+	}
+
+	if output.Status != "Success" {
+		return err
+	}
+
+	return nil
+}
+
+func (b BottlerocketLogCollector) Run(ctx context.Context, instanceIP, logBundleUrl string) error {
+	commands := []string{
+		"sudo /usr/sbin/chroot /.bottlerocket/rootfs/ logdog --output /var/log/eks-hybrid-logs.tar.gz",
+		"sudo curl --retry 5 --request PUT --upload-file /.bottlerocket/rootfs/var/log/eks-hybrid-logs.tar.gz '" + logBundleUrl + "'",
+		"sudo rm /.bottlerocket/rootfs/var/log/eks-hybrid-logs.tar.gz",
+	}
+
+	output, err := b.Runner.Run(ctx, instanceIP, commands)
+	if err != nil {
+		return err
+	}
+
+	if output.Status != "Success" {
+		return err
+	}
+
+	return nil
+}

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -71,13 +71,19 @@ func (r RedHat8) InstanceType(region string, instanceSize e2e.InstanceSize, comp
 	return getInstanceTypeFromRegionAndArch(region, r.architecture, instanceSize, computeType)
 }
 
-func (r RedHat8) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {
+func (r RedHat8) AMIName(ctx context.Context, awsConfig aws.Config, _ string) (string, error) {
 	// there is no rhel ssm parameter
 	// aws ec2 describe-images --owners 309956199498 --query 'sort_by(Images, &CreationDate)[-1].[ImageId]' --filters "Name=name,Values=RHEL-8*" "Name=architecture,Values=x86_64" --region us-west-2
 	return findLatestImage(ctx, ec2.NewFromConfig(awsConfig), "RHEL-8*", r.amiArchitecture)
 }
 
 func (r RedHat8) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) {
+	nodeadmConfigYaml, err := generateNodeadmConfigYaml(userDataInput.NodeadmConfig)
+	if err != nil {
+		return nil, err
+	}
+	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
+
 	if err := populateBaseScripts(&userDataInput); err != nil {
 		return nil, err
 	}
@@ -144,13 +150,19 @@ func (r RedHat9) InstanceType(region string, instanceSize e2e.InstanceSize, comp
 	return getInstanceTypeFromRegionAndArch(region, r.architecture, instanceSize, computeType)
 }
 
-func (r RedHat9) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {
+func (r RedHat9) AMIName(ctx context.Context, awsConfig aws.Config, _ string) (string, error) {
 	// there is no rhel ssm parameter
 	// aws ec2 describe-images --owners 309956199498 --query 'sort_by(Images, &CreationDate)[-1].[ImageId]' --filters "Name=name,Values=RHEL-9*" "Name=architecture,Values=x86_64" --region us-west-2
 	return findLatestImage(ctx, ec2.NewFromConfig(awsConfig), "RHEL-9*", r.amiArchitecture)
 }
 
 func (r RedHat9) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) {
+	nodeadmConfigYaml, err := generateNodeadmConfigYaml(userDataInput.NodeadmConfig)
+	if err != nil {
+		return nil, err
+	}
+	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
+
 	if err := populateBaseScripts(&userDataInput); err != nil {
 		return nil, err
 	}
@@ -244,9 +256,4 @@ func paginationDone(in *ec2.DescribeImagesInput, out *ec2.DescribeImagesOutput) 
 	// This function helps go through all the pages to make sure if filtered
 	// result shows up in any one of the pages
 	return out.NextToken == nil || (in.NextToken != nil && in.NextToken == out.NextToken)
-}
-
-// IsRHEL8 returns true if the given name is a RHEL 8 OS name.
-func IsRHEL8(name string) bool {
-	return strings.HasPrefix(name, "rhel8")
 }

--- a/test/e2e/os/testdata/bottlerocket/settings.toml
+++ b/test/e2e/os/testdata/bottlerocket/settings.toml
@@ -1,0 +1,43 @@
+[settings.kubernetes]
+cluster-name = "{{ .ClusterName }}"
+api-server = "{{ .KubernetesAPIServer }}"
+cluster-certificate = "{{ .ClusterCertificate }}"
+cluster-dns-ip = "172.16.0.10"
+
+authentication-mode = "aws"
+cloud-provider = ""
+
+hostname-override = "{{ .HostName }}"
+provider-id = "eks-hybrid:///{{ .Region }}/{{ .ClusterName }}/{{ .HostName }}"
+
+[settings.network]
+hostname = "{{ .HostName }}"
+
+[settings.aws]
+region = "{{ .Region }}"
+config = "{{ .AWSConfig }}"
+
+[settings.kubernetes.node-labels]
+"eks.amazonaws.com/compute-type" = "hybrid"
+"test.eks-hybrid.amazonaws.com/node-name" = "{{ .HostName }}"
+{{- if .IamRA }}
+"eks.amazonaws.com/hybrid-credential-provider" = "iam-ra"
+{{- else }}
+"eks.amazonaws.com/hybrid-credential-provider" = "ssm"
+{{- end }}
+
+[settings.bootstrap-containers.eks-hybrid-setup]
+mode = "always"
+source = "public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.2.2"
+user-data = "{{ .HybridContainerUserData }}"
+
+[settings.host-containers.admin]
+enabled = true
+source = "public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.20"
+user-data = "{{ .AdminContainerUserData }}"
+
+{{- if not .IamRA }}
+[settings.host-containers.control]
+enabled = true
+source = "public.ecr.aws/bottlerocket/bottlerocket-control:v0.8.4"
+{{- end }}

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -79,12 +79,18 @@ func (u Ubuntu2004) InstanceType(region string, instanceSize e2e.InstanceSize, c
 	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize, computeType)
 }
 
-func (u Ubuntu2004) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {
+func (u Ubuntu2004) AMIName(ctx context.Context, awsConfig aws.Config, _ string) (string, error) {
 	amiId, err := getAmiIDFromSSM(ctx, ssm.NewFromConfig(awsConfig), "/aws/service/canonical/ubuntu/server/20.04/stable/current/"+u.amiArchitecture+"/hvm/ebs-gp2/ami-id")
 	return *amiId, err
 }
 
 func (u Ubuntu2004) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) {
+	nodeadmConfigYaml, err := generateNodeadmConfigYaml(userDataInput.NodeadmConfig)
+	if err != nil {
+		return nil, err
+	}
+	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
+
 	if err := populateBaseScripts(&userDataInput); err != nil {
 		return nil, err
 	}
@@ -147,12 +153,18 @@ func (u Ubuntu2204) InstanceType(region string, instanceSize e2e.InstanceSize, c
 	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize, computeType)
 }
 
-func (u Ubuntu2204) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {
+func (u Ubuntu2204) AMIName(ctx context.Context, awsConfig aws.Config, _ string) (string, error) {
 	amiId, err := getAmiIDFromSSM(ctx, ssm.NewFromConfig(awsConfig), "/aws/service/canonical/ubuntu/server/22.04/stable/current/"+u.amiArchitecture+"/hvm/ebs-gp2/ami-id")
 	return *amiId, err
 }
 
 func (u Ubuntu2204) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) {
+	nodeadmConfigYaml, err := generateNodeadmConfigYaml(userDataInput.NodeadmConfig)
+	if err != nil {
+		return nil, err
+	}
+	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
+
 	if err := populateBaseScripts(&userDataInput); err != nil {
 		return nil, err
 	}
@@ -226,12 +238,18 @@ func (u Ubuntu2404) InstanceType(region string, instanceSize e2e.InstanceSize, c
 	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize, computeType)
 }
 
-func (u Ubuntu2404) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {
+func (u Ubuntu2404) AMIName(ctx context.Context, awsConfig aws.Config, _ string) (string, error) {
 	amiId, err := getAmiIDFromSSM(ctx, ssm.NewFromConfig(awsConfig), "/aws/service/canonical/ubuntu/server/24.04/stable/current/"+u.amiArchitecture+"/hvm/ebs-gp3/ami-id")
 	return *amiId, err
 }
 
 func (u Ubuntu2404) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) {
+	nodeadmConfigYaml, err := generateNodeadmConfigYaml(userDataInput.NodeadmConfig)
+	if err != nil {
+		return nil, err
+	}
+	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
+
 	if err := populateBaseScripts(&userDataInput); err != nil {
 		return nil, err
 	}
@@ -254,9 +272,4 @@ func (u Ubuntu2404) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, erro
 	}
 
 	return executeTemplate(ubuntu2404CloudInit, data)
-}
-
-// IsUbuntu2004 returns true if the given name is an Ubuntu 2004 OS name.
-func IsUbuntu2004(name string) bool {
-	return strings.HasPrefix(name, "ubuntu2004")
 }

--- a/test/e2e/peered/serial.go
+++ b/test/e2e/peered/serial.go
@@ -10,7 +10,6 @@ import (
 	"github.com/onsi/gomega"
 
 	"github.com/aws/eks-hybrid/test/e2e"
-	"github.com/aws/eks-hybrid/test/e2e/ec2"
 	"github.com/aws/eks-hybrid/test/e2e/ssh"
 )
 
@@ -30,7 +29,7 @@ type SerialOutputBlock struct {
 type SerialOutputConfig struct {
 	By         func(description string, callback ...func())
 	PeeredNode *Node
-	Instance   ec2.Instance
+	Instance   PeeredInstance
 	TestLogger e2e.PausableLogger
 	OutputFile string
 	Output     io.Writer // Writer to output serial console to, defaults to os.Stdout if nil

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -16,7 +16,7 @@ type AddonEc2Test struct {
 
 // NewNodeMonitoringAgentTest creates a new NodeMonitoringAgentTest
 func (a *AddonEc2Test) NewNodeMonitoringAgentTest() *addon.NodeMonitoringAgentTest {
-	commandRunner := ssm.NewSSHOnSSMCommandRunner(a.SSMClient, a.JumpboxInstanceId, a.Logger)
+	commandRunner := ssm.NewStandardLinuxSSHOnSSMCommandRunner(a.SSMClient, a.JumpboxInstanceId, a.Logger)
 	return &addon.NodeMonitoringAgentTest{
 		Cluster:       a.Cluster.Name,
 		K8S:           a.k8sClient,
@@ -82,7 +82,7 @@ func (a *AddonEc2Test) NewPrometheusNodeExporterTest() *addon.PrometheusNodeExpo
 
 // NewNvidiaDevicePluginTest creates a new NvidiaDevicePluginTest
 func (a *AddonEc2Test) NewNvidiaDevicePluginTest(nodeName string) *addon.NvidiaDevicePluginTest {
-	commandRunner := ssm.NewSSHOnSSMCommandRunner(a.SSMClient, a.JumpboxInstanceId, a.Logger)
+	commandRunner := ssm.NewStandardLinuxSSHOnSSMCommandRunner(a.SSMClient, a.JumpboxInstanceId, a.Logger)
 	return &addon.NvidiaDevicePluginTest{
 		Cluster:       a.Cluster.Name,
 		K8S:           a.k8sClient,

--- a/test/e2e/suite/conformance/conformance_test.go
+++ b/test/e2e/suite/conformance/conformance_test.go
@@ -69,7 +69,7 @@ var _ = SynchronizedBeforeSuite(
 			nodesToCreate = append(nodesToCreate, suite.NodeCreate{
 				OS:           os,
 				Provider:     provider,
-				InstanceName: test.InstanceName("conformance", os, provider),
+				InstanceName: test.InstanceName("conformance", os.Name(), string(provider.Name())),
 				InstanceSize: e2e.XLarge,
 				NodeName:     "conformance" + "-node-" + string(provider.Name()) + "-" + os.Name(),
 			})

--- a/test/e2e/suite/nodeadm/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm/nodeadm_test.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/aws/eks-hybrid/test/e2e"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+	"github.com/aws/eks-hybrid/test/e2e/os"
+	"github.com/aws/eks-hybrid/test/e2e/ssm"
 	"github.com/aws/eks-hybrid/test/e2e/suite"
 )
 
@@ -78,11 +80,17 @@ var _ = Describe("Hybrid Nodes", func() {
 		When("using ec2 instance as hybrid nodes", func() {
 			upgradeEntries := []TableEntry{}
 			initEntries := []TableEntry{}
+			bottlerocketInitEntries := []TableEntry{}
 			for _, osProvider := range suite.OSProviderList(credentialProviders) {
 				os := osProvider.OS
 				provider := osProvider.Provider
 				initEntries = append(initEntries, Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), os, provider, Label(os.Name(), string(provider.Name()), "simpleflow", "init")))
 				upgradeEntries = append(upgradeEntries, Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), os, provider, Label(os.Name(), string(provider.Name()), "upgradeflow")))
+			}
+			for _, os := range suite.BottlerocketOSList() {
+				for _, provider := range credentialProviders {
+					bottlerocketInitEntries = append(bottlerocketInitEntries, Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), os, provider, Label(os.Name(), string(provider.Name()), "simpleflow", "init")))
+				}
 			}
 
 			DescribeTable("Joining a node",
@@ -90,7 +98,7 @@ var _ = Describe("Hybrid Nodes", func() {
 					Expect(nodeOS).NotTo(BeNil())
 					Expect(provider).NotTo(BeNil())
 
-					instanceName := test.InstanceName("init", nodeOS, provider)
+					instanceName := test.InstanceName("init", nodeOS.Name(), string(provider.Name()))
 					nodeName := "simpleflow" + "-node-" + string(provider.Name()) + "-" + nodeOS.Name()
 
 					k8sVersion := test.Cluster.KubernetesVersion
@@ -100,19 +108,20 @@ var _ = Describe("Hybrid Nodes", func() {
 
 					testNode := test.NewTestNode(ctx, instanceName, nodeName, k8sVersion, nodeOS, provider, e2e.Large, e2e.CPUInstance)
 					Expect(testNode.Start(ctx)).To(Succeed(), "node should start successfully")
+					Expect(testNode.WaitForJoin(ctx)).To(Succeed(), "node should join successfully")
 					Expect(testNode.Verify(ctx)).To(Succeed(), "node should be fully functional")
 
 					test.Logger.Info("Testing Pod Identity add-on functionality")
-					verifyPodIdentityAddon := test.NewVerifyPodIdentityAddon(testNode.PeerdNode().Name)
+					verifyPodIdentityAddon := test.NewVerifyPodIdentityAddon(testNode.PeeredInstance().Name)
 					Expect(verifyPodIdentityAddon.Run(ctx)).To(Succeed(), "pod identity add-on should be created successfully")
 
 					test.Logger.Info("Resetting hybrid node...")
-					n := testNode.PeerdNode()
+					i := testNode.PeeredInstance()
 					cleanNode := test.NewCleanNode(
 						provider,
-						testNode.PeeredNode.NodeInfrastructureCleaner(*n),
-						n.Name,
-						n.Instance.IP,
+						testNode.PeeredNode.NodeInfrastructureCleaner(*i),
+						i.Name,
+						i.IP,
 					)
 					Expect(cleanNode.Run(ctx)).To(Succeed(), "node should have been reset successfully")
 
@@ -123,7 +132,7 @@ var _ = Describe("Hybrid Nodes", func() {
 					testNode.It("re-joins the cluster after reboot", func() {
 						Expect(testNode.WaitForNodeReady(ctx)).Error().To(Succeed(), "node should have re-joined, there must be a problem with uninstall")
 					})
-					Expect(testNode.PeeredNetwork.CreateRoutesForNode(ctx, n)).Should(Succeed(), "EC2 route to pod CIDR should have been created successfully")
+					Expect(testNode.PeeredNetwork.CreateRoutesForNode(ctx, i)).Should(Succeed(), "EC2 route to pod CIDR should have been created successfully")
 
 					Expect(testNode.Verify(ctx)).To(Succeed(), "node should be fully functional")
 
@@ -143,13 +152,13 @@ var _ = Describe("Hybrid Nodes", func() {
 					Expect(provider).NotTo(BeNil())
 
 					// Skip upgrade flow for cluster with the minimum kubernetes version
-					isSupport, err := kubernetes.IsPreviousVersionSupported(test.Cluster.KubernetesVersion)
+					isPreviousVersionSupported, err := kubernetes.IsPreviousVersionSupported(test.Cluster.KubernetesVersion)
 					Expect(err).NotTo(HaveOccurred(), "expected to get previous k8s version")
-					if !isSupport {
+					if !isPreviousVersionSupported {
 						Skip(fmt.Sprintf("Skipping upgrade test as minimum k8s version is %s", kubernetes.MinimumVersion))
 					}
 
-					instanceName := test.InstanceName("upgrade", nodeOS, provider)
+					instanceName := test.InstanceName("upgrade", nodeOS.Name(), string(provider.Name()))
 					nodeName := "upgradeflow" + "-node-" + string(provider.Name()) + "-" + nodeOS.Name()
 
 					nodeKubernetesVersion, err := kubernetes.PreviousVersion(test.Cluster.KubernetesVersion)
@@ -157,9 +166,10 @@ var _ = Describe("Hybrid Nodes", func() {
 
 					testNode := test.NewTestNode(ctx, instanceName, nodeName, nodeKubernetesVersion, nodeOS, provider, e2e.Large, e2e.CPUInstance)
 					Expect(testNode.Start(ctx)).To(Succeed(), "node should start successfully")
+					Expect(testNode.WaitForJoin(ctx)).To(Succeed(), "node should join successfully")
 					Expect(testNode.Verify(ctx)).To(Succeed(), "node should be fully functional")
 
-					Expect(test.NewUpgradeNode(testNode.PeerdNode().Name, testNode.PeerdNode().Instance.IP).Run(ctx)).To(Succeed(), "node should have upgraded successfully")
+					Expect(test.NewUpgradeNode(testNode.PeeredInstance().Name, testNode.PeeredInstance().IP).Run(ctx)).To(Succeed(), "node should have upgraded successfully")
 
 					Expect(testNode.Verify(ctx)).To(Succeed(), "node should have joined the cluster successfully after nodeadm upgrade")
 
@@ -168,18 +178,56 @@ var _ = Describe("Hybrid Nodes", func() {
 						return
 					}
 
-					n := testNode.PeerdNode()
+					i := testNode.PeeredInstance()
 					cleanNode := test.NewCleanNode(
 						provider,
-						testNode.PeeredNode.NodeInfrastructureCleaner(*n),
-						n.Name,
-						n.Instance.IP,
+						testNode.PeeredNode.NodeInfrastructureCleaner(*i),
+						i.Name,
+						i.IP,
 					)
 					Expect(cleanNode.Run(ctx)).To(
 						Succeed(), "node should have been reset successfully",
 					)
 				},
 				upgradeEntries,
+			)
+
+			DescribeTable("Joining a Bottlerocket node",
+				func(ctx context.Context, nodeOS e2e.NodeadmOS, provider e2e.NodeadmCredentialsProvider) {
+					Expect(nodeOS).NotTo(BeNil())
+					Expect(provider).NotTo(BeNil())
+
+					instanceName := test.InstanceName("init", nodeOS.Name(), string(provider.Name()))
+					nodeName := "init" + "-node-" + string(provider.Name()) + "-" + nodeOS.Name()
+
+					k8sVersion := test.Cluster.KubernetesVersion
+					if test.OverrideNodeK8sVersion != "" {
+						k8sVersion = test.OverrideNodeK8sVersion
+					}
+
+					remoteCommandRunner := ssm.NewBottlerocketSSHOnSSMCommandRunner(test.SSMClient, test.JumpboxInstanceId, test.Logger)
+					logCollector := os.BottlerocketLogCollector{
+						Runner: remoteCommandRunner,
+					}
+					testNode := test.NewTestNode(ctx, instanceName, nodeName, k8sVersion, nodeOS, provider, e2e.Large, e2e.CPUInstance)
+					testNode.PeeredNode.RemoteCommandRunner = remoteCommandRunner
+					testNode.PeeredNode.LogCollector = logCollector
+					Expect(testNode.Start(ctx)).To(Succeed(), "node should start successfully")
+					testNode.NodeWaiter = testNode.NewBottlerocketNodeWaiter()
+					Expect(testNode.WaitForJoin(ctx)).To(Succeed(), "node should join successfully")
+					Expect(testNode.Verify(ctx)).To(Succeed(), "node should be fully functional")
+
+					test.Logger.Info("Testing Pod Identity add-on functionality")
+					verifyPodIdentityAddon := test.NewVerifyPodIdentityAddon(testNode.PeeredInstance().Name)
+					Expect(verifyPodIdentityAddon.Run(ctx)).To(Succeed(), "pod identity add-on should be created successfully")
+
+					i := testNode.PeeredInstance()
+
+					Expect(testNode.PeeredNetwork.CreateRoutesForNode(ctx, i)).Should(Succeed(), "EC2 route to pod CIDR should have been created successfully")
+
+					Expect(testNode.Verify(ctx)).To(Succeed(), "node should be fully functional")
+				},
+				bottlerocketInitEntries,
 			)
 		})
 	})

--- a/test/e2e/suite/waiter.go
+++ b/test/e2e/suite/waiter.go
@@ -1,0 +1,116 @@
+package suite
+
+import (
+	"context"
+
+	ec2v2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-hybrid/test/e2e/commands"
+	"github.com/aws/eks-hybrid/test/e2e/constants"
+	"github.com/aws/eks-hybrid/test/e2e/ec2"
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+	"github.com/aws/eks-hybrid/test/e2e/nodeadm"
+)
+
+type NodeWaiter interface {
+	Run(ctx context.Context, flakeRun FlakeRun)
+}
+
+type StandardLinuxNodeWaiter struct {
+	ec2Client           *ec2v2.Client
+	instanceID          string
+	instanceIP          string
+	verifyNode          *kubernetes.VerifyNode
+	remoteCommandRunner commands.RemoteCommandRunner
+	logger              logr.Logger
+}
+
+type BottlerocketNodeWaiter struct {
+	ec2Client           *ec2v2.Client
+	instanceID          string
+	instanceIP          string
+	verifyNode          *kubernetes.VerifyNode
+	remoteCommandRunner commands.RemoteCommandRunner
+	logger              logr.Logger
+}
+
+func (n *testNode) NewStandardLinuxNodeWaiter() *StandardLinuxNodeWaiter {
+	return &StandardLinuxNodeWaiter{
+		ec2Client:           n.EC2Client,
+		instanceID:          n.peeredInstance.ID,
+		instanceIP:          n.peeredInstance.IP,
+		verifyNode:          n.verifyNode,
+		remoteCommandRunner: n.PeeredNode.RemoteCommandRunner,
+		logger:              n.Logger,
+	}
+}
+
+func (n *testNode) NewBottlerocketNodeWaiter() *BottlerocketNodeWaiter {
+	return &BottlerocketNodeWaiter{
+		ec2Client:           n.EC2Client,
+		instanceID:          n.peeredInstance.ID,
+		instanceIP:          n.peeredInstance.IP,
+		verifyNode:          n.verifyNode,
+		remoteCommandRunner: n.PeeredNode.RemoteCommandRunner,
+		logger:              n.Logger,
+	}
+}
+
+func (w *StandardLinuxNodeWaiter) Run(ctx context.Context, flakeRun FlakeRun) {
+	w.logger.Info("Waiting for EC2 Instance to be Running...")
+	flakeRun.RetryableExpect(ec2.WaitForEC2InstanceRunning(ctx, w.ec2Client, w.instanceID)).To(Succeed(), "EC2 Instance should have been reached Running status")
+	_, err := w.verifyNode.WaitForNodeReady(ctx)
+
+	// if the node is impaired, we want to trigger a retryable expect
+	// if the node is not impaired, we run nodeadm debug regardless of whether the node joined the cluster successfully
+	// if the node joined successfully and debug fails, the test will fail
+	expect := flakeRun.RetryableExpect
+	isImpaired := isImpaired(ctx, err, w.ec2Client, w.instanceID, w.logger)
+	var debugErr error
+	if !isImpaired {
+		expect = Expect
+		debugErr = nodeadm.RunNodeadmDebug(ctx, w.remoteCommandRunner, w.instanceIP)
+	}
+
+	// attempt to get the nodeadm version regardless of previous errors
+	version, versionErr := nodeadm.RunNodeadmVersion(ctx, w.remoteCommandRunner, w.instanceIP)
+	if versionErr == nil && version != "" {
+		AddReportEntry(constants.TestNodeadmVersion, version)
+	}
+
+	expect(err).To(Succeed(), "node should have joined the cluster successfully")
+	Expect(debugErr).NotTo(HaveOccurred(), "nodeadm debug should have been run successfully")
+	Expect(versionErr).NotTo(HaveOccurred(), "nodeadm version should have been retrieved successfully")
+	Expect(version).NotTo(BeEmpty(), "nodeadm version should not be empty")
+}
+
+func (w *BottlerocketNodeWaiter) Run(ctx context.Context, flakeRun FlakeRun) {
+	w.logger.Info("Waiting for EC2 Instance to be Running...")
+	flakeRun.RetryableExpect(ec2.WaitForEC2InstanceRunning(ctx, w.ec2Client, w.instanceID)).To(Succeed(), "EC2 Instance should have been reached Running status")
+	_, err := w.verifyNode.WaitForNodeReady(ctx)
+
+	// if the node is impaired, we want to trigger a retryable expect
+	// if the node is not impaired, we run nodeadm debug regardless of whether the node joined the cluster successfully
+	// if the node joined successfully and debug fails, the test will fail
+	expect := flakeRun.RetryableExpect
+	isImpaired := isImpaired(ctx, err, w.ec2Client, w.instanceID, w.logger)
+	if !isImpaired {
+		expect = Expect
+	}
+
+	expect(err).To(Succeed(), "node should have joined the cluster successfully")
+
+	AddReportEntry(constants.TestNodeadmVersion, "N/A")
+}
+
+func isImpaired(ctx context.Context, waitErr error, ec2Client *ec2v2.Client, instanceID string, logger logr.Logger) bool {
+	if waitErr == nil {
+		return false
+	}
+	isImpaired, err := ec2.IsEC2InstanceImpaired(ctx, ec2Client, instanceID)
+	logger.Error(err, "describing instance status")
+	return isImpaired
+}


### PR DESCRIPTION
This PR adds Bottlerocket tests to E2E test suite for both SSM and IAM-RA credential providers.

*Testing (if applicable):*

Tested the combinations `[bottlerocket-amd64, iam-ra, simpleflow, init]` and `[bottlerocket-amd64, ssm, simpleflow, init]` locally

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

