### PR TITLE
Fix error cast for ResourcesInUseException in addon package

### DIFF
--- a/test/e2e/addon/addon.go
+++ b/test/e2e/addon/addon.go
@@ -2,13 +2,14 @@ package addon
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/go-logr/logr"
+
+	"github.com/aws/eks-hybrid/test/e2e/errors"
 )
 
 type Addon struct {
@@ -32,7 +33,7 @@ func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logge
 
 	_, err := client.CreateAddon(ctx, params)
 
-	if err == nil || errors.Is(err, &types.ResourceInUseException{}) {
+	if err == nil || errors.IsType(err, &types.ResourceInUseException{}) {
 		// Ignore if add-on is already created
 		return nil
 	}

--- a/test/e2e/addon/podidentityaddon.go
+++ b/test/e2e/addon/podidentityaddon.go
@@ -2,7 +2,6 @@ package addon
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -12,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	clientgo "k8s.io/client-go/kubernetes"
 
+	"github.com/aws/eks-hybrid/test/e2e/errors"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 )
 
@@ -58,7 +58,7 @@ func (p PodIdentityAddon) Create(ctx context.Context, logger logr.Logger, eksCli
 	}
 
 	_, err := eksClient.CreatePodIdentityAssociation(ctx, createPodIdentityAssociationInput)
-	if err == nil || errors.Is(err, &types.ResourceInUseException{}) {
+	if err == nil || errors.IsType(err, &types.ResourceInUseException{}) {
 		return nil
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

`Errors.IsType()` seems not working as expected. 


*Description of changes:*
Create `Errors.IsAWSErr()` to correctly identify aws err type.

I have the following test code in `addon.go` and manually trigger `ResourcesInUseException` by running node setup twice.

```go
import (
	"errors"
	e2eErrors "github.com/aws/eks-hybrid/test/e2e/errors"
)

func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logger) error {
	logger.Info("Create cluster add-on", "ClusterAddon", a.Name)

	params := &eks.CreateAddonInput{
		ClusterName:         &a.Cluster,
		AddonName:           &a.Name,
		ConfigurationValues: &a.Configuration,
	}

	_, err := client.CreateAddon(ctx, params)

	logger.Info("errors.Is", "ResourceInUseException", errors.Is(err, &types.ResourceInUseException{}))
	logger.Info("errors.Is", "AccessDeniedException", errors.Is(err, &types.AccessDeniedException{}))
	logger.Info("errors.Is", "InvalidRequestException", errors.Is(err, &types.InvalidRequestException{}))
	
	logger.Info("e2eErrors.IsType", "ResourceInUseException", e2eErrors.IsType(err, &types.ResourceInUseException{}))
	logger.Info("e2eErrors.IsType", "AccessDeniedException", e2eErrors.IsType(err, &types.AccessDeniedException{}))
	logger.Info("e2eErrors.IsType", "InvalidRequestException", e2eErrors.IsType(err, &types.InvalidRequestException{}))
	
	logger.Info("e2eErrors.IsAWSErr", "ResourceInUseException", e2eErrors.IsAWSErr(err, &types.ResourceInUseException{}))
	logger.Info("e2eErrors.IsAWSErr", "AccessDeniedException", e2eErrors.IsAWSErr(err, &types.AccessDeniedException{}))
	logger.Info("e2eErrors.IsAWSErr", "InvalidRequestException", e2eErrors.IsAWSErr(err, &types.InvalidRequestException{}))
	
	if err == nil || errors.IsAWSErr(err, &types.ResourceInUseException{}) {
		// Ignore if add-on is already created
		return nil
	}
	return err
}
```

Outupt
```
2025-02-20T10:54:05.659-0800	INFO	Create cluster add-on	{"ClusterAddon": "eks-pod-identity-agent"}
2025-02-20T10:54:05.874-0800	INFO	Error	{"err": "operation error EKS: CreateAddon, https response error StatusCode: 409, RequestID: 28f2bcd6-a2ce-4efb-958e-b169281d9b59, ResourceInUseException: Addon already exists."}
2025-02-20T10:54:05.874-0800	INFO	errors.Is	{"ResourceInUseException": false}
2025-02-20T10:54:05.874-0800	INFO	errors.Is	{"AccessDeniedException": false}
2025-02-20T10:54:05.874-0800	INFO	errors.Is	{"InvalidRequestException": false}
2025-02-20T10:54:05.874-0800	INFO	e2eErrors.IsType	{"ResourceInUseException": true}
2025-02-20T10:54:05.874-0800	INFO	e2eErrors.IsType	{"AccessDeniedException": true}
2025-02-20T10:54:05.874-0800	INFO	e2eErrors.IsType	{"InvalidRequestException": true}
2025-02-20T10:54:05.874-0800	INFO	e2eErrors.IsAWSErr	{"ResourceInUseException": true}
2025-02-20T10:54:05.874-0800	INFO	e2eErrors.IsAWSErr	{"AccessDeniedException": false}
2025-02-20T10:54:05.874-0800	INFO	e2eErrors.IsAWSErr	{"InvalidRequestException": false}
```

---
Updates:
`IsAWSErr()` will be discarded in favor of [PR - Fix bug on errors.IsType helper](https://github.com/aws/eks-hybrid/pull/380). 
This PR only fixes the error type check in addon package now.


*Testing (if applicable):*
Manual testing

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


