### PR TITLE
Add proxy flags to IAM-RA

### DIFF
--- a/internal/iamrolesanywhere/aws_config.go
+++ b/internal/iamrolesanywhere/aws_config.go
@@ -53,12 +53,19 @@ type AWSConfig struct {
 
 	// PrivateKeyPath is the location on disk for the certificate's private key.
 	PrivateKeyPath string `json:"privateKeyPath,omitempty"`
+
+	// ProxyEnabled marks if proxy is enabled on the host
+	ProxyEnabled bool `json:"proxyEnabled,omitempty"`
 }
 
 // WriteAWSConfig writes an AWS configuration file with contents appropriate for node config
 func WriteAWSConfig(cfg AWSConfig) error {
 	if cfg.ConfigPath == "" {
 		cfg.ConfigPath = DefaultAWSConfigPath
+	}
+
+	if httpProxy, httpsProxy := os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"); httpProxy != "" || httpsProxy != "" {
+		cfg.ProxyEnabled = true
 	}
 
 	if err := validateAWSConfig(cfg); err != nil {

--- a/internal/iamrolesanywhere/aws_config.tpl
+++ b/internal/iamrolesanywhere/aws_config.tpl
@@ -1,3 +1,3 @@
 [profile %v]
 region = {{ .Region }}
-credential_process = {{ .SigningHelperBinPath }} credential-process --certificate {{ .CertificatePath }} --private-key {{ .PrivateKeyPath }} --trust-anchor-arn {{ .TrustAnchorARN }} --profile-arn {{ .ProfileARN }} --role-arn {{ .RoleARN }} --role-session-name {{ .NodeName }}
+credential_process = {{ .SigningHelperBinPath }} credential-process --certificate {{ .CertificatePath }} --private-key {{ .PrivateKeyPath }} --trust-anchor-arn {{ .TrustAnchorARN }} --profile-arn {{ .ProfileARN }} --role-arn {{ .RoleARN }} --role-session-name {{ .NodeName }}{{ if .ProxyEnabled }} --with-proxy{{end}}


### PR DESCRIPTION
*Description of changes:*
IAM-RA uses aws_signing_helper binary which requires an explicit `--with-proxy` flag to be set if we expect the binary to consume the proxy env vars. This changes checks if proxy env vars are set and adds the flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

