### PR TITLE
adds retries around install artifacts if checksums fail

### DIFF
--- a/internal/artifact/source.go
+++ b/internal/artifact/source.go
@@ -1,6 +1,7 @@
 package artifact
 
 import (
+	"fmt"
 	"hash"
 	"io"
 )
@@ -31,7 +32,7 @@ type ChecksumVerifier interface {
 func WithChecksum(rc io.ReadCloser, digest hash.Hash, expect []byte) (Source, error) {
 	parsedExpectedChecksum, err := ParseGNUChecksum(expect)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing expected checksum: %w", err)
 	}
 	return struct {
 		io.Reader

--- a/internal/aws/source.go
+++ b/internal/aws/source.go
@@ -170,19 +170,19 @@ func getSource(ctx context.Context, artifactName string, availableArtifacts []Ar
 		if releaseArtifact.Name == artifactName && releaseArtifact.Arch == runtime.GOARCH && releaseArtifact.OS == runtime.GOOS {
 			obj, err := util.GetHttpFileReader(ctx, releaseArtifact.URI)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("getting artifact file reader: %w", err)
 			}
 
 			artifactChecksum, err := util.GetHttpFile(ctx, releaseArtifact.ChecksumURI)
 			if err != nil {
 				obj.Close()
-				return nil, err
+				return nil, fmt.Errorf("getting artifact checksum file reader: %w", err)
 			}
 
 			source, err := artifact.WithChecksum(obj, sha256.New(), artifactChecksum)
 			if err != nil {
 				obj.Close()
-				return nil, err
+				return nil, fmt.Errorf("getting artifact with checksum: %w", err)
 			}
 			return source, nil
 		}

--- a/internal/cni/install.go
+++ b/internal/cni/install.go
@@ -3,6 +3,7 @@ package cni
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -27,25 +28,60 @@ type Source interface {
 	GetCniPlugins(context.Context) (artifact.Source, error)
 }
 
-func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
-	if err := installFromSource(ctx, src); err != nil {
+type InstallOptions struct {
+	// InstallRoot is optionally the root directory of the installation
+	// If not provided, the default will be /
+	InstallRoot string
+	Logger      *zap.Logger
+	Source      Source
+	Tracker     *tracker.Tracker
+}
+
+func Install(ctx context.Context, opts InstallOptions) error {
+	if err := installFromSource(ctx, opts); err != nil {
 		return err
 	}
-	if err := tracker.Add(artifact.CniPlugins); err != nil {
-		return err
+
+	if err := opts.Tracker.Add(artifact.CniPlugins); err != nil {
+		return errors.Wrap(err, "adding cni-plugins to tracker")
 	}
 
 	return nil
 }
 
-func installFromSource(ctx context.Context, src Source) error {
-	cniPlugins, err := src.GetCniPlugins(ctx)
+func installFromSource(ctx context.Context, opts InstallOptions) error {
+	if err := downloadFileWithRetries(ctx, opts); err != nil {
+		return errors.Wrap(err, "installing cni-plugins")
+	}
+
+	if err := artifact.InstallTarGz(filepath.Join(opts.InstallRoot, BinPath), filepath.Join(opts.InstallRoot, TgzPath)); err != nil {
+		return errors.Wrap(err, "extracting and installing cni-plugins")
+	}
+
+	return nil
+}
+
+func downloadFileWithRetries(ctx context.Context, opts InstallOptions) error {
+	// Retry up to 3 times to download and validate the checksum
+	var err error
+	for range 3 {
+		err = downloadFileTo(ctx, opts)
+		if err == nil {
+			break
+		}
+		opts.Logger.Error("Downloading cni-plugins failed. Retrying...", zap.Error(err))
+	}
+	return err
+}
+
+func downloadFileTo(ctx context.Context, opts InstallOptions) error {
+	cniPlugins, err := opts.Source.GetCniPlugins(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to get cni-plugins source")
+		return errors.Wrap(err, "getting cni-plugins source")
 	}
 	defer cniPlugins.Close()
 
-	if err := artifact.InstallFile(TgzPath, cniPlugins, 0o755); err != nil {
+	if err := artifact.InstallFile(filepath.Join(opts.InstallRoot, TgzPath), cniPlugins, 0o755); err != nil {
 		return errors.Wrap(err, "installing cni-plugins archive")
 	}
 
@@ -53,9 +89,6 @@ func installFromSource(ctx context.Context, src Source) error {
 		return errors.Errorf("cni-plugins checksum mismatch: %v", artifact.NewChecksumError(cniPlugins))
 	}
 
-	if err := artifact.InstallTarGz(BinPath, TgzPath); err != nil {
-		return errors.Wrap(err, "extracting and install cni-plugins")
-	}
 	return nil
 }
 
@@ -67,7 +100,11 @@ func Uninstall() error {
 // Since cni-plugins is delivered as a tarball, its not possible to check if they are due for an upgrade
 // todo: (@vignesh-goutham) check if we can publish cni-plugins independently with their checksum on our manifest
 func Upgrade(ctx context.Context, src Source, log *zap.Logger) error {
-	if err := installFromSource(ctx, src); err != nil {
+	opts := InstallOptions{
+		Source: src,
+		Logger: log,
+	}
+	if err := installFromSource(ctx, opts); err != nil {
 		return errors.Wrapf(err, "upgrading cni-plugins")
 	}
 	log.Info("Upgraded", zap.String("artifact", artifactName))

--- a/internal/cni/install_test.go
+++ b/internal/cni/install_test.go
@@ -1,0 +1,65 @@
+package cni_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/aws"
+	"github.com/aws/eks-hybrid/internal/cni"
+	"github.com/aws/eks-hybrid/internal/test"
+	"github.com/aws/eks-hybrid/internal/tracker"
+)
+
+func tarGzFile(g *GomegaWithT) []byte {
+	// create a tar.gz file with no content
+	buf := new(bytes.Buffer)
+	gw := gzip.NewWriter(buf)
+	tw := tar.NewWriter(gw)
+
+	err := tw.WriteHeader(&tar.Header{
+		Name: "cni-plugins.tgz",
+		Mode: 0o644,
+		Size: 0,
+	})
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	hdr := &tar.Header{
+		Name: "fake-plugin",
+		Size: 0,
+	}
+	g.Expect(tw.WriteHeader(hdr)).NotTo(HaveOccurred())
+	g.Expect(tw.Write([]byte(""))).Error().NotTo(HaveOccurred())
+
+	tw.Close()
+	gw.Close()
+	return buf.Bytes()
+}
+
+func TestInstall(t *testing.T) {
+	g := NewGomegaWithT(t)
+	test.RunInstallTest(t, test.TestData{
+		ArtifactName: "cni-plugins",
+		BinaryName:   "cni-plugins.tgz",
+		Data:         tarGzFile(g),
+		Install: func(ctx context.Context, tempDir string, source aws.Source, tr *tracker.Tracker) error {
+			return cni.Install(ctx, cni.InstallOptions{
+				Tracker:     tr,
+				Source:      source,
+				Logger:      zap.NewNop(),
+				InstallRoot: tempDir,
+			})
+		},
+		Verify: func(g *GomegaWithT, tempDir string, tr *tracker.Tracker) {
+			g.Expect(tr.Artifacts.CniPlugins).To(BeTrue())
+		},
+		VerifyFilePaths: []string{filepath.Join(cni.BinPath, "fake-plugin")},
+	})
+}

--- a/internal/flows/install.go
+++ b/internal/flows/install.go
@@ -75,7 +75,11 @@ func (i *Installer) installCredentialProcess(ctx context.Context) error {
 	switch i.CredentialProvider {
 	case creds.IamRolesAnywhereCredentialProvider:
 		i.Logger.Info("Installing AWS signing helper...")
-		if err := iamrolesanywhere.Install(ctx, i.Tracker, i.AwsSource); err != nil {
+		if err := iamrolesanywhere.Install(ctx, iamrolesanywhere.InstallOptions{
+			Tracker: i.Tracker,
+			Source:  i.AwsSource,
+			Logger:  i.Logger,
+		}); err != nil {
 			return err
 		}
 	case creds.SsmCredentialProvider:
@@ -98,25 +102,45 @@ func (i *Installer) installCredentialProcess(ctx context.Context) error {
 
 func (i *Installer) installEksArtifacts(ctx context.Context) error {
 	i.Logger.Info("Installing kubelet...")
-	if err := kubelet.Install(ctx, i.Tracker, i.AwsSource); err != nil {
+	if err := kubelet.Install(ctx, kubelet.InstallOptions{
+		Tracker: i.Tracker,
+		Source:  i.AwsSource,
+		Logger:  i.Logger,
+	}); err != nil {
 		return err
 	}
 
 	i.Logger.Info("Installing kubectl...")
-	if err := kubectl.Install(ctx, i.Tracker, i.AwsSource); err != nil {
+	if err := kubectl.Install(ctx, kubectl.InstallOptions{
+		Tracker: i.Tracker,
+		Source:  i.AwsSource,
+		Logger:  i.Logger,
+	}); err != nil {
 		return err
 	}
 
 	i.Logger.Info("Installing cni-plugins...")
-	if err := cni.Install(ctx, i.Tracker, i.AwsSource); err != nil {
+	if err := cni.Install(ctx, cni.InstallOptions{
+		Tracker: i.Tracker,
+		Source:  i.AwsSource,
+		Logger:  i.Logger,
+	}); err != nil {
 		return err
 	}
 
 	i.Logger.Info("Installing image credential provider...")
-	if err := imagecredentialprovider.Install(ctx, i.Tracker, i.AwsSource); err != nil {
+	if err := imagecredentialprovider.Install(ctx, imagecredentialprovider.InstallOptions{
+		Tracker: i.Tracker,
+		Source:  i.AwsSource,
+		Logger:  i.Logger,
+	}); err != nil {
 		return err
 	}
 
 	i.Logger.Info("Installing IAM authenticator...")
-	return iamauthenticator.Install(ctx, i.Tracker, i.AwsSource)
+	return iamauthenticator.Install(ctx, iamauthenticator.InstallOptions{
+		Tracker: i.Tracker,
+		Source:  i.AwsSource,
+		Logger:  i.Logger,
+	})
 }

--- a/internal/iamauthenticator/install_test.go
+++ b/internal/iamauthenticator/install_test.go
@@ -1,0 +1,36 @@
+package iamauthenticator_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/aws"
+	"github.com/aws/eks-hybrid/internal/iamauthenticator"
+	"github.com/aws/eks-hybrid/internal/test"
+	"github.com/aws/eks-hybrid/internal/tracker"
+)
+
+func TestInstall(t *testing.T) {
+	iamauthenticatorData := []byte("test aws-iam-authenticator binary")
+
+	test.RunInstallTest(t, test.TestData{
+		ArtifactName: "aws-iam-authenticator",
+		BinaryName:   "aws-iam-authenticator",
+		Data:         iamauthenticatorData,
+		Install: func(ctx context.Context, tempDir string, source aws.Source, tr *tracker.Tracker) error {
+			return iamauthenticator.Install(ctx, iamauthenticator.InstallOptions{
+				InstallRoot: tempDir,
+				Tracker:     tr,
+				Source:      source,
+				Logger:      zap.NewNop(),
+			})
+		},
+		Verify: func(g *GomegaWithT, tempDir string, tr *tracker.Tracker) {
+			g.Expect(tr.Artifacts.IamAuthenticator).To(BeTrue())
+		},
+		VerifyFilePaths: []string{iamauthenticator.IAMAuthenticatorBinPath},
+	})
+}

--- a/internal/iamrolesanywhere/install_test.go
+++ b/internal/iamrolesanywhere/install_test.go
@@ -1,0 +1,36 @@
+package iamrolesanywhere_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/aws"
+	"github.com/aws/eks-hybrid/internal/iamrolesanywhere"
+	"github.com/aws/eks-hybrid/internal/test"
+	"github.com/aws/eks-hybrid/internal/tracker"
+)
+
+func TestInstall(t *testing.T) {
+	iamrolesanywhereData := []byte("test aws_signing_helper binary")
+
+	test.RunInstallTest(t, test.TestData{
+		ArtifactName: "aws_signing_helper",
+		BinaryName:   "aws_signing_helper",
+		Data:         iamrolesanywhereData,
+		Install: func(ctx context.Context, tempDir string, source aws.Source, tr *tracker.Tracker) error {
+			return iamrolesanywhere.Install(ctx, iamrolesanywhere.InstallOptions{
+				InstallRoot: tempDir,
+				Tracker:     tr,
+				Source:      source,
+				Logger:      zap.NewNop(),
+			})
+		},
+		Verify: func(g *GomegaWithT, tempDir string, tr *tracker.Tracker) {
+			g.Expect(tr.Artifacts.IamRolesAnywhere).To(BeTrue())
+		},
+		VerifyFilePaths: []string{iamrolesanywhere.SigningHelperBinPath},
+	})
+}

--- a/internal/imagecredentialprovider/install.go
+++ b/internal/imagecredentialprovider/install.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -12,8 +13,8 @@ import (
 	"github.com/aws/eks-hybrid/internal/tracker"
 )
 
-// BinPath is the path to the image-credential-provider binary.
 const (
+	// BinPath is the path to the image-credential-provider binary.
 	BinPath = "/etc/eks/image-credential-provider/ecr-credential-provider"
 
 	artifactName      = "image-credential-provider"
@@ -25,23 +26,61 @@ type Source interface {
 	GetImageCredentialProvider(context.Context) (artifact.Source, error)
 }
 
+// InstallOptions contains options for installing image credential provider
+type InstallOptions struct {
+	InstallRoot string
+	Tracker     *tracker.Tracker
+	Source      Source
+	Logger      *zap.Logger
+}
+
 // Install installs the image-credential-provider at BinPath.
-func Install(ctx context.Context, tracker *tracker.Tracker, src Source) error {
-	imageCredentialProvider, err := src.GetImageCredentialProvider(ctx)
+func Install(ctx context.Context, opts InstallOptions) error {
+	if err := installFromSource(ctx, opts); err != nil {
+		return errors.Wrap(err, "installing image-credential-provider")
+	}
+
+	if err := opts.Tracker.Add(artifact.ImageCredentialProvider); err != nil {
+		return errors.Wrap(err, "adding image-credential-provider to tracker")
+	}
+
+	return nil
+}
+
+func installFromSource(ctx context.Context, opts InstallOptions) error {
+	if err := downloadFileWithRetries(ctx, opts); err != nil {
+		return errors.Wrap(err, "downloading image-credential-provider")
+	}
+
+	return nil
+}
+
+func downloadFileWithRetries(ctx context.Context, opts InstallOptions) error {
+	// Retry up to 3 times to download and validate the checksum
+	var err error
+	for range 3 {
+		err = downloadFileTo(ctx, opts)
+		if err == nil {
+			break
+		}
+		opts.Logger.Error("Downloading image-credential-provider failed. Retrying...", zap.Error(err))
+	}
+	return err
+}
+
+func downloadFileTo(ctx context.Context, opts InstallOptions) error {
+	imageCredentialProvider, err := opts.Source.GetImageCredentialProvider(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to image-credential-provider source")
+		return errors.Wrap(err, "getting image-credential-provider source")
 	}
 	defer imageCredentialProvider.Close()
 
-	if err := artifact.InstallFile(BinPath, imageCredentialProvider, artifactFilePerms); err != nil {
-		return errors.Wrap(err, "failed to install image-credential-provider")
+	if err := artifact.InstallFile(filepath.Join(opts.InstallRoot, BinPath), imageCredentialProvider, artifactFilePerms); err != nil {
+		return errors.Wrap(err, "installing image-credential-provider")
 	}
 
 	if !imageCredentialProvider.VerifyChecksum() {
 		return errors.Errorf("image-credential-provider checksum mismatch: %v", artifact.NewChecksumError(imageCredentialProvider))
-	}
-	if err = tracker.Add(artifact.ImageCredentialProvider); err != nil {
-		return err
 	}
 
 	return nil

--- a/internal/imagecredentialprovider/install_test.go
+++ b/internal/imagecredentialprovider/install_test.go
@@ -1,0 +1,36 @@
+package imagecredentialprovider_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/aws"
+	"github.com/aws/eks-hybrid/internal/imagecredentialprovider"
+	"github.com/aws/eks-hybrid/internal/test"
+	"github.com/aws/eks-hybrid/internal/tracker"
+)
+
+func TestInstall(t *testing.T) {
+	imagecredentialproviderData := []byte("test ecr-credential-provider binary")
+
+	test.RunInstallTest(t, test.TestData{
+		ArtifactName: "ecr-credential-provider",
+		BinaryName:   "ecr-credential-provider",
+		Data:         imagecredentialproviderData,
+		Install: func(ctx context.Context, tempDir string, source aws.Source, tr *tracker.Tracker) error {
+			return imagecredentialprovider.Install(ctx, imagecredentialprovider.InstallOptions{
+				InstallRoot: tempDir,
+				Tracker:     tr,
+				Source:      source,
+				Logger:      zap.NewNop(),
+			})
+		},
+		Verify: func(g *GomegaWithT, tempDir string, tr *tracker.Tracker) {
+			g.Expect(tr.Artifacts.ImageCredentialProvider).To(BeTrue())
+		},
+		VerifyFilePaths: []string{imagecredentialprovider.BinPath},
+	})
+}

--- a/internal/kubectl/install_test.go
+++ b/internal/kubectl/install_test.go
@@ -1,0 +1,36 @@
+package kubectl_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/aws"
+	"github.com/aws/eks-hybrid/internal/kubectl"
+	"github.com/aws/eks-hybrid/internal/test"
+	"github.com/aws/eks-hybrid/internal/tracker"
+)
+
+func TestInstall(t *testing.T) {
+	kubectlData := []byte("test kubectl binary")
+
+	test.RunInstallTest(t, test.TestData{
+		ArtifactName: "kubectl",
+		BinaryName:   "kubectl",
+		Data:         kubectlData,
+		Install: func(ctx context.Context, tempDir string, source aws.Source, tr *tracker.Tracker) error {
+			return kubectl.Install(ctx, kubectl.InstallOptions{
+				InstallRoot: tempDir,
+				Tracker:     tr,
+				Source:      source,
+				Logger:      zap.NewNop(),
+			})
+		},
+		Verify: func(g *GomegaWithT, tempDir string, tr *tracker.Tracker) {
+			g.Expect(tr.Artifacts.Kubectl).To(BeTrue())
+		},
+		VerifyFilePaths: []string{kubectl.BinPath},
+	})
+}

--- a/internal/test/install.go
+++ b/internal/test/install.go
@@ -1,0 +1,179 @@
+package test
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-hybrid/internal/aws"
+	"github.com/aws/eks-hybrid/internal/tracker"
+)
+
+// TestData represents the data needed to run an installation test
+type TestData struct {
+	ArtifactName    string
+	BinaryName      string
+	Data            []byte
+	Install         func(context.Context, string, aws.Source, *tracker.Tracker) error
+	Verify          func(*GomegaWithT, string, *tracker.Tracker)
+	VerifyFilePaths []string
+}
+
+func checksum(data []byte) []byte {
+	h := sha256.New()
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+// RunInstallTest runs the standard installation test suite
+func RunInstallTest(t *testing.T, td TestData) {
+	checksumData := fmt.Sprintf("%x %s", checksum(td.Data), td.BinaryName)
+	badChecksumData := fmt.Sprintf("%x %s", checksum(append(td.Data, []byte("bad")...)), td.BinaryName)
+
+	tests := []struct {
+		name          string
+		serverData    []byte
+		checksum      string
+		statusCode    int
+		wantErr       string
+		flakyChecksum bool
+		flakyHTTP     bool
+	}{
+		{
+			name:       "successful installation",
+			serverData: td.Data,
+			checksum:   checksumData,
+			statusCode: http.StatusOK,
+			wantErr:    "",
+		},
+		{
+			name:       "bad checksum",
+			serverData: td.Data,
+			checksum:   badChecksumData,
+			statusCode: http.StatusOK,
+			wantErr:    "checksum mismatch",
+		},
+		{
+			name:          "intermittent bad checksum",
+			serverData:    td.Data,
+			checksum:      checksumData,
+			statusCode:    http.StatusOK,
+			wantErr:       "",
+			flakyChecksum: true,
+		},
+		{
+			name:       "intermittent bad http status code",
+			serverData: td.Data,
+			checksum:   checksumData,
+			statusCode: http.StatusOK,
+			wantErr:    "",
+			flakyHTTP:  true,
+		},
+		{
+			name:       "server error",
+			statusCode: http.StatusInternalServerError,
+			wantErr:    "unexpected status code: 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			server := NewHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+				if tt.statusCode != http.StatusOK {
+					w.WriteHeader(tt.statusCode)
+					return
+				}
+
+				artifactPath := fmt.Sprintf("/latest/linux_amd64/%s", td.BinaryName)
+				if r.URL.Path == artifactPath {
+					if tt.flakyHTTP {
+						tt.flakyHTTP = false
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+
+					if _, err := w.Write(tt.serverData); err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+				}
+
+				checksumPath := fmt.Sprintf("/latest/linux_amd64/%s.sha256", td.BinaryName)
+				if r.URL.Path == checksumPath {
+					checksumData := tt.checksum
+					if tt.flakyChecksum {
+						checksumData = badChecksumData
+						tt.flakyChecksum = false
+					}
+					if _, err := w.Write([]byte(checksumData)); err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+				}
+			})
+
+			var source aws.Source
+			if td.ArtifactName == "aws_signing_helper" {
+				source = aws.Source{
+					Iam: aws.IamRolesAnywhereRelease{
+						Artifacts: []aws.Artifact{
+							{
+								Arch:        runtime.GOARCH,
+								OS:          runtime.GOOS,
+								Name:        td.ArtifactName,
+								URI:         server.URL + "/latest/linux_amd64/" + td.BinaryName,
+								ChecksumURI: server.URL + "/latest/linux_amd64/" + td.BinaryName + ".sha256",
+							},
+						},
+					},
+				}
+			} else {
+				source = aws.Source{
+					Eks: aws.EksPatchRelease{
+						Artifacts: []aws.Artifact{
+							{
+								Arch:        runtime.GOARCH,
+								OS:          runtime.GOOS,
+								Name:        td.ArtifactName,
+								URI:         server.URL + "/latest/linux_amd64/" + td.BinaryName,
+								ChecksumURI: server.URL + "/latest/linux_amd64/" + td.BinaryName + ".sha256",
+							},
+						},
+					},
+				}
+			}
+
+			tr := &tracker.Tracker{Artifacts: &tracker.InstalledArtifacts{}}
+
+			f, err := os.MkdirTemp("", td.ArtifactName+"-test")
+			g.Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(f)
+
+			err = td.Install(context.Background(), f, source, tr)
+
+			if tt.wantErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			td.Verify(g, f, tr)
+
+			for _, filePath := range td.VerifyFilePaths {
+				filePath := filepath.Join(f, filePath)
+				_, err := os.Stat(filePath)
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When adding gpg validation to ssm, I added retries around both the downloading and the checksum validation to catch cases where the checksum fails due to a bad download.  I actually saw something like this in 1 test run in my devstack.

This PR changes the remaining artifact downloading to match this pattern where checksum validation can trigger a retry.

Note:

The new unit tests are basically the same between the different artifacts.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

