### PR TITLE
limits ginkgo imports to e2e/suite

### DIFF
--- a/cmd/e2e-test/node/create.go
+++ b/cmd/e2e-test/node/create.go
@@ -23,7 +23,6 @@ import (
 	osystem "github.com/aws/eks-hybrid/test/e2e/os"
 	"github.com/aws/eks-hybrid/test/e2e/peered"
 	"github.com/aws/eks-hybrid/test/e2e/s3"
-	"github.com/aws/eks-hybrid/test/e2e/suite"
 )
 
 type create struct {
@@ -62,7 +61,7 @@ func (c *create) Flaggy() *flaggy.Subcommand {
 
 func (c *create) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	ctx := context.Background()
-	config, err := suite.ReadConfig(c.configFile)
+	config, err := e2e.ReadConfig(c.configFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/e2e-test/node/delete.go
+++ b/cmd/e2e-test/node/delete.go
@@ -20,7 +20,6 @@ import (
 	"github.com/aws/eks-hybrid/test/e2e/ec2"
 	"github.com/aws/eks-hybrid/test/e2e/peered"
 	"github.com/aws/eks-hybrid/test/e2e/ssm"
-	"github.com/aws/eks-hybrid/test/e2e/suite"
 )
 
 type Delete struct {
@@ -48,7 +47,7 @@ func (d *Delete) Flaggy() *flaggy.Subcommand {
 
 func (d *Delete) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	ctx := context.Background()
-	config, err := suite.ReadConfig(d.configFile)
+	config, err := e2e.ReadConfig(d.configFile)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -1,4 +1,4 @@
-package suite
+package e2e
 
 import (
 	"fmt"

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -48,7 +48,7 @@ var (
 )
 
 type suiteConfiguration struct {
-	TestConfig             *TestConfig              `json:"testConfig"`
+	TestConfig             *e2e.TestConfig          `json:"testConfig"`
 	SkipCleanup            bool                     `json:"skipCleanup"`
 	CredentialsStackOutput *credentials.StackOutput `json:"ec2StackOutput"`
 	RolesAnywhereCACertPEM []byte                   `json:"rolesAnywhereCACertPEM"`
@@ -107,7 +107,7 @@ var _ = SynchronizedBeforeSuite(
 	// In this case, we use a struct marshalled in json.
 	func(ctx context.Context) []byte {
 		Expect(filePath).NotTo(BeEmpty(), "filepath should be configured") // Fail the test if the filepath flag is not provided
-		config, err := ReadConfig(filePath)
+		config, err := e2e.ReadConfig(filePath)
 		Expect(err).NotTo(HaveOccurred(), "should read valid test configuration")
 
 		logger := newLoggerForTests().Logger
@@ -271,6 +271,7 @@ var _ = Describe("Hybrid Nodes", func() {
 								verifyNode = test.newVerifyNode(instance.IP)
 
 								serialOutput = peered.NewSerialOutputBlockBestEffort(ctx, &peered.SerialOutputConfig{
+									By:           By,
 									PeeredNode:   peeredNode,
 									Instance:     instance,
 									TestLogger:   test.loggerControl,
@@ -386,6 +387,7 @@ var _ = Describe("Hybrid Nodes", func() {
 								verifyNode = test.newVerifyNode(instance.IP)
 
 								serialOutput = peered.NewSerialOutputBlockBestEffort(ctx, &peered.SerialOutputConfig{
+									By:           By,
 									PeeredNode:   peeredNode,
 									Instance:     instance,
 									TestLogger:   test.loggerControl,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We want to try and limit the usage of ginkgo + types in the test/e2e/suite package. This moves a bit of the code around to achieve that.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

