### PR TITLE
adds signal handling to e2e ssh command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,6 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.opentelemetry.io/otel v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	k8s.io/cli-runtime v0.32.2 // indirect
 	sigs.k8s.io/kustomize/api v0.19.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.opentelemetry.io/otel v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
+	go.uber.org/goleak v1.3.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	k8s.io/cli-runtime v0.32.2 // indirect
 	sigs.k8s.io/kustomize/api v0.19.0 // indirect


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When using the ssh command, its really easy to ctrl-c, like to cancel a bad typing or reverse search and that currently kills the session.  This adds the signal trapping so we can forward it to the process without killing it.  To exit, use either the `exit` command or ctrl-d, which matches the standard the ssh behavior.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

