### PR TITLE
Set firewall rules on best effort basis

### DIFF
--- a/internal/system/ports.go
+++ b/internal/system/ports.go
@@ -47,7 +47,9 @@ func (s *portsAspect) Name() string {
 func (s *portsAspect) Setup() error {
 	firewallEnabled, err := s.firewallManager.IsEnabled()
 	if err != nil {
-		return err
+		s.logger.Warn("Failed to get firewall status", zap.Error(err))
+		s.logger.Info("Skip setting firewall rules")
+		return nil
 	}
 	if firewallEnabled {
 		s.logger.Info("Allowing port on firewall", zap.Reflect("kubelet-server-port", kubeletServePort))

--- a/test/integration/cases/hybrid-node-system-aspects/run.sh
+++ b/test/integration/cases/hybrid-node-system-aspects/run.sh
@@ -35,3 +35,11 @@ assert::swap-disabled-validate-path
 assert::allowed-by-firewalld "10250" "tcp"
 assert::allowed-by-firewalld "10256" "tcp"
 assert::allowed-by-firewalld "30000-32767" "tcp"
+
+exit_code=0
+systemctl stop firewalld
+STDERR=$(nodeadm init --skip run,install-validation --config-source file://config.yaml 2>&1) || exit_code=$?
+if [ $exit_code -ne 0]; then
+  echo "nodeadm init should not fail with firewall-cmd installed but firewalld service not running"
+  exit 1
+fi


### PR DESCRIPTION
*Description of changes:*
Nodeadm during init would look if firewall is enabled and if it is, it will setup firewall rules to make sure node can operate properly. It opens up ports for Kubelet, Kube-proxy as well as node ports. 

Depending on the OS nodeadm checks for ufw and firewalld states for configuring the different firewall rules. Sometimes the backing firewall service may not be running or failing and nodeadm init process would just fail. With this change, nodeadm checks if firewall is enabled, it its not, or if theres any error in checking for the firewall state, nodeadm skips setting up the rules and moves on with the init process.

An example log
```
{"level":"warn","ts":1739568835.7944512,"caller":"system/ports.go:50","msg":"Failed to get firewall status","error":"exit status 254"}
{"level":"info","ts":1739568835.7944925,"caller":"system/ports.go:51","msg":"Skip setting firewall rules"}
```

*Testing (if applicable):*
Tested with integration tests
/hold for e2e testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

