### PR TITLE
sets retry mode/attempts at aws config level for e2e

### DIFF
--- a/test/e2e/cluster/cluster.go
+++ b/test/e2e/cluster/cluster.go
@@ -59,10 +59,7 @@ func (h *hybridCluster) create(ctx context.Context, client *eks.Client, logger l
 			},
 		},
 	}
-	_, err := client.CreateCluster(ctx, hybridCluster, func(o *eks.Options) {
-		o.RetryMaxAttempts = 20
-		o.RetryMode = aws.RetryModeAdaptive
-	})
+	_, err := client.CreateCluster(ctx, hybridCluster)
 	if err != nil && !errors.IsType(err, &types.ResourceInUseException{}) {
 		return fmt.Errorf("creating EKS hybrid cluster: %w", err)
 	}

--- a/test/e2e/credentials/ssm.go
+++ b/test/e2e/credentials/ssm.go
@@ -74,10 +74,7 @@ func (s *SsmProvider) createSSMActivation(ctx context.Context, clusterName, node
 	}
 
 	// Call CreateActivation to create the SSM activation
-	result, err := s.SSM.CreateActivation(ctx, input, func(o *ssm.Options) {
-		o.RetryMaxAttempts = 20
-		o.RetryMode = aws.RetryModeAdaptive
-	})
+	result, err := s.SSM.CreateActivation(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("creating SSM activation: %v", err)
 	}

--- a/test/e2e/peered/cluster.go
+++ b/test/e2e/peered/cluster.go
@@ -57,10 +57,7 @@ func getClusterDetails(ctx context.Context, client *eks.Client, clusterName stri
 	input := &eks.DescribeClusterInput{
 		Name: aws.String(clusterName),
 	}
-	result, err := client.DescribeCluster(ctx, input, func(o *eks.Options) {
-		o.RetryMaxAttempts = 20
-		o.RetryMode = aws.RetryModeAdaptive
-	})
+	result, err := client.DescribeCluster(ctx, input)
 	if err != nil {
 		return ekstypes.Cluster{}, fmt.Errorf("getting cluster details: %w", err)
 	}

--- a/test/e2e/ssm/command.go
+++ b/test/e2e/ssm/command.go
@@ -57,7 +57,6 @@ func RunCommand(ctx context.Context, client *ssm.Client, instanceId, command str
 		InstanceIds: []string{instanceId},
 	}
 	optsFn := func(opts *ssm.Options) {
-		opts.RetryMode = aws.RetryModeAdaptive
 		opts.RetryMaxAttempts = 60
 	}
 	output, err := client.SendCommand(ctx, input, optsFn)

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -459,7 +459,7 @@ func buildPeeredVPCTestForSuite(ctx context.Context, suite *suiteConfiguration) 
 		skipCleanup:            suite.SkipCleanup,
 	}
 
-	aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(suite.TestConfig.ClusterRegion))
+	aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(suite.TestConfig.ClusterRegion), awsconfig.WithRetryMaxAttempts(20), awsconfig.WithRetryMode(aws.RetryModeAdaptive))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Instead of configuring retries per request, set the mode and attempts on the config which will apply to all clients created via that config.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

