### PR TITLE
Log instanceID when creating EC2 instace for hybrid testing

### DIFF
--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -136,6 +136,7 @@ func (c NodeCreate) Create(ctx context.Context, spec *NodeSpec) (ec2.Instance, e
 		return ec2.Instance{}, fmt.Errorf("EC2 Instance should have been created successfully: %w", err)
 	}
 
+	c.Logger.Info("A Hybrid EC2 instace is created", "instanceID", instance.ID)
 	return instance, nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Log instanceID when creating EC2 instace for hybrid testing

Currently when running hybrid test, it does not output instance ID for EC2, which is not convenient, especially in scenarios that we want to ssh into the EC2 instance for some inspection. We can of course find out the instance ID using aws console but it is annoying.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

