### PR TITLE
adds new integration test mocking eks api

### DIFF
--- a/test/integration/cases/init-with-config-enrichment/config.yaml
+++ b/test/integration/cases/init-with-config-enrichment/config.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    region: us-west-2
+  hybrid:
+    enableCredentialsFile: true
+    iamRolesAnywhere:
+      nodeName: mock-hybrid-node
+      roleArn: arn:aws:iam::123456789010:role/mockHybridNodeRole
+      profileArn: arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole
+      trustAnchorArn: arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7

--- a/test/integration/cases/init-with-config-enrichment/run.sh
+++ b/test/integration/cases/init-with-config-enrichment/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+wait::dbus-ready
+
+export AWS_ENDPOINT_URL=http://localhost:5000
+
+mkdir -p /etc/iam/pki
+touch  /etc/iam/pki/server.pem
+touch  /etc/iam/pki/server.key
+
+nodeadm install 1.30  --credential-provider iam-ra
+
+mock::aws_signing_helper
+
+exit_code=0
+STDERR=$(nodeadm init --skip run,node-ip-validation --config-source file://config.yaml 2>&1) || exit_code=$?
+if [ $exit_code -ne 0 ]; then
+    assert::is-substring "$STDERR" "ResourceNotFoundException"
+else
+    echo "nodeadm init should have failed while cluster does not exist"
+    exit 1
+fi
+
+aws eks create-cluster \
+    --name my-cluster \
+    --region us-west-2 \
+    --kubernetes-version 1.31 \
+    --role-arn arn:aws:iam::123456789012:role/eksClusterRole-12-3 \
+    --resources-vpc-config subnetIds=subnet-123456789012,subnet-123456789013,securityGroupIds=sg-123456789014,endpointPrivateAccess=true,endpointPublicAccess=false \
+    --remote-network-config '{"remoteNodeNetworks":[{"cidrs":["10.100.0.0/16"]}],"remotePodNetworks":[{"cidrs":["10.101.0.0/16"]}]}'
+
+if ! nodeadm init --skip run,node-ip-validation --config-source file://config.yaml; then
+    echo "nodeadm init should have succeeded after creating the cluster"
+    exit 1
+fi

--- a/test/integration/docs/patching-moto.md
+++ b/test/integration/docs/patching-moto.md
@@ -4,9 +4,19 @@ This document describes how to temporarily patch moto in the integration test Do
 
 ## Overview
 
-Sometimes we need to carry patches for moto while waiting for upstream releases. This document outlines the process for creating and applying patches to moto in our integration test environment.
+Sometimes we need to switch to an unreleased moto or carry patches for moto while waiting for upstream releases. This document outlines the process for creating and applying patches to moto in our integration test environment.
 
-## Steps to Patch Moto
+## Steps to install unreleased moto
+
+1. Update the Dockerfile to pip install from a specific commit:
+   ```dockerfile
+   # Install moto from specific commit
+   RUN pip install --user 'moto[server] @ git+https://github.com/getmoto/moto.git@<commit-hash>'
+   ```
+
+2. Document the reason for using the specific commit in a comment above the installation line.
+
+## Steps to patch moto
 
 1. Create a `moto-patches` directory in `test/integration/infra/` if it doesn't exist:
    ```bash
@@ -15,7 +25,9 @@ Sometimes we need to carry patches for moto while waiting for upstream releases.
 
 2. Generate a patch file, ideally open a PR upstream with the changes and store in the `moto-patches` folder.
 
-3. Update the Dockerfile to apply the patch:
+3. Ideally, open a PR upstream with the changes and store the patch in the `moto-patches` folder while waiting for the PR to be merged.
+
+4. Update the Dockerfile to apply the patch:
    ```dockerfile
    # Install moto from specific commit
    RUN pip install --user 'moto[server] @ git+https://github.com/getmoto/moto.git@<commit-hash>'
@@ -39,3 +51,4 @@ Once a patch is included in an upstream release:
 1. Remove the patch file from `test/integration/infra/moto-patches/`
 2. Update the moto installation in the Dockerfile to use the new release
 3. Remove the patch application command from the Dockerfile
+4. Update any documentation or comments that reference the patch

--- a/test/integration/docs/patching-moto.md
+++ b/test/integration/docs/patching-moto.md
@@ -1,0 +1,41 @@
+# Patching Moto in Integration Tests
+
+This document describes how to temporarily patch moto in the integration test Dockerfile while waiting for upstream releases.
+
+## Overview
+
+Sometimes we need to carry patches for moto while waiting for upstream releases. This document outlines the process for creating and applying patches to moto in our integration test environment.
+
+## Steps to Patch Moto
+
+1. Create a `moto-patches` directory in `test/integration/infra/` if it doesn't exist:
+   ```bash
+   mkdir -p test/integration/infra/moto-patches
+   ```
+
+2. Generate a patch file, ideally open a PR upstream with the changes and store in the `moto-patches` folder.
+
+3. Update the Dockerfile to apply the patch:
+   ```dockerfile
+   # Install moto from specific commit
+   RUN pip install --user 'moto[server] @ git+https://github.com/getmoto/moto.git@<commit-hash>'
+
+   # Copy and apply patches
+   COPY test/integration/infra/moto-patches/*.patch /moto-patches/
+   RUN patch -p1 -d /root/.local/lib/python*/site-packages/ < /moto-patches/your-patch.patch
+   ```
+
+## Best Practices
+
+1. Name patch files with a descriptive name or PR number (e.g., `8710.patch`)
+2. Document the reason for the patch in the patch file header
+3. Include the upstream issue/PR reference if available
+4. Remove patches once they are included in an upstream release
+5. Keep patches minimal and focused on specific issues
+
+## Removing Patches
+
+Once a patch is included in an upstream release:
+1. Remove the patch file from `test/integration/infra/moto-patches/`
+2. Update the moto installation in the Dockerfile to use the new release
+3. Remove the patch application command from the Dockerfile

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -263,6 +263,11 @@ function mock::kubelet() {
   chmod +x /usr/bin/kubelet
 }
 
+function mock::aws_signing_helper() {
+  printf "#!/usr/bin/env bash\necho '{\"Version\": 1, \"AccessKeyId\": \"${AWS_ACCESS_KEY_ID}\", \"SecretAccessKey\": \"${AWS_SECRET_ACCESS_KEY}\", \"SessionToken\": \"${AWS_SESSION_TOKEN}\"}'" > /usr/local/bin/aws_signing_helper
+  chmod +x /usr/local/bin/aws_signing_helper
+}
+
 function mock::ssm() {
   # mock ssm agent binary
   if [ -e  /usr/bin/amazon-ssm-agent]; then

--- a/test/integration/infra/Dockerfile
+++ b/test/integration/infra/Dockerfile
@@ -15,8 +15,12 @@ RUN mv _bin/nodeadm /nodeadm
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN dnf -y update && \
-    dnf -y install systemd containerd jq python3 awscli tar procps && \
+    dnf -y install systemd containerd jq python3 tar procps zip && \
     dnf clean all
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip    
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
     rm get-pip.py

--- a/test/integration/infra/Dockerfile
+++ b/test/integration/infra/Dockerfile
@@ -15,7 +15,7 @@ RUN mv _bin/nodeadm /nodeadm
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN dnf -y update && \
-    dnf -y install systemd containerd jq python3 tar procps zip && \
+    dnf -y install systemd containerd jq git-core python3 tar procps zip && \
     dnf clean all
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
@@ -24,7 +24,11 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "aws
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
     rm get-pip.py
-RUN pip install --user 'moto[server]'
+# install moto from main to fix eks timestamp issue
+# remove when there is a new moto release with this commit included
+RUN pip install --user 'moto[server] @ git+https://github.com/getmoto/moto.git@5edb0c50b88db96d3a90b3f69096317ba2daf04c'
+
+
 # I know how this looks, but it lets us use moto with our mocked IMDS and for now the simplicity is worth the hack
 RUN sed -i 's/= random_instance_id()/= "i-1234567890abcdef0"/g' $HOME/.local/lib/python*/site-packages/moto/ec2/models/instances.py
 COPY --from=imds-mock-build /imds-mock /usr/local/bin/imds-mock


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When working on a new debug command validation, I wanted to validate that config enrichment worked during that command flow.  I realized we did not have any integration test that mocked the eks api.  

This adds a new test, more so as an example since our e2e tests validation config enrichment, that shows how to mock the eks api, with iam-ra, and validates that if the ca/remoteconfig/apiendpoint arent supplied via the config, they are pulled from the eks api.

We needed a [fix](https://github.com/getmoto/moto/pull/8710) to moto due to moto's handling of timestamp types for eks clusters, but there was already a PR open which merged today.  For now, the second commit, installs moto from a specific commit has. Once there is a new release we can revert that commit.

I originally implemented this by patching moto after install doing something like this.  This could be helpful in the future if we run into other cases with moto where we need to temporarily patch while waiting on a release.  We should have a way to handle this and not be blocked on their release timeline.

```
RUN pip install --user 'moto[server] @ git+https://github.com/getmoto/moto.git@0637c5c46a1f49a1ce3defff8e508d6f140344f8'

COPY test/integration/infra/moto-patches/*.patch /moto-patches/
RUN patch -p1 -d /root/.local/lib/python*/site-packages/ < /moto-patches/8710.patch
```

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

