### PR TITLE
adds rsyslog to al23 instances in e2e

### DIFF
--- a/test/e2e/os/testdata/amazonlinux/2023/cloud-init.txt
+++ b/test/e2e/os/testdata/amazonlinux/2023/cloud-init.txt
@@ -8,6 +8,8 @@ users:
     hashed_passwd: {{ .RootPasswordHash }}
 {{- end }}
 package_update: true
+packages:
+  - rsyslog
 write_files:
   - content: |
 {{ .NodeadmConfigYaml | indent 6 }}
@@ -22,6 +24,7 @@ write_files:
 {{- end }}
 
 runcmd:
+  - systemctl enable rsyslog --now
   - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The eks log-collector script will collect standard log files, such as [/var/log/messages](https://github.com/awslabs/amazon-eks-ami/blob/main/log-collector-script/linux/eks-log-collector.sh). In al23, this file is not created by default like it was in al2.  Following this [guide](https://repost.aws/knowledge-center/ec2-linux-al2023-find-log-files), its fairly simple to enable rsyslog and have it create this file which would then be captured in our log bundle.

An alternative, future improvement, would be to somehow generate this during the log collection script so its more consistent between al2 and al23.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

