### PR TITLE
Update ginkgo version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ KUSTOMIZE_VERSION ?= v5.0.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.3
 CODE_GENERATOR_VERSION ?= v0.30.6
 CRD_REF_DOCS_VERSION ?= v0.1.0
-GINKGO_VERSION ?= v2.22.2
+GINKGO_VERSION ?= v2.23.0
 
 tools: kustomize controller-gen conversion-gen crd-ref-docs ginkgo ## Install the toolchain.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When running `ginkgo` test locally, I saw the following prompt. 

```
❯ ./_bin/ginkgo -v -tags=e2e --label-filter="al23-amd64 && ssm && simpleflow" ./test/e2e/suite -- -filepath=/Users/jupeng/workplace/eks-hybrid/e2e-param.yaml
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.22.2
  Mismatched package versions found:
    2.23.0 used by suite

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.

```

Upgrade ginkgo version in `Makefile` to match `ginkgo` version in go.mod

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

