### PR TITLE
Add e2e test commands for manually creating a deleting a node

### DIFF
--- a/cmd/e2e-test/cleanup/cleanup.go
+++ b/cmd/e2e-test/cleanup/cleanup.go
@@ -15,13 +15,13 @@ import (
 	"github.com/aws/eks-hybrid/test/e2e/cluster"
 )
 
-type command struct {
+type Command struct {
 	flaggy            *flaggy.Subcommand
 	resourcesFilePath string
 }
 
-func NewCommand() cli.Command {
-	cmd := command{}
+func NewCommand() *Command {
+	cmd := Command{}
 
 	cleanup := flaggy.NewSubcommand("cleanup")
 	cleanup.Description = "Delete the E2E test infrastructure"
@@ -34,11 +34,15 @@ func NewCommand() cli.Command {
 	return &cmd
 }
 
-func (c *command) Flaggy() *flaggy.Subcommand {
+func (c *Command) Flaggy() *flaggy.Subcommand {
 	return c.flaggy
 }
 
-func (s *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+func (c *Command) Commands() []cli.Command {
+	return []cli.Command{c}
+}
+
+func (s *Command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	ctx := context.Background()
 	logger := e2e.NewLogger()
 

--- a/cmd/e2e-test/main.go
+++ b/cmd/e2e-test/main.go
@@ -5,19 +5,26 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/aws/eks-hybrid/cmd/e2e-test/cleanup"
+	"github.com/aws/eks-hybrid/cmd/e2e-test/node"
 	"github.com/aws/eks-hybrid/cmd/e2e-test/setup"
 	"github.com/aws/eks-hybrid/cmd/e2e-test/ssh"
 	"github.com/aws/eks-hybrid/internal/cli"
 )
 
+type command interface {
+	Flaggy() *flaggy.Subcommand
+	Commands() []cli.Command
+}
+
 func main() {
 	flaggy.SetName("e2e-test")
 	flaggy.SetDescription("Manage the lifecycle of EKS clusters for E2E tests")
 
-	cmds := []cli.Command{
+	cmds := []command{
 		setup.NewCommand(),
 		cleanup.NewCommand(),
 		ssh.NewCommand(),
+		node.NewCommand(),
 	}
 
 	for _, cmd := range cmds {
@@ -29,13 +36,15 @@ func main() {
 	opts := cli.NewGlobalOptions()
 	log := cli.NewLogger(opts)
 
-	for _, cmd := range cmds {
-		if cmd.Flaggy().Used {
-			err := cmd.Run(log, opts)
-			if err != nil {
-				log.Fatal("Command failed", zap.Error(err))
+	for _, subCmd := range cmds {
+		for _, cmd := range subCmd.Commands() {
+			if cmd.Flaggy().Used {
+				err := cmd.Run(log, opts)
+				if err != nil {
+					log.Fatal("Command failed", zap.Error(err))
+				}
+				return
 			}
-			return
 		}
 	}
 	flaggy.ShowHelpAndExit("No command specified")

--- a/cmd/e2e-test/node/create.go
+++ b/cmd/e2e-test/node/create.go
@@ -1,0 +1,234 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	s3sdk "github.com/aws/aws-sdk-go-v2/service/s3"
+	ssmsdk "github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/go-logr/logr"
+	"github.com/integrii/flaggy"
+	"go.uber.org/zap"
+	clientgo "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/aws/eks-hybrid/internal/cli"
+	"github.com/aws/eks-hybrid/test/e2e"
+	"github.com/aws/eks-hybrid/test/e2e/cluster"
+	"github.com/aws/eks-hybrid/test/e2e/credentials"
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+	osystem "github.com/aws/eks-hybrid/test/e2e/os"
+	"github.com/aws/eks-hybrid/test/e2e/peered"
+	"github.com/aws/eks-hybrid/test/e2e/s3"
+	"github.com/aws/eks-hybrid/test/e2e/suite"
+)
+
+type create struct {
+	flaggy        *flaggy.Subcommand
+	configFile    string
+	instanceName  string
+	credsProvider string
+	os            string
+	arch          string
+	waitForReady  bool
+}
+
+func NewCreateCommand() cli.Command {
+	cmd := create{
+		os:   "al23",
+		arch: "amd64",
+	}
+
+	createCmd := flaggy.NewSubcommand("create")
+	createCmd.Description = "Create a Hybrid Node"
+	createCmd.AddPositionalValue(&cmd.instanceName, "INSTANCE_NAME", 1, true, "Name of the instance to create.")
+	createCmd.String(&cmd.configFile, "f", "config-file", "Path tests config file.")
+	createCmd.String(&cmd.credsProvider, "c", "creds-provider", "Credentials provider to use (iam-ra, ssm).")
+	createCmd.String(&cmd.os, "o", "os", "OS to use (al23, ubuntu2004, ubuntu2204, ubuntu2404, rhel8, rhel9).")
+	createCmd.String(&cmd.arch, "a", "arch", "Architecture to use (amd64, arm64).")
+	createCmd.Bool(&cmd.waitForReady, "w", "wait-for-ready", "Wait for the node to be ready.")
+
+	cmd.flaggy = createCmd
+
+	return &cmd
+}
+
+func (c *create) Flaggy() *flaggy.Subcommand {
+	return c.flaggy
+}
+
+func (c *create) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+	ctx := context.Background()
+	config, err := suite.ReadConfig(c.configFile)
+	if err != nil {
+		return err
+	}
+
+	logger := e2e.NewLogger()
+	aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.ClusterRegion))
+	if err != nil {
+		return fmt.Errorf("reading AWS configuration: %w", err)
+	}
+
+	infra, err := peered.Setup(ctx, logger, aws, config.ClusterName, config.Endpoint)
+	if err != nil {
+		return fmt.Errorf("setting up test infrastructure: %w", err)
+	}
+
+	eksClient := eks.NewFromConfig(aws)
+	ec2Client := ec2.NewFromConfig(aws)
+	ssmClient := ssmsdk.NewFromConfig(aws)
+	s3Client := s3sdk.NewFromConfig(aws)
+
+	clientConfig, err := clientcmd.BuildConfigFromFlags("", cluster.KubeconfigPath(config.ClusterName))
+	if err != nil {
+		return err
+	}
+	k8s, err := clientgo.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	cluster, err := peered.GetHybridCluster(ctx, eksClient, ec2Client, config.ClusterName)
+	if err != nil {
+		return err
+	}
+
+	urls, err := s3.BuildNodeamURLs(ctx, s3Client, config.NodeadmUrlAMD, config.NodeadmUrlARM)
+	if err != nil {
+		return err
+	}
+
+	node := peered.NodeCreate{
+		AWS:     aws,
+		Cluster: cluster,
+		EC2:     ec2Client,
+		SSM:     ssmClient,
+		Logger:  logger,
+
+		NodeadmURLs: *urls,
+		PublicKey:   infra.NodesPublicSSHKey,
+	}
+
+	nodeOS, err := buildOS(c.os, c.arch)
+	if err != nil {
+		return err
+	}
+
+	var credsProvider e2e.NodeadmCredentialsProvider
+
+	switch c.credsProvider {
+	case "iam-ra":
+		credsProvider = &credentials.IamRolesAnywhereProvider{
+			RoleARN:        infra.Credentials.IRANodeRoleARN,
+			ProfileARN:     infra.Credentials.IRAProfileARN,
+			TrustAnchorARN: infra.Credentials.IRATrustAnchorARN,
+			CA:             infra.Credentials.RolesAnywhereCA,
+		}
+	case "ssm":
+		credsProvider = &credentials.SsmProvider{
+			SSM:  ssmClient,
+			Role: infra.Credentials.SSMNodeRoleName,
+		}
+	}
+
+	instance, err := node.Create(ctx, &peered.NodeSpec{
+		InstanceName:   c.instanceName,
+		NodeK8sVersion: cluster.KubernetesVersion,
+		NodeNamePrefix: c.instanceName,
+		OS:             nodeOS,
+		Provider:       credsProvider,
+	})
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Node created", "instanceID", instance.ID)
+
+	if c.waitForReady {
+		logger.Info("Connecting to the node serial console...")
+		serial, err := node.SerialConsole(ctx, instance.ID)
+		if err != nil {
+			return fmt.Errorf("preparing EC2 for serial connection: %w", err)
+		}
+		defer serial.Close()
+
+		pausableOutput := e2e.NewSwitchWriter(os.Stdout)
+		pausableOutput.Pause()
+		if err := serial.Copy(pausableOutput); err != nil {
+			return fmt.Errorf("connecting to EC2 serial console: %w", err)
+		}
+
+		logger.Info("Waiting for the node to initialize...")
+		if err := pausableOutput.Resume(); err != nil {
+			return fmt.Errorf("resuming output: %w", err)
+		}
+		verify := kubernetes.VerifyNode{
+			K8s:           k8s,
+			Logger:        logr.Discard(),
+			NodeIPAddress: instance.IP,
+		}
+		node, err := verify.WaitForNodeReady(ctx)
+		if err != nil {
+			return fmt.Errorf("waiting for node to be ready: %w", err)
+		}
+		pausableOutput.Pause()
+		fmt.Println() // newline after pausing the serial output to ensure a clean log after
+		logger.Info("Node is ready", "nodeName", node.Name)
+	}
+
+	return nil
+}
+
+func buildOS(osName, arch string) (e2e.NodeadmOS, error) {
+	osBuilders, ok := oses[osName]
+	if !ok {
+		return nil, fmt.Errorf("unknown OS %s", osName)
+	}
+
+	build, ok := osBuilders[arch]
+	if !ok {
+		return nil, fmt.Errorf("unknown architecture %q for OS %q", arch, osName)
+	}
+
+	return build(), nil
+}
+
+var oses = map[string]map[string]func() e2e.NodeadmOS{
+	"al23": {
+		"amd64": func() e2e.NodeadmOS { return osystem.NewAmazonLinux2023AMD() },
+		"arm64": func() e2e.NodeadmOS { return osystem.NewAmazonLinux2023ARM() },
+	},
+	"ubuntu2004": {
+		"amd64": func() e2e.NodeadmOS { return osystem.NewUbuntu2004AMD() },
+		"arm64": func() e2e.NodeadmOS { return osystem.NewUbuntu2004ARM() },
+	},
+	"ubuntu2204": {
+		"amd64": func() e2e.NodeadmOS { return osystem.NewUbuntu2204AMD() },
+		"arm64": func() e2e.NodeadmOS { return osystem.NewUbuntu2204ARM() },
+	},
+	"ubuntu2404": {
+		"amd64": func() e2e.NodeadmOS { return osystem.NewUbuntu2404AMD() },
+		"arm64": func() e2e.NodeadmOS { return osystem.NewUbuntu2404ARM() },
+	},
+	"rhel8": {
+		"amd64": func() e2e.NodeadmOS {
+			return osystem.NewRedHat8AMD(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD"))
+		},
+		"arm64": func() e2e.NodeadmOS {
+			return osystem.NewRedHat8ARM(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD"))
+		},
+	},
+	"rhel9": {
+		"amd64": func() e2e.NodeadmOS {
+			return osystem.NewRedHat9AMD(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD"))
+		},
+		"arm64": func() e2e.NodeadmOS {
+			return osystem.NewRedHat9ARM(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD"))
+		},
+	},
+}

--- a/cmd/e2e-test/node/delete.go
+++ b/cmd/e2e-test/node/delete.go
@@ -1,0 +1,123 @@
+package node
+
+import (
+	"context"
+	"fmt"
+
+	sdk "github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	ec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	s3sdk "github.com/aws/aws-sdk-go-v2/service/s3"
+	ssmsdk "github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/integrii/flaggy"
+	"go.uber.org/zap"
+	clientgo "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/aws/eks-hybrid/internal/cli"
+	"github.com/aws/eks-hybrid/test/e2e"
+	"github.com/aws/eks-hybrid/test/e2e/cluster"
+	"github.com/aws/eks-hybrid/test/e2e/ec2"
+	"github.com/aws/eks-hybrid/test/e2e/peered"
+	"github.com/aws/eks-hybrid/test/e2e/ssm"
+	"github.com/aws/eks-hybrid/test/e2e/suite"
+)
+
+type Delete struct {
+	flaggy       *flaggy.Subcommand
+	configFile   string
+	instanceName string
+}
+
+func NewDeleteCommand() *Delete {
+	cmd := &Delete{}
+
+	deleteCmd := flaggy.NewSubcommand("delete")
+	deleteCmd.Description = "Delete a Hybrid Node"
+	deleteCmd.AddPositionalValue(&cmd.instanceName, "INSTANCE_NAME", 1, true, "Name of the instance to delete.")
+	deleteCmd.String(&cmd.configFile, "f", "config-file", "Path tests config file.")
+
+	cmd.flaggy = deleteCmd
+
+	return cmd
+}
+
+func (d *Delete) Flaggy() *flaggy.Subcommand {
+	return d.flaggy
+}
+
+func (d *Delete) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+	ctx := context.Background()
+	config, err := suite.ReadConfig(d.configFile)
+	if err != nil {
+		return err
+	}
+
+	logger := e2e.NewLogger()
+	aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.ClusterRegion))
+	if err != nil {
+		return fmt.Errorf("reading AWS configuration: %w", err)
+	}
+
+	ec2Client := ec2sdk.NewFromConfig(aws)
+	ssmClient := ssmsdk.NewFromConfig(aws)
+	s3Client := s3sdk.NewFromConfig(aws)
+
+	instances, err := ec2Client.DescribeInstances(ctx, &ec2sdk.DescribeInstancesInput{
+		Filters: []types.Filter{
+			{
+				Name:   sdk.String("tag:Name"),
+				Values: []string{d.instanceName},
+			},
+			{
+				Name:   sdk.String("instance-state-name"),
+				Values: []string{"running", "pending"},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("describing instance %s: %w", d.instanceName, err)
+	}
+	if len(instances.Reservations) == 0 || len(instances.Reservations[0].Instances) == 0 {
+		return fmt.Errorf("no instance found with name %s", d.instanceName)
+	}
+
+	instance := instances.Reservations[0].Instances[0]
+
+	clientConfig, err := clientcmd.BuildConfigFromFlags("", cluster.KubeconfigPath(config.ClusterName))
+	if err != nil {
+		return err
+	}
+	k8s, err := clientgo.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	jumpbox, err := peered.JumpboxInstance(ctx, ec2Client, config.ClusterName)
+	if err != nil {
+		return err
+	}
+
+	commandRunner := ssm.NewSSHOnSSMCommandRunner(ssmClient, *jumpbox.InstanceId, logger)
+
+	node := peered.NodeCleanup{
+		EC2:                 ec2Client,
+		S3:                  s3Client,
+		K8s:                 k8s,
+		RemoteCommandRunner: commandRunner,
+		Logger:              logger,
+		ClusterName:         config.ClusterName,
+		LogsBucket:          config.LogsBucket,
+	}
+
+	if err := node.Cleanup(ctx, ec2.Instance{
+		ID:   *instance.InstanceId,
+		IP:   *instance.PrivateIpAddress,
+		Name: d.instanceName,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/e2e-test/node/node.go
+++ b/cmd/e2e-test/node/node.go
@@ -1,0 +1,34 @@
+package node
+
+import (
+	"github.com/integrii/flaggy"
+
+	"github.com/aws/eks-hybrid/internal/cli"
+)
+
+type Command struct {
+	*flaggy.Subcommand
+	subcommands []cli.Command
+}
+
+func (n Command) Flaggy() *flaggy.Subcommand {
+	return n.Subcommand
+}
+
+func (n Command) Commands() []cli.Command {
+	return n.subcommands
+}
+
+func NewCommand() Command {
+	node := flaggy.NewSubcommand("node")
+	node.Description = "Manage Hybrid Nodes"
+	create := NewCreateCommand()
+	node.AttachSubcommand(create.Flaggy(), 1)
+	delete := NewDeleteCommand()
+	node.AttachSubcommand(delete.Flaggy(), 1)
+
+	return Command{
+		Subcommand:  node,
+		subcommands: []cli.Command{create, delete},
+	}
+}

--- a/cmd/e2e-test/setup/setup.go
+++ b/cmd/e2e-test/setup/setup.go
@@ -15,13 +15,13 @@ import (
 	"github.com/aws/eks-hybrid/test/e2e/cluster"
 )
 
-type command struct {
+type Command struct {
 	flaggy         *flaggy.Subcommand
 	configFilePath string
 }
 
-func NewCommand() cli.Command {
-	cmd := command{}
+func NewCommand() *Command {
+	cmd := Command{}
 
 	setupCmd := flaggy.NewSubcommand("setup")
 	setupCmd.Description = "Create the E2E test infrastructure"
@@ -34,11 +34,15 @@ func NewCommand() cli.Command {
 	return &cmd
 }
 
-func (c *command) Flaggy() *flaggy.Subcommand {
+func (c *Command) Flaggy() *flaggy.Subcommand {
 	return c.flaggy
 }
 
-func (s *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+func (c *Command) Commands() []cli.Command {
+	return []cli.Command{c}
+}
+
+func (s *Command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	ctx := context.Background()
 	file, err := os.ReadFile(s.configFilePath)
 	if err != nil {

--- a/cmd/e2e-test/ssh/ssh.go
+++ b/cmd/e2e-test/ssh/ssh.go
@@ -16,13 +16,13 @@ import (
 	"github.com/aws/eks-hybrid/test/e2e/peered"
 )
 
-type command struct {
+type Command struct {
 	flaggy     *flaggy.Subcommand
 	instanceID string
 }
 
-func NewCommand() cli.Command {
-	cmd := command{}
+func NewCommand() *Command {
+	cmd := Command{}
 
 	setupCmd := flaggy.NewSubcommand("ssh")
 	setupCmd.Description = "SSH into a E2E Hybrid Node running in the peered VPC through the jumpbox"
@@ -33,11 +33,15 @@ func NewCommand() cli.Command {
 	return &cmd
 }
 
-func (c *command) Flaggy() *flaggy.Subcommand {
+func (c *Command) Flaggy() *flaggy.Subcommand {
 	return c.flaggy
 }
 
-func (s *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+func (c *Command) Commands() []cli.Command {
+	return []cli.Command{c}
+}
+
+func (s *Command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	ctx := context.Background()
 
 	cfg, err := config.LoadDefaultConfig(ctx)

--- a/test/e2e/credentials/stack.go
+++ b/test/e2e/credentials/stack.go
@@ -64,6 +64,8 @@ func (s *Stack) Deploy(ctx context.Context, logger logr.Logger) (*StackOutput, e
 	for range 2 {
 		if err = s.deployStack(ctx, logger); err == nil {
 			break
+		} else {
+			logger.Error(err, "Error deploying stack, retrying")
 		}
 	}
 	if err != nil {

--- a/test/e2e/s3/urls.go
+++ b/test/e2e/s3/urls.go
@@ -9,12 +9,34 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/aws/eks-hybrid/test/e2e"
 )
 
 const (
 	httpsScheme = "https"
 	s3Scheme    = "s3"
 )
+
+func BuildNodeamURLs(ctx context.Context, client *s3.Client, amdURL, armURL string) (*e2e.NodeadmURLs, error) {
+	urls := &e2e.NodeadmURLs{}
+	if amdURL != "" {
+		url, err := GetNodeadmURL(ctx, client, amdURL)
+		if err != nil {
+			return nil, err
+		}
+		urls.AMD = url
+	}
+	if armURL != "" {
+		url, err := GetNodeadmURL(ctx, client, armURL)
+		if err != nil {
+			return nil, err
+		}
+		urls.ARM = url
+	}
+
+	return urls, nil
+}
 
 func GetNodeadmURL(ctx context.Context, client *s3.Client, nodeadmUrl string) (string, error) {
 	parsedURL, err := url.Parse(nodeadmUrl)

--- a/test/e2e/suite/config.go
+++ b/test/e2e/suite/config.go
@@ -1,0 +1,40 @@
+package suite
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+type TestConfig struct {
+	ClusterName     string `yaml:"clusterName"`
+	ClusterRegion   string `yaml:"clusterRegion"`
+	NodeadmUrlAMD   string `yaml:"nodeadmUrlAMD"`
+	NodeadmUrlARM   string `yaml:"nodeadmUrlARM"`
+	SetRootPassword bool   `yaml:"setRootPassword"`
+	NodeK8sVersion  string `yaml:"nodeK8SVersion"`
+	LogsBucket      string `yaml:"logsBucket"`
+	Endpoint        string `yaml:"endpoint"`
+	// ArtifactsFolder is the local path where the test will store the artifacts.
+	ArtifactsFolder string `yaml:"artifactsFolder"`
+}
+
+// ReadConfig reads the configuration from the specified file path and unmarshals it into the TestConfig struct.
+func ReadConfig(configPath string) (*TestConfig, error) {
+	config := &TestConfig{}
+	file, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading tests configuration file %s: %w", configPath, err)
+	}
+
+	if err = yaml.Unmarshal(file, config); err != nil {
+		return nil, fmt.Errorf("unmarshaling test configuration: %w", err)
+	}
+
+	if config.ArtifactsFolder == "" {
+		config.ArtifactsFolder = "/tmp"
+	}
+
+	return config, nil
+}


### PR DESCRIPTION
*Description of changes:*
Useful when manually testing or investigating.
```
./_bin/e2e-test node create -h
create - Create a Hybrid Node

  Usage:
    create [INSTANCE_NAME]

  Positional Variables:
    INSTANCE_NAME   Name of the instance to create. (Required)
  Flags:
       --version          Displays the program version string.
    -h --help             Displays help with available flag, subcommand, and positional value parameters.
    -f --config-file      Path tests config file.
    -c --creds-provider   Credentials provider to use (iam-ra, ssm).
    -o --os               OS to use (al23, ubuntu2004, ubuntu2204, ubuntu2404, rhel8, rhel9). (default: al23)
    -a --arch             Architecture to use (amd64, arm64). (default: amd64)
    -w --wait-for-ready   Wait for the node to be ready.
```

```
./_bin/e2e-test node delete -h
delete - Delete a Hybrid Node

  Usage:
    delete [INSTANCE_NAME]

  Positional Variables:
    INSTANCE_NAME   Name of the instance to delete. (Required)
  Flags:
       --version       Displays the program version string.
    -h --help          Displays help with available flag, subcommand, and positional value parameters.
    -f --config-file   Path tests config file.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

