### PR TITLE
standardizes the loading of the aws config for e2e

### DIFF
--- a/cmd/e2e-test/cleanup/cleanup.go
+++ b/cmd/e2e-test/cleanup/cleanup.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
@@ -57,7 +55,7 @@ func (s *Command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return fmt.Errorf("unmarshaling cleanup config: %w", err)
 	}
 
-	aws, err := config.LoadDefaultConfig(ctx, config.WithRegion(deleteCluster.ClusterRegion), config.WithRetryMaxAttempts(20), config.WithRetryMode(aws.RetryModeAdaptive))
+	aws, err := e2e.NewAWSConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)
 	}

--- a/cmd/e2e-test/node/create.go
+++ b/cmd/e2e-test/node/create.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	s3sdk "github.com/aws/aws-sdk-go-v2/service/s3"
@@ -69,7 +68,7 @@ func (c *create) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 
 	logger := e2e.NewLogger()
-	aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.ClusterRegion))
+	aws, err := e2e.NewAWSConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)
 	}

--- a/cmd/e2e-test/node/delete.go
+++ b/cmd/e2e-test/node/delete.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	sdk "github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	ec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	s3sdk "github.com/aws/aws-sdk-go-v2/service/s3"
@@ -55,7 +54,7 @@ func (d *Delete) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 
 	logger := e2e.NewLogger()
-	aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.ClusterRegion))
+	aws, err := e2e.NewAWSConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)
 	}

--- a/cmd/e2e-test/setup/setup.go
+++ b/cmd/e2e-test/setup/setup.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
@@ -56,7 +54,7 @@ func (s *Command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return fmt.Errorf("unmarshaling test infra configuration: %w", err)
 	}
 
-	aws, err := config.LoadDefaultConfig(ctx, config.WithRegion(testResources.ClusterRegion), config.WithRetryMaxAttempts(20), config.WithRetryMode(aws.RetryModeAdaptive))
+	aws, err := e2e.NewAWSConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)
 	}

--- a/cmd/e2e-test/ssh/ssh.go
+++ b/cmd/e2e-test/ssh/ssh.go
@@ -7,12 +7,12 @@ import (
 	"os/exec"
 	"os/signal"
 
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 
 	"github.com/aws/eks-hybrid/internal/cli"
+	"github.com/aws/eks-hybrid/test/e2e"
 	"github.com/aws/eks-hybrid/test/e2e/constants"
 	"github.com/aws/eks-hybrid/test/e2e/peered"
 )
@@ -45,7 +45,7 @@ func (c *Command) Commands() []cli.Command {
 func (s *Command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	ctx := context.Background()
 
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := e2e.NewAWSConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)
 	}

--- a/cmd/e2e-test/sweeper/sweeper.go
+++ b/cmd/e2e-test/sweeper/sweeper.go
@@ -5,10 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
-	"github.com/aws/aws-sdk-go-v2/aws/retry"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 
@@ -73,26 +69,7 @@ func (s *SweeperCommand) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	if s.clusterPrefix == "" && s.clusterName == "" && !s.all {
 		return fmt.Errorf("either --cluster-prefix, --cluster-name, or --all must be specified")
 	}
-	aws, err := config.LoadDefaultConfig(ctx, config.WithRetryer(func() aws.Retryer {
-		return retry.NewAdaptiveMode(func(o *retry.AdaptiveModeOptions) {
-			// the adaptive retryer wraps the standard retryer but implements a custom rate limiterfor getting the AttemptToken
-			// which the sdk calls internally before making a request (including retried requests)
-			// when getting this GetAttemptToken it will sleep if neccessary based on its internal rate limiter
-			// However, when a request fails, the sdk calls GetRetryToken, which adapative sends its wrapped standard retryer
-			// the standard retryer uses the TokenRateLimit to make a determination of whether to retry or not and its pretty tight
-			// this disables the TokenRateLimit on the standard retryer by setting it to the None implementation
-			// see for more:
-			//	https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-retries-timeouts.html
-			//	https://github.com/aws/aws-sdk-go-v2/blob/main/aws/retry/adaptive.go
-			//	https://github.com/aws/aws-sdk-go-v2/blob/main/aws/retry/standard.go
-			o.StandardOptions = []func(*retry.StandardOptions){
-				func(o *retry.StandardOptions) {
-					o.MaxAttempts = 40
-					o.RateLimiter = ratelimit.None
-				},
-			}
-		})
-	}))
+	aws, err := e2e.NewAWSConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)
 	}

--- a/test/e2e/aws.go
+++ b/test/e2e/aws.go
@@ -1,7 +1,13 @@
 package e2e
 
 import (
+	"context"
 	"regexp"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/config"
 )
 
 // SanitizeForAWSName removes everything except alphanumeric characters and hyphens from a string.
@@ -16,4 +22,27 @@ func Truncate(name string, limit int) string {
 		name = name[:limit]
 	}
 	return name
+}
+
+func NewAWSConfig(ctx context.Context) (aws.Config, error) {
+	return config.LoadDefaultConfig(ctx, config.WithRetryer(func() aws.Retryer {
+		return retry.NewAdaptiveMode(func(o *retry.AdaptiveModeOptions) {
+			// the adaptive retryer wraps the standard retryer but implements a custom rate limiterfor getting the AttemptToken
+			// which the sdk calls internally before making a request (including retried requests)
+			// when getting this GetAttemptToken it will sleep if neccessary based on its internal rate limiter
+			// However, when a request fails, the sdk calls GetRetryToken, which adapative sends its wrapped standard retryer
+			// the standard retryer uses the TokenRateLimit to make a determination of whether to retry or not and its pretty tight
+			// this disables the TokenRateLimit on the standard retryer by setting it to the None implementation
+			// see for more:
+			//	https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-retries-timeouts.html
+			//	https://github.com/aws/aws-sdk-go-v2/blob/main/aws/retry/adaptive.go
+			//	https://github.com/aws/aws-sdk-go-v2/blob/main/aws/retry/standard.go
+			o.StandardOptions = []func(*retry.StandardOptions){
+				func(o *retry.StandardOptions) {
+					o.MaxAttempts = 40
+					o.RateLimiter = ratelimit.None
+				},
+			}
+		})
+	}))
 }

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	ec2v2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
@@ -112,7 +111,7 @@ var _ = SynchronizedBeforeSuite(
 		Expect(err).NotTo(HaveOccurred(), "should read valid test configuration")
 
 		logger := newLoggerForTests().Logger
-		aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.ClusterRegion))
+		aws, err := e2e.NewAWSConfig(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		infra, err := peered.Setup(ctx, logger, aws, config.ClusterName, config.Endpoint)
@@ -459,7 +458,7 @@ func buildPeeredVPCTestForSuite(ctx context.Context, suite *suiteConfiguration) 
 		skipCleanup:            suite.SkipCleanup,
 	}
 
-	aws, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(suite.TestConfig.ClusterRegion), awsconfig.WithRetryMaxAttempts(20), awsconfig.WithRetryMode(aws.RetryModeAdaptive))
+	aws, err := e2e.NewAWSConfig(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes all the places we load the aws config in the e2e flows to use the same helper to avoid inconsistent retry settings.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

