### PR TITLE
adds retry for ec2 instance creation

### DIFF
--- a/test/e2e/ec2/instance.go
+++ b/test/e2e/ec2/instance.go
@@ -163,6 +163,28 @@ func WaitForEC2InstanceRunning(ctx context.Context, ec2Client *ec2.Client, insta
 	return waiter.Wait(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{instanceID}}, nodeRunningTimeout)
 }
 
+func IsEC2InstanceImpaired(ctx context.Context, ec2Client *ec2.Client, instanceID string) (bool, error) {
+	describeStatusOutput, err := ec2Client.DescribeInstanceStatus(ctx, &ec2.DescribeInstanceStatusInput{
+		InstanceIds:         []string{instanceID},
+		IncludeAllInstances: aws.Bool(true),
+	})
+	if err != nil {
+		return false, fmt.Errorf("describing instance status %s: %w", instanceID, err)
+	}
+	isImpaired := false
+	for _, status := range describeStatusOutput.InstanceStatuses[0].SystemStatus.Details {
+		if status.Name == "reachability" {
+			isImpaired = true
+		}
+	}
+	for _, status := range describeStatusOutput.InstanceStatuses[0].InstanceStatus.Details {
+		if status.Name == "reachability" {
+			isImpaired = true
+		}
+	}
+	return isImpaired, nil
+}
+
 func LogEC2InstanceDescribe(ctx context.Context, ec2Client *ec2.Client, instanceID string, logger logr.Logger) error {
 	instances, ec2Err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 		InstanceIds: []string{instanceID},

--- a/test/e2e/suite/flake_attempt.go
+++ b/test/e2e/suite/flake_attempt.go
@@ -1,0 +1,99 @@
+package suite
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
+)
+
+type FlakeAttempt struct {
+	logger logr.Logger
+}
+type FlakeRun struct {
+	DeferCleanup    func(func(context.Context), ...interface{})
+	RetryableExpect func(actual interface{}, extra ...interface{}) Assertion
+}
+
+type IgnorablePanic struct{}
+
+func (IgnorablePanic) GinkgoRecoverShouldIgnoreThisPanic() {}
+
+func (f *FlakeAttempt) It(ctx context.Context, description string, flakeAttempts int, body func(ctx context.Context, flakeRun FlakeRun)) {
+	var lastErr error
+	for attempt := range flakeAttempts {
+		// register globally as well in case the test fails for any reason
+		// including being cancelled while this block is executing
+		// track if the cleanup runs and do not run it again if it does
+		cleanups := []func(context.Context){}
+		deferCleanup := func(cleanup func(context.Context), args ...interface{}) {
+			ran := false
+			onced := func(ctx context.Context) {
+				if ran {
+					f.logger.Info(fmt.Sprintf("Cleanup already ran for flake attempt %d, skipping", attempt+1))
+					return
+				}
+				ran = true
+				cleanup(ctx)
+			}
+			cleanups = append(cleanups, onced)
+			DeferCleanup(onced, args)
+		}
+
+		testGoMega := gomega.NewGomega(func(message string, callerSkip ...int) {
+			lastErr = fmt.Errorf("%s", message)
+			panic(IgnorablePanic{})
+		})
+		flakeRun := FlakeRun{
+			DeferCleanup:    deferCleanup,
+			RetryableExpect: testGoMega.Expect,
+		}
+
+		c := make(chan error)
+		go func() {
+			defer func() {
+				var err error
+				// if this was a ignorable panic, we send nil
+				// to indicate that we should retry
+				// otherwise we send the error to end execution
+				e := recover()
+				if lastErr == nil && e != nil {
+					err = e.(error)
+				}
+				c <- err
+			}()
+			By(description)
+			body(ctx, flakeRun)
+		}()
+
+		var panicableError error
+		Eventually(c).WithContext(ctx).Should(Receive(&panicableError))
+		Expect(panicableError).NotTo(HaveOccurred())
+
+		if lastErr == nil {
+			if attempt > 1 {
+				f.logger.Info(fmt.Sprintf("Succeeded on attempt %d after previous failures", attempt+1))
+			}
+			break
+		}
+
+		if attempt == flakeAttempts-1 {
+			break
+		}
+
+		// omly run cleanups if about to retry, otherwise let gingko handle it
+		for _, f := range slices.Backward(cleanups) {
+			f(ctx)
+		}
+
+		f.logger.Error(lastErr, fmt.Sprintf("Failed attempt %d/%d", attempt+1, flakeAttempts))
+		time.Sleep(time.Second * time.Duration(attempt))
+
+	}
+	Expect(lastErr).To(BeNil(), "should have succeeded")
+}

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -240,40 +240,62 @@ var _ = Describe("Hybrid Nodes", func() {
 							if test.overrideNodeK8sVersion != "" {
 								k8sVersion = suite.TestConfig.NodeK8sVersion
 							}
-
 							peeredNode := test.newPeeredNode()
-							instance, err := peeredNode.Create(ctx, &peered.NodeSpec{
-								InstanceName:   instanceName,
-								NodeK8sVersion: k8sVersion,
-								NodeNamePrefix: "simpleflow",
-								OS:             nodeOS,
-								Provider:       provider,
-							})
-							Expect(err).NotTo(HaveOccurred(), "EC2 Instance should have been created successfully")
-							DeferCleanup(func(ctx context.Context) {
-								Expect(peeredNode.Cleanup(ctx, instance)).To(Succeed())
-							}, NodeTimeout(deferCleanupTimeout))
 
-							verifyNode := test.newVerifyNode(instance.IP)
+							var verifyNode *kubernetes.VerifyNode
+							var serialOutput peered.ItBlockCloser
+							var instance ec2.Instance
 
-							serialOutput := peered.NewSerialOutputBlockBestEffort(ctx, &peered.SerialOutputConfig{
-								PeeredNode:   peeredNode,
-								Instance:     instance,
-								TestLogger:   test.loggerControl,
-								OutputFolder: test.artifactsPath,
-							})
-							Expect(err).NotTo(HaveOccurred(), "should prepare serial output")
-							DeferCleanup(func() {
-								serialOutput.Close()
-							})
+							flakeAttempt := &FlakeAttempt{
+								logger: test.logger,
+							}
+							flakeAttempt.It(ctx, "Creating a node", 3, func(ctx context.Context, flakeRun FlakeRun) {
+								var err error
+								instance, err = peeredNode.Create(ctx, &peered.NodeSpec{
+									InstanceName:   instanceName,
+									NodeK8sVersion: k8sVersion,
+									NodeNamePrefix: "simpleflow",
+									OS:             nodeOS,
+									Provider:       provider,
+								})
+								Expect(err).NotTo(HaveOccurred(), "EC2 Instance should have been created successfully")
+								flakeRun.DeferCleanup(func(ctx context.Context) {
+									Expect(peeredNode.Cleanup(ctx, instance)).To(Succeed())
+								}, NodeTimeout(deferCleanupTimeout))
 
-							serialOutput.It("joins the cluster", func() {
-								test.logger.Info("Waiting for EC2 Instance to be Running...")
-								Expect(ec2.WaitForEC2InstanceRunning(ctx, test.ec2Client, instance.ID)).To(Succeed(), "EC2 Instance should have been reached Running status")
-								Expect(verifyNode.WaitForNodeReady(ctx)).Error().To(
-									Succeed(), "node should have joined the cluster successfully"+
-										". You can access the collected node logs at: %s", peeredNode.S3LogsURL(instance.Name),
-								)
+								verifyNode = test.newVerifyNode(instance.IP)
+
+								serialOutput = peered.NewSerialOutputBlockBestEffort(ctx, &peered.SerialOutputConfig{
+									PeeredNode:   peeredNode,
+									Instance:     instance,
+									TestLogger:   test.loggerControl,
+									OutputFolder: test.artifactsPath,
+								})
+								flakeRun.DeferCleanup(func(ctx context.Context) {
+									serialOutput.Close()
+								}, NodeTimeout(deferCleanupTimeout))
+
+								serialOutput.It("joins the cluster", func() {
+									test.logger.Info("Waiting for EC2 Instance to be Running...")
+									Expect(ec2.WaitForEC2InstanceRunning(ctx, test.ec2Client, instance.ID)).To(Succeed(), "EC2 Instance should have been reached Running status")
+									_, err := verifyNode.WaitForNodeReady(ctx)
+									if err != nil {
+										isImpaired, oErr := ec2.IsEC2InstanceImpaired(ctx, test.ec2Client, instance.ID)
+										if oErr != nil {
+											Expect(err).NotTo(HaveOccurred(), "should describe instance status")
+										}
+										expect := Expect
+										if isImpaired {
+											expect = flakeRun.RetryableExpect
+										}
+
+										expect(err).To(
+											Succeed(), "node should have joined the cluster successfully"+
+												". You can access the collected node logs at: %s", peeredNode.S3LogsURL(instance.Name),
+										)
+
+									}
+								})
 							})
 
 							Expect(verifyNode.Run(ctx)).To(Succeed(), "node should be fully functional")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We have noticed a fair amount of ec2 instances that for some reason do not appear to get far enough into the boot/cloud-init process to join as eks nodes.  This PRs uses the instancestatus to check for impaired instances.  Impaired is being defined as the reachability check has failed.  If the node fails to join as normal, we check if its impaired and retry if so.

To handle this retry we can not use the default ginkgo retry mechanism because we would need to break our test up into multiple Its.  This was tried in https://github.com/aws/eks-hybrid/pull/317.  This would work and probably be simpler than this PR, however, once we break them into multiple It blocks, the test output in CI will be all munged together.  I do not think that would be a good change.

This introduces a FlakeAttempt "It" so we can wrap the code which creates the ec2 instance in a block that will retry if we trigger a retryablexpect.

Additional Notes

I tested creating instances and tracking when the instance status changes and it does not seem to be related to cloud-init timings and/or error codes. The node checks (as well as the healthy status) goes green a minute or more after the cloud-init finishes.  I think this also gives us some confidence that if the cloud-init script is running and fails, that would not affect the ec2 healthchecks. So we can rely on this reachability check to determine if its ok to delete and retry the node.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

