### PR TITLE
Use DefaultBackoff retry for ExecPodWithRetries

### DIFF
--- a/test/e2e/kubernetes/kubernetes.go
+++ b/test/e2e/kubernetes/kubernetes.go
@@ -495,7 +495,7 @@ func getPodLogs(ctx context.Context, k8s *kubernetes.Clientset, name, namespace 
 
 // Retries up to 5 times to avoid connection errors
 func ExecPodWithRetries(ctx context.Context, config *restclient.Config, k8s *kubernetes.Clientset, name, namespace string, cmd ...string) (stdout, stderr string, err error) {
-	err = retry.OnError(retry.DefaultRetry, func(err error) bool {
+	err = retry.OnError(retry.DefaultBackoff, func(err error) bool {
 		// Retry any error type
 		return true
 	}, func() error {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We are seeing a sporadic issue that pod identity fails to get aws credentials although we have implemented retry strategy.  

```
exec aws sts get-caller-identity command on pod awscli-mi-0aa3f3ba93b69a6c3: err: command terminated with exit code 255, stdout:
Error when retrieving credentials from container-role: Error retrieving metadata: Received error when attempting to retrieve container metadata: Connect timeout on endpoint URL: "http://169.254.170.23/v1/credentials"
```

So far we have no clue why this happens. In this PR, I am changing `retry.DefaultRetry` to `retry.DefaultBackoff` in `ExecPodWithRetries` so that it can wait a bit more time when retrying the pod exec command.
 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

