### PR TITLE
ignore correct nosuchbucket error for s3 cleanup

### DIFF
--- a/test/e2e/cleanup/s3.go
+++ b/test/e2e/cleanup/s3.go
@@ -40,7 +40,7 @@ func (s *S3Cleaner) ListBuckets(ctx context.Context, filterInput FilterInput) ([
 			tags, err := s.s3Client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
 				Bucket: bucket.Name,
 			})
-			if err != nil && errors.IsType(err, &types.NoSuchBucket{}) {
+			if err != nil && errors.IsS3BucketNotFound(err) {
 				// skipping log since we are possiblying checking buckets we do not
 				// intend to delete
 				continue


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Missed a place in cleanup where checking for the NoSuchBucket error. The SDK does not return the actual type, the helper checks for the proper errorcode.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

