### PR TITLE
add e2e-label to kube node to detect joining

### DIFF
--- a/cmd/e2e-test/node/delete.go
+++ b/cmd/e2e-test/node/delete.go
@@ -110,9 +110,12 @@ func (d *Delete) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		LogsBucket:          config.LogsBucket,
 	}
 
-	if err := node.Cleanup(ctx, ec2.Instance{
-		ID:   *instance.InstanceId,
-		IP:   *instance.PrivateIpAddress,
+	if err := node.Cleanup(ctx, peered.PeerdNode{
+		Instance: ec2.Instance{
+			ID:   *instance.InstanceId,
+			IP:   *instance.PrivateIpAddress,
+			Name: d.instanceName,
+		},
 		Name: d.instanceName,
 	}); err != nil {
 		return err

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -30,7 +30,7 @@ const (
 
 type VerifyPodIdentityAddon struct {
 	Cluster             string
-	NodeIP              string
+	NodeName            string
 	PodIdentityS3Bucket string
 	K8S                 clientgo.Interface
 	EKSClient           *eks.Client
@@ -72,9 +72,9 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 		return fmt.Errorf("getting daemon set %s: %w", podIdentityDaemonSet, err)
 	}
 
-	node, err := kubernetes.WaitForNode(ctx, v.K8S, v.NodeIP, v.Logger)
+	node, err := kubernetes.WaitForNode(ctx, v.K8S, v.NodeName, v.Logger)
 	if err != nil {
-		return fmt.Errorf("waiting for node %s to be ready: %w", v.NodeIP, err)
+		return fmt.Errorf("waiting for node %s to be ready: %w", v.NodeName, err)
 	}
 
 	if err := kubernetes.WaitForDaemonSetPodToBeRunning(ctx, v.K8S, "kube-system", podIdentityDaemonSet, node.Name, v.Logger); err != nil {

--- a/test/e2e/constants/constants.go
+++ b/test/e2e/constants/constants.go
@@ -14,4 +14,5 @@ const (
 	TestSerialOutputLogFile         = "TestSerialOutputLogFile"
 	TestS3LogsFolder                = "logs"
 	SerialOutputLogFile             = "serial-output.log"
+	TestInstanceNameKubernetesLabel = "test.eks-hybrid.amazonaws.com/node-name"
 )

--- a/test/e2e/kubernetes/node.go
+++ b/test/e2e/kubernetes/node.go
@@ -13,7 +13,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubectl/pkg/drain"
+
+	"github.com/aws/eks-hybrid/test/e2e/constants"
 )
 
 const (
@@ -24,18 +27,18 @@ const (
 	nodeCordonTimeout        = 30 * time.Second
 )
 
-// WaitForNode wait for the node to join the cluster and fetches the node info from an internal IP address of the node
-func WaitForNode(ctx context.Context, k8s kubernetes.Interface, internalIP string, logger logr.Logger) (*corev1.Node, error) {
+// WaitForNode wait for the node to join the cluster and fetches the node info which has the nodeName label
+func WaitForNode(ctx context.Context, k8s kubernetes.Interface, nodeName string, logger logr.Logger) (*corev1.Node, error) {
 	foundNode := &corev1.Node{}
 	consecutiveErrors := 0
 	err := wait.PollUntilContextTimeout(ctx, hybridNodeDelayInterval, hybridNodeWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
-		node, err := getNodeByInternalIP(ctx, k8s, internalIP)
+		node, err := getNodeByE2ELabelName(ctx, k8s, nodeName)
 		if err != nil {
 			consecutiveErrors += 1
 			if consecutiveErrors > 3 {
 				return false, err
 			}
-			logger.Info("Retryable error listing nodes when looking for node with IP. Continuing to poll", "internalIP", internalIP, "error", err)
+			logger.Info("Retryable error listing nodes when looking for node with name. Continuing to poll", "nodeName", nodeName, "error", err)
 			return false, nil // continue polling
 		}
 		consecutiveErrors = 0
@@ -44,7 +47,7 @@ func WaitForNode(ctx context.Context, k8s kubernetes.Interface, internalIP strin
 			return true, nil // node found, stop polling
 		}
 
-		logger.Info("Node with internal IP doesn't exist yet", "internalIP", internalIP)
+		logger.Info("Node with e2e label doesn't exist yet", "nodeName", nodeName)
 		return false, nil // continue polling
 	})
 	if err != nil {
@@ -53,26 +56,57 @@ func WaitForNode(ctx context.Context, k8s kubernetes.Interface, internalIP strin
 	return foundNode, nil
 }
 
-func getNodeByInternalIP(ctx context.Context, k8s kubernetes.Interface, internalIP string) (*corev1.Node, error) {
-	nodes, err := k8s.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("listing nodes when looking for node with IP %s: %w", internalIP, err)
-	}
-	return nodeByInternalIP(nodes, internalIP), nil
-}
-
-func nodeByInternalIP(nodes *corev1.NodeList, nodeIP string) *corev1.Node {
-	for _, node := range nodes.Items {
-		for _, address := range node.Status.Addresses {
-			if address.Type == "InternalIP" && address.Address == nodeIP {
-				return &node
-			}
+func GetNodeInternalIP(node *corev1.Node) string {
+	for _, address := range node.Status.Addresses {
+		if address.Type == "InternalIP" {
+			return address.Address
 		}
 	}
-	return nil
+	return ""
 }
 
-func WaitForHybridNodeToBeReady(ctx context.Context, k8s kubernetes.Interface, nodeName string, logger logr.Logger) error {
+func CheckForNodeWithE2ELabel(ctx context.Context, k8s kubernetes.Interface, nodeName string) (*corev1.Node, error) {
+	var node *corev1.Node
+	err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		return true
+	}, func() error {
+		var err error
+		node, err = getNodeByE2ELabelName(ctx, k8s, nodeName)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return node, err
+}
+
+func getNodeByE2ELabelName(ctx context.Context, k8s kubernetes.Interface, nodeName string) (*corev1.Node, error) {
+	nodes, err := k8s.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: constants.TestInstanceNameKubernetesLabel + "=" + nodeName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing nodes when looking for node with e2e label %s: %w", nodeName, err)
+	}
+
+	// return nil if no node is found to retry
+	if len(nodes.Items) == 0 {
+		return nil, nil
+	}
+
+	if len(nodes.Items) > 1 {
+		return nil, fmt.Errorf("found multiple nodes with e2e label %s: %v", nodeName, nodes.Items)
+	}
+
+	return &nodes.Items[0], nil
+}
+
+// WaitForHybridNodeToBeReady will continue to poll until the node is:
+// - marked ready
+// - cilium-agent taint is removed (agent is ready on this node)
+// - nodeNetworkAvailable is true
+// - internal IP address is set
+func WaitForHybridNodeToBeReady(ctx context.Context, k8s kubernetes.Interface, nodeName string, logger logr.Logger) (*corev1.Node, error) {
+	foundNode := &corev1.Node{}
 	consecutiveErrors := 0
 	err := wait.PollUntilContextTimeout(ctx, nodePodDelayInterval, hybridNodeWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		node, err := k8s.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
@@ -96,18 +130,21 @@ func WaitForHybridNodeToBeReady(ctx context.Context, k8s kubernetes.Interface, n
 			logger.Info("Node's cilium-agent is not ready yet. Verify the cilium-operator is running.", "node", nodeName)
 		} else if !nodeNetworkAvailable(node) {
 			logger.Info("Node is ready, but network is NetworkUnavailable condition not False", "node", nodeName)
+		} else if GetNodeInternalIP(node) == "" {
+			logger.Info("Node is ready, but internal IP address is not set", "node", nodeName)
 		} else {
 			logger.Info("Node is ready", "node", nodeName)
+			foundNode = node
 			return true, nil // node is ready, stop polling
 		}
 
 		return false, nil // continue polling
 	})
 	if err != nil {
-		return fmt.Errorf("waiting for node %s to be ready: %w", nodeName, err)
+		return nil, fmt.Errorf("waiting for node %s to be ready: %w", nodeName, err)
 	}
 
-	return nil
+	return foundNode, nil
 }
 
 func WaitForHybridNodeToBeNotReady(ctx context.Context, k8s kubernetes.Interface, nodeName string, logger logr.Logger) error {
@@ -166,10 +203,10 @@ func DeleteNode(ctx context.Context, k8s kubernetes.Interface, name string) erro
 	return nil
 }
 
-func EnsureNodeWithIPIsDeleted(ctx context.Context, k8s kubernetes.Interface, internalIP string) error {
-	node, err := getNodeByInternalIP(ctx, k8s, internalIP)
+func EnsureNodeWithE2ELabelIsDeleted(ctx context.Context, k8s kubernetes.Interface, nodeName string) error {
+	node, err := getNodeByE2ELabelName(ctx, k8s, nodeName)
 	if err != nil {
-		return fmt.Errorf("getting node by internal IP: %w", err)
+		return fmt.Errorf("getting node by e2e label: %w", err)
 	}
 	if node == nil {
 		return nil

--- a/test/e2e/kubernetes/verify.go
+++ b/test/e2e/kubernetes/verify.go
@@ -22,12 +22,13 @@ type VerifyNode struct {
 	Logger       logr.Logger
 	Region       string
 
-	NodeIPAddress string
+	NodeName string
+	NodeIP   string
 }
 
 func (v VerifyNode) WaitForNodeReady(ctx context.Context) (*corev1.Node, error) {
 	// get the hybrid node registered using nodeadm by the internal IP of an EC2 Instance
-	node, err := WaitForNode(ctx, v.K8s, v.NodeIPAddress, v.Logger)
+	node, err := WaitForNode(ctx, v.K8s, v.NodeName, v.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +39,17 @@ func (v VerifyNode) WaitForNodeReady(ctx context.Context) (*corev1.Node, error) 
 	nodeName := node.Name
 
 	v.Logger.Info("Waiting for hybrid node to be ready...")
-	if err = WaitForHybridNodeToBeReady(ctx, v.K8s, nodeName, v.Logger); err != nil {
-		return nil, err
+	node, err = WaitForHybridNodeToBeReady(ctx, v.K8s, nodeName, v.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("waiting for hybrid node to be ready: %w", err)
+	}
+
+	internalAddress := GetNodeInternalIP(node)
+	if internalAddress == "" {
+		return nil, fmt.Errorf("node InternalIP missing from node status. All Addresses: %v", node.Status.Addresses)
+	}
+	if internalAddress != v.NodeIP {
+		return nil, fmt.Errorf("node InternalIP %s does not match expected instance IP %s. Inspect the nodes `ifconfig.txt` log file. All Addresses: %v", internalAddress, v.NodeIP, node.Status.Addresses)
 	}
 
 	return node, nil

--- a/test/e2e/nodeadm/uninstall.go
+++ b/test/e2e/nodeadm/uninstall.go
@@ -18,7 +18,8 @@ type CleanNode struct {
 	Verifier            UninstallVerifier
 	Logger              logr.Logger
 
-	NodeIP string
+	NodeName string
+	NodeIP   string
 }
 
 // UninstallVerifier checks if nodeadm uninstall process was successful in a node.
@@ -27,7 +28,7 @@ type UninstallVerifier interface {
 }
 
 func (u CleanNode) Run(ctx context.Context) error {
-	node, err := kubernetes.WaitForNode(ctx, u.K8s, u.NodeIP, u.Logger)
+	node, err := kubernetes.WaitForNode(ctx, u.K8s, u.NodeName, u.Logger)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/nodeadm/upgrade.go
+++ b/test/e2e/nodeadm/upgrade.go
@@ -20,11 +20,12 @@ type UpgradeNode struct {
 	Logger              logr.Logger
 
 	NodeIP           string
+	NodeName         string
 	TargetK8sVersion string
 }
 
 func (u UpgradeNode) Run(ctx context.Context) error {
-	node, err := kubernetes.WaitForNode(ctx, u.K8s, u.NodeIP, u.Logger)
+	node, err := kubernetes.WaitForNode(ctx, u.K8s, u.NodeName, u.Logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds a new label to the created kubenetes nodes in the e2e tests.  This label will be used to detect when the node joins the instead of the internal IP.  

We have seen cases where it appears that the node joins and gets ready, but it is never found by the internalip.  This does include a check when the node joins, validating the joined internal IP with the instance IP.  For now, this will still fail the test, but may gave us a clue into what is causing this discrepancy. 

The instanceName is used, instead of the nodeName because the created ec2.Instance via peeredNode, has the instanceName instead of the nodeName. Using the instanceName made it easier to grab the correct value in the various places throughout the test.  Not opposed to use the nodeName instead.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

