### PR TITLE
addds --region flag to nodeadm install during e2e

### DIFF
--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -26,6 +26,7 @@ type UserDataInput struct {
 	NodeadmConfigYaml string
 	Provider          string
 	PublicKey         string
+	Region            string
 	RootPasswordHash  string
 	Files             []File
 }

--- a/test/e2e/os/testdata/amazonlinux/2023/cloud-init.txt
+++ b/test/e2e/os/testdata/amazonlinux/2023/cloud-init.txt
@@ -25,6 +25,6 @@ write_files:
 
 runcmd:
   - systemctl enable rsyslog --now
-  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}"
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/os/testdata/nodeadm-init.sh
+++ b/test/e2e/os/testdata/nodeadm-init.sh
@@ -7,7 +7,8 @@ set -o pipefail
 NODEADM_URL="$1"
 KUBERNETES_VERSION="$2"
 PROVDER="$3"
-NODEADM_ADDITIONAL_ARGS="${4-}"
+REGION="$4"
+NODEADM_ADDITIONAL_ARGS="${5-}"
 
 function run_debug(){
     /tmp/nodeadm debug -c file:///nodeadm-config.yaml || true
@@ -28,7 +29,7 @@ for i in {1..5}; do curl --fail -s --retry 5 -L "$NODEADM_URL" -o /tmp/nodeadm &
 chmod +x /tmp/nodeadm
 
 echo "Installing kubernetes components"
-/tmp/nodeadm install $KUBERNETES_VERSION $NODEADM_ADDITIONAL_ARGS --credential-provider $PROVDER
+/tmp/nodeadm install $KUBERNETES_VERSION $NODEADM_ADDITIONAL_ARGS --credential-provider $PROVDER --region $REGION
 
 echo "Initializing the node"
 /tmp/nodeadm init -c file:///nodeadm-config.yaml

--- a/test/e2e/os/testdata/rhel/8/cloud-init.txt
+++ b/test/e2e/os/testdata/rhel/8/cloud-init.txt
@@ -25,6 +25,6 @@ write_files:
 {{- end }}
 
 runcmd:
-  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "--containerd-source docker"
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}" "--containerd-source docker"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/os/testdata/rhel/9/cloud-init.txt
+++ b/test/e2e/os/testdata/rhel/9/cloud-init.txt
@@ -25,6 +25,6 @@ write_files:
 {{- end }}
 
 runcmd:
-  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "--containerd-source docker"
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}" "--containerd-source docker"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/os/testdata/ubuntu/2004/cloud-init.txt
+++ b/test/e2e/os/testdata/ubuntu/2004/cloud-init.txt
@@ -22,6 +22,6 @@ write_files:
 {{- end }}
 
 runcmd:
-  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .NodeadmAdditionalArgs }}"
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}" "{{ .NodeadmAdditionalArgs }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/os/testdata/ubuntu/2204/cloud-init.txt
+++ b/test/e2e/os/testdata/ubuntu/2204/cloud-init.txt
@@ -22,6 +22,6 @@ write_files:
 {{- end }}
 
 runcmd:
-  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .NodeadmAdditionalArgs }}"
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}" "{{ .NodeadmAdditionalArgs }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/os/testdata/ubuntu/2404/cloud-init.txt
+++ b/test/e2e/os/testdata/ubuntu/2404/cloud-init.txt
@@ -22,6 +22,6 @@ write_files:
 {{- end }}
 
 runcmd:
-  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .NodeadmAdditionalArgs }}"
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}" "{{ .NodeadmAdditionalArgs }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -104,6 +104,7 @@ func (c NodeCreate) Create(ctx context.Context, spec *NodeSpec) (ec2.Instance, e
 		NodeadmConfigYaml: string(nodeadmConfigYaml),
 		Provider:          string(spec.Provider.Name()),
 		RootPasswordHash:  rootPasswordHash,
+		Region:            c.Cluster.Region,
 		Files:             files,
 		PublicKey:         c.PublicKey,
 	})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

With the latest release of nodeadm, we can pass the `--region` flag to the install command to specify where to download the ssm install setup from.  This adds that new flag to our cloud-init scripts for the e2e tests.



*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

