### PR TITLE
improves e2e pod identity debugging

### DIFF
--- a/test/e2e/addon/podidentitybucket.go
+++ b/test/e2e/addon/podidentitybucket.go
@@ -1,0 +1,59 @@
+package addon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/aws/eks-hybrid/test/e2e/constants"
+)
+
+var PodIdentityBucketNotFound = errors.New("pod identity bucket not found")
+
+// PodIdentityBucket returns the pod identity bucket for the given cluster.
+func PodIdentityBucket(ctx context.Context, client *s3.Client, cluster string) (string, error) {
+	listBucketsOutput, err := client.ListBuckets(ctx, &s3.ListBucketsInput{
+		Prefix: aws.String(PodIdentityS3BucketPrefix),
+	})
+	if err != nil {
+		return "", fmt.Errorf("listing buckets: %w", err)
+	}
+
+	var foundBuckets []string
+	for _, bucket := range listBucketsOutput.Buckets {
+		getBucketTaggingOutput, err := client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
+			Bucket: bucket.Name,
+		})
+		if err != nil {
+			return "", fmt.Errorf("getting bucket tagging: %w", err)
+		}
+
+		var foundClusterTag, foundPodIdentityTag bool
+		for _, tag := range getBucketTaggingOutput.TagSet {
+			if *tag.Key == constants.TestClusterTagKey && *tag.Value == cluster {
+				foundClusterTag = true
+			}
+
+			if *tag.Key == PodIdentityS3BucketPrefix && *tag.Value == "true" {
+				foundPodIdentityTag = true
+			}
+
+			if foundClusterTag && foundPodIdentityTag {
+				foundBuckets = append(foundBuckets, *bucket.Name)
+			}
+		}
+	}
+
+	if len(foundBuckets) > 1 {
+		return "", fmt.Errorf("found multiple pod identity buckets for cluster %s: %v", cluster, foundBuckets)
+	}
+
+	if len(foundBuckets) == 0 {
+		return "", PodIdentityBucketNotFound
+	}
+
+	return foundBuckets[0], nil
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ran into a few issues while testing locally with the new pod identity test:

- We want e2e-test cleanup to be able to be run multiple times and not fail out due to resources already being cleaned up.  I removed the code in the stack.go:delete which relied on the stack information to find the bucket. Instead move the code from nodeadm_test into a helper, similar to the way we handle the jumpbox, and use that during the test and the delete.
- The test was failing for me locally, which ended up being due to having left around buckets from previous test clusters, i use the same cluster name.  I added more steps to the test to try and pinpoint where the issue was. This ended up being that since i had multiple buckets, the code would pick one and that one it picked, the test file had been deleted.  I added an error in the case that it finds multiple buckets.
- Changed the runPod method to return the stdout/stderr even if there is an error so we can output it in the returned error. This was helpful to see the actual s3 error that was returned due to the missing file.
-  changed the waitForPodRunnign method to accept a ListOptions instead of a name so we could use it to wait for the demonset pod on the actual node we were testing on.
- add context to each of the returned errors

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

