### PR TITLE
adds wait for jumpbox to e2e infra stack

### DIFF
--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -369,6 +369,9 @@ Resources:
   
   Jumpbox:
     Type: AWS::EC2::Instance
+    CreationPolicy:   
+      ResourceSignal:
+        Timeout: PT5M
     DeletionPolicy: Delete
     Properties:
       ImageId: resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64
@@ -404,6 +407,8 @@ Resources:
                   chmod 0600 /root/.ssh/id_rsa
                 path: /root/download-private-key.sh
                 permissions: "0755"
+            runcmd:
+              - cfn-signal --stack ${AWS::StackName} --resource Jumpbox --region ${AWS::Region}
 
   PodIdentityS3Bucket:
     Type: AWS::S3::Bucket

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -32,7 +32,7 @@ import (
 var setupTemplateBody []byte
 
 const (
-	stackWaitTimeout  = 5 * time.Minute
+	stackWaitTimeout  = 7 * time.Minute
 	stackWaitInterval = 10 * time.Second
 )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We have hit a few issues where the jumpbox can not be found when starting the test.  This could be because the instances has not reach the running status or it could be that the instance never boots.

Changing the describeinstance call to use an instance waiter which will loop until the instance is running.

CFN also supports creationpolicy signals for instance creation.  `cfn-signal` is included in the al23 AMI and it calls back to the cfn api to signal that the instance is up and ready.  If this signal does not come within the timeout, cfn will delete and recreate the instance.  This coupled with https://github.com/aws/eks-hybrid/pull/396 should make the stack creation resilient to instance boot failures.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

