### PR TITLE
test: add integration test for ip-validation

### DIFF
--- a/internal/node/hybrid/ip_validator_test.go
+++ b/internal/node/hybrid/ip_validator_test.go
@@ -34,6 +34,11 @@ func TestHybridNodeProvider_ValidateNodeIP(t *testing.T) {
 						Flags: []string{"--node-ip=10.0.0.3"},
 					},
 				},
+				Status: api.NodeConfigStatus{
+					Hybrid: api.HybridDetails{
+						NodeName: "node1.example.com",
+					},
+				},
 			},
 			cluster: &types.Cluster{
 				Name: aws.String("test-cluster"),
@@ -46,12 +51,18 @@ func TestHybridNodeProvider_ValidateNodeIP(t *testing.T) {
 				},
 			},
 			network: &mockNetwork{
-				DNSRecords:       map[string][]net.IP{},
+				DNSRecords: map[string][]net.IP{
+					"node1.example.com": {net.ParseIP("1.2.3.4")},
+				},
 				ResolvedBindAddr: net.ParseIP("192.1.1.1"),
 				BindAddrErr:      nil,
 				NetworkInterfaces: []net.Addr{
 					&net.IPNet{
 						IP:   net.ParseIP("192.1.1.1"),
+						Mask: net.CIDRMask(24, 32),
+					},
+					&net.IPNet{
+						IP:   net.ParseIP("1.2.3.4"),
 						Mask: net.CIDRMask(24, 32),
 					},
 					&net.IPNet{

--- a/test/integration/cases/init-with-node-ip-validation/config-ip-in-range.yaml
+++ b/test/integration/cases/init-with-node-ip-validation/config-ip-in-range.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: test-cluster
+    region: us-west-2
+  kubelet:
+    flags:
+      - --node-ip=172.16.0.1
+  hybrid:
+    iamRolesAnywhere:
+      nodeName: mock-hybrid-node
+      awsConfigPath: /.aws/config
+      roleArn: arn:aws:iam::123456789010:role/mockHybridNodeRole
+      profileArn: arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole
+      trustAnchorArn: arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7

--- a/test/integration/cases/init-with-node-ip-validation/config-ip-out-of-range.yaml
+++ b/test/integration/cases/init-with-node-ip-validation/config-ip-out-of-range.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: test-cluster
+    region: us-west-2
+  kubelet:
+    flags:
+      - --node-ip=1.2.3.4
+  hybrid:
+    iamRolesAnywhere:
+      nodeName: mock-hybrid-node
+      awsConfigPath: /.aws/config
+      roleArn: arn:aws:iam::123456789010:role/mockHybridNodeRole
+      profileArn: arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole
+      trustAnchorArn: arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7

--- a/test/integration/cases/init-with-node-ip-validation/run.sh
+++ b/test/integration/cases/init-with-node-ip-validation/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+
+aws eks create-cluster \
+    --name test-cluster \
+    --region us-west-2 \
+    --kubernetes-version 1.30 \
+    --role-arn arn:aws:iam::123456789010:role/mockHybridNodeRole \
+    --resources-vpc-config "subnetIds=subnet-1,subnet-2,endpointPublicAccess=true" \
+    --remote-network-config '{"remoteNodeNetworks":[{"cidrs":["172.16.0.0/24"]}],"remotePodNetworks":[{"cidrs":["10.0.0.0/8"]}]}'
+
+wait::dbus-ready
+
+mkdir -p /etc/iam/pki
+touch  /etc/iam/pki/server.pem
+touch  /etc/iam/pki/server.key
+
+nodeadm install 1.30 --credential-provider iam-ra
+
+mock::aws_signing_helper
+
+# should fail when --node-ip set to ip not in remote node networks
+if nodeadm init --skip run --config-source file://config-ip-out-of-range.yaml; then
+    echo "nodeadm init should have failed with ip out of range but succeeded unexpectedly"
+    exit 1
+fi
+
+# should succeed when --node-ip set to ip in remote node networks
+nodeadm init --skip run --config-source file://config-ip-in-range.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds an integration test for `node-ip-validation` init flag and updates the unit test with passing node-ip validation flag so that the test case includes a DNS record; this ensures that the --node-ip flag value is used first

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

