### PR TITLE
Fix documentation for enableCredentialsFile option

### DIFF
--- a/api/v1alpha1/nodeconfig_types.go
+++ b/api/v1alpha1/nodeconfig_types.go
@@ -107,8 +107,8 @@ const (
 // HybridOptions defines the options specific to hybrid node enrollment.
 type HybridOptions struct {
 	// EnableCredentialsFile enables a shared credentials file on the host at /eks-hybrid/.aws/credentials
-	// For SSM, this means that nodeadm will not create symlink from `/root/.aws/credentials` to `/eks-hybrid/.aws/credentials`.
-	// For IAM Roles Anywhere, this means that nodeadm will not set up a systemd service to write and refresh the credentials to `/eks-hybrid/.aws/credentials`.
+	// For SSM, this means that nodeadm will create a symlink from `/root/.aws/credentials` to `/eks-hybrid/.aws/credentials`.
+	// For IAM Roles Anywhere, this means that nodeadm will set up a systemd service to write and refresh the credentials to `/eks-hybrid/.aws/credentials`.
 	EnableCredentialsFile bool `json:"enableCredentialsFile,omitempty"`
 
 	// IAMRolesAnywhere includes IAM Roles Anywhere specific configuration and is mutually exclusive

--- a/crds/node.eks.aws_nodeconfigs.yaml
+++ b/crds/node.eks.aws_nodeconfigs.yaml
@@ -91,8 +91,8 @@ spec:
                   enableCredentialsFile:
                     description: |-
                       EnableCredentialsFile enables a shared credentials file on the host at /eks-hybrid/.aws/credentials
-                      For SSM, this means that nodeadm will not create symlink from `/root/.aws/credentials` to `/eks-hybrid/.aws/credentials`.
-                      For IAM Roles Anywhere, this means that nodeadm will not set up a systemd service to write and refresh the credentials to `/eks-hybrid/.aws/credentials`.
+                      For SSM, this means that nodeadm will create a symlink from `/root/.aws/credentials` to `/eks-hybrid/.aws/credentials`.
+                      For IAM Roles Anywhere, this means that nodeadm will set up a systemd service to write and refresh the credentials to `/eks-hybrid/.aws/credentials`.
                     type: boolean
                   iamRolesAnywhere:
                     description: |-

--- a/doc/api.md
+++ b/doc/api.md
@@ -46,7 +46,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `enableCredentialsFile` _boolean_ | EnableCredentialsFile enables a shared credentials file on the host at /eks-hybrid/.aws/credentials<br />For SSM, this means that nodeadm will not create symlink from `/root/.aws/credentials` to `/eks-hybrid/.aws/credentials`.<br />For IAM Roles Anywhere, this means that nodeadm will not set up a systemd service to write and refresh the credentials to `/eks-hybrid/.aws/credentials`. |
+| `enableCredentialsFile` _boolean_ | EnableCredentialsFile enables a shared credentials file on the host at /eks-hybrid/.aws/credentials<br />For SSM, this means that nodeadm will create a symlink from `/root/.aws/credentials` to `/eks-hybrid/.aws/credentials`.<br />For IAM Roles Anywhere, this means that nodeadm will set up a systemd service to write and refresh the credentials to `/eks-hybrid/.aws/credentials`. |
 | `iamRolesAnywhere` _[IAMRolesAnywhere](#iamrolesanywhere)_ | IAMRolesAnywhere includes IAM Roles Anywhere specific configuration and is mutually exclusive<br />with SSM. |
 | `ssm` _[SSM](#ssm)_ | SSM includes Systems Manager specific configuration and is mutually exclusive with<br />IAMRolesAnywhere. |
 


### PR DESCRIPTION
Fix documentation for `enableCredentialsFile` config field, to be written from the POV of enabling the option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

