### PR TITLE
Log ec2 DescribeInstanceStatus for failed nodes

### DIFF
--- a/test/e2e/ec2/instance.go
+++ b/test/e2e/ec2/instance.go
@@ -186,7 +186,7 @@ func LogEC2InstanceDescribe(ctx context.Context, ec2Client *ec2.Client, instance
 	if len(describeStatusOutput.InstanceStatuses) == 0 {
 		return fmt.Errorf("no instance status found with ID %s", instanceID)
 	}
-	logger.Info("Instance status", "InstanceID", instanceID, "DescribeInstanceStatusResponse", awsutil.Prettify(describeStatusOutput.InstanceStatuses))
+	logger.Info("Instance status", "instanceID", instanceID, "describeInstanceStatusResponse", awsutil.Prettify(describeStatusOutput.InstanceStatuses))
 	return nil
 }
 

--- a/test/e2e/ec2/instance.go
+++ b/test/e2e/ec2/instance.go
@@ -174,7 +174,7 @@ func LogEC2InstanceDescribe(ctx context.Context, ec2Client *ec2.Client, instance
 	if len(instances.Reservations) == 0 || len(instances.Reservations[0].Instances) == 0 {
 		return fmt.Errorf("no instance found with ID %s", instanceID)
 	}
-	logger.Info("Instance details", "InstanceID", instanceID, "DescribeInstanceResponse", awsutil.Prettify(instances.Reservations[0].Instances))
+	logger.Info("Instance details", "instanceID", instanceID, "describeInstanceResponse", awsutil.Prettify(instances.Reservations[0].Instances))
 
 	describeStatusOutput, err := ec2Client.DescribeInstanceStatus(ctx, &ec2.DescribeInstanceStatusInput{
 		InstanceIds:         []string{instanceID},

--- a/test/e2e/ec2/instance.go
+++ b/test/e2e/ec2/instance.go
@@ -174,7 +174,19 @@ func LogEC2InstanceDescribe(ctx context.Context, ec2Client *ec2.Client, instance
 	if len(instances.Reservations) == 0 || len(instances.Reservations[0].Instances) == 0 {
 		return fmt.Errorf("no instance found with ID %s", instanceID)
 	}
-	logger.Info(awsutil.Prettify(instances.Reservations[0].Instances))
+	logger.Info("Instance details", "InstanceID", instanceID, "DescribeInstanceResponse", awsutil.Prettify(instances.Reservations[0].Instances))
+
+	describeStatusOutput, err := ec2Client.DescribeInstanceStatus(ctx, &ec2.DescribeInstanceStatusInput{
+		InstanceIds:         []string{instanceID},
+		IncludeAllInstances: aws.Bool(true),
+	})
+	if err != nil {
+		return fmt.Errorf("describing instance status %s: %w", instanceID, err)
+	}
+	if len(describeStatusOutput.InstanceStatuses) == 0 {
+		return fmt.Errorf("no instance status found with ID %s", instanceID)
+	}
+	logger.Info("Instance status", "InstanceID", instanceID, "DescribeInstanceStatusResponse", awsutil.Prettify(describeStatusOutput.InstanceStatuses))
 	return nil
 }
 


### PR DESCRIPTION
*Description of changes:*
We are seeing some tests fail with node not being ready. The logs fail to collect on that node as well. 
This PR adds another log that prints the instance health status in case of such failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

