### PR TITLE
Set AWS region when fetching the jumpbox SSH keypair 

### DIFF
--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -352,7 +352,7 @@ Resources:
               - content: |
                   #!/usr/bin/env bash
 
-                  if ! aws ssm get-parameter --name /ec2/keypair/${JumpboxKeyPair.KeyPairId} --with-decryption --query Parameter.Value --output text > /root/.ssh/id_rsa ||
+                  if ! aws ssm get-parameter --name /ec2/keypair/${JumpboxKeyPair.KeyPairId} --region ${ClusterRegion} --with-decryption --query Parameter.Value --output text > /root/.ssh/id_rsa ||
                     ! openssl rsa -in /root/.ssh/id_rsa -pubout; then
                     echo "Problem downloading private key from ssm!"
                     cat /root/.ssh/id_rsa


### PR DESCRIPTION
*Description of changes:*
We are seeing intermittent issues on tests when calling `aws` CLI to download SSH key pair on the jumpbox
```
2025-02-17T21:47:22.024Z	[34mINFO[0m	Stdout: Problem downloading private key from ssm!	1739829048904
EVENTS	1739829052825	2025/02/17 21:50:48         	            		1739829048904
EVENTS	1739829052825	2025/02/17 21:50:48         	            	2025-02-17T21:47:22.024Z	[34mINFO[0m	Stderr: 	1739829048904
EVENTS	1739829052825	2025/02/17 21:50:48         	            	You must specify a region. You can also configure your region by running "aws configure".	1739829048904
EVENTS	1739829052825	2025/02/17 21:50:48         	            	failed to run commands: exit status 1	1739829048904
EVENTS	1739829052825	2025/02/17 21:50:48         	            	{"level":"fatal","ts":1739828842.0248203,"caller":"e2e-test/main.go:36","msg":"Command failed","error":"creating E2E test infrastructure: creating stack for cluster infra: jumpbox getting private key from ssm","stacktrace":"main.main\n\t/codebuild/output/src2762515691/src/cmd/e2e-test/main.go:36\nruntime.main\n\t/root/sdk/go1.23.5/src/runtime/proc.go:272"}
```

This PR passes the region to the command to avoid running into that issue.

*Testing (if applicable):*
Deployed the stack on my account and ensured that the region was set on cloudinit config


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

