### PR TITLE
Fix bug on errors.IsType helper

### DIFF
--- a/test/e2e/errors/type.go
+++ b/test/e2e/errors/type.go
@@ -3,6 +3,6 @@ package errors
 import "errors"
 
 // IsType returns true if any errors in the chain are of the specified type.
-func IsType(err error, targetType interface{}) bool {
+func IsType[T error](err error, targetType T) bool {
 	return errors.As(err, &targetType)
 }


### PR DESCRIPTION
*Description of changes:*
If we take an empty interface, the errors.As receives as such instead of as the original type passed to our helper. Since all errors can be assigned to an empty interface, our helper always returns true. By making the function take a generic type we both ensure that errors.As receives the right type as well as enforcing that our helper only takes types that implement error, which is required by errors.As.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

