### PR TITLE
removes aws config and ssm symlink on uninstall

### DIFF
--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/eks-hybrid/internal/logger"
 	"github.com/aws/eks-hybrid/internal/node"
 	"github.com/aws/eks-hybrid/internal/packagemanager"
-	"github.com/aws/eks-hybrid/internal/ssm"
 	"github.com/aws/eks-hybrid/internal/tracker"
 )
 
@@ -122,7 +121,6 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		Artifacts:      installed.Artifacts,
 		DaemonManager:  daemonManager,
 		PackageManager: packageManager,
-		SSMUninstall:   ssm.DeregisterAndUninstall,
 		Logger:         log,
 		CNIUninstall:   cni.Uninstall,
 	}

--- a/internal/ssm/aws.go
+++ b/internal/ssm/aws.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 )
 
-func isInstanceManaged(client *awsSsm.Client, instanceId string) (bool, error) {
+func isInstanceManaged(client SSMClient, instanceId string) (bool, error) {
 	output, err := client.DescribeInstanceInformation(context.Background(), &awsSsm.DescribeInstanceInformationInput{
 		Filters: []types.InstanceInformationStringFilter{
 			{
@@ -24,7 +24,7 @@ func isInstanceManaged(client *awsSsm.Client, instanceId string) (bool, error) {
 	return len(output.InstanceInformationList) > 0, nil
 }
 
-func deregister(client *awsSsm.Client, instanceId string) error {
+func deregister(client SSMClient, instanceId string) error {
 	_, err := client.DeregisterManagedInstance(context.Background(), &awsSsm.DeregisterManagedInstanceInput{
 		InstanceId: &instanceId,
 	})

--- a/internal/ssm/install_test.go
+++ b/internal/ssm/install_test.go
@@ -2,15 +2,22 @@ package ssm_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/ProtonMail/gopenpgp/v3/crypto"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsSsm "github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 
+	"github.com/aws/eks-hybrid/internal/artifact"
 	"github.com/aws/eks-hybrid/internal/ssm"
 	"github.com/aws/eks-hybrid/internal/test"
 	"github.com/aws/eks-hybrid/internal/tracker"
@@ -89,7 +96,6 @@ func TestInstall(t *testing.T) {
 			g := NewGomegaWithT(t)
 
 			tmpDir := t.TempDir()
-			installerPath := filepath.Join(tmpDir, "ssm-setup-cli")
 
 			server := test.NewHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
 				if tt.statusCode != http.StatusOK {
@@ -121,10 +127,10 @@ func TestInstall(t *testing.T) {
 			logger := zap.NewNop()
 
 			err := ssm.Install(context.Background(), ssm.InstallOptions{
-				Tracker:       tr,
-				Source:        source,
-				Logger:        logger,
-				InstallerPath: installerPath,
+				Tracker:     tr,
+				Source:      source,
+				Logger:      logger,
+				InstallRoot: tmpDir,
 			})
 
 			if tt.wantErr != "" {
@@ -135,11 +141,182 @@ func TestInstall(t *testing.T) {
 
 			g.Expect(err).NotTo(HaveOccurred())
 
-			installedData, err := os.ReadFile(installerPath)
+			installedData, err := os.ReadFile(tmpDir + "/opt/ssm/ssm-setup-cli")
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(installedData).To(Equal(tt.installerData))
 
 			g.Expect(tr.Artifacts.Ssm).To(BeTrue())
+		})
+	}
+}
+
+type MockSSMClient struct {
+	g                                 *GomegaWithT
+	instanceId                        string
+	describeInstanceInformationOutput *awsSsm.DescribeInstanceInformationOutput
+	describeInstanceInformationErr    error
+	deregisterManagedInstanceOutput   *awsSsm.DeregisterManagedInstanceOutput
+	deregisterManagedInstanceErr      error
+}
+
+func (m *MockSSMClient) DescribeInstanceInformation(ctx context.Context, params *awsSsm.DescribeInstanceInformationInput, optFns ...func(*awsSsm.Options)) (*awsSsm.DescribeInstanceInformationOutput, error) {
+	m.g.Expect(*params.Filters[0].Key).To(Equal("InstanceIds"))
+	m.g.Expect(params.Filters[0].Values[0]).To(Equal(m.instanceId))
+	return m.describeInstanceInformationOutput, m.describeInstanceInformationErr
+}
+
+func (m *MockSSMClient) DeregisterManagedInstance(ctx context.Context, params *awsSsm.DeregisterManagedInstanceInput, optFns ...func(*awsSsm.Options)) (*awsSsm.DeregisterManagedInstanceOutput, error) {
+	m.g.Expect(*params.InstanceId).To(Equal(m.instanceId))
+	return m.deregisterManagedInstanceOutput, m.deregisterManagedInstanceErr
+}
+
+type TestPackageManager struct {
+	mock.Mock
+	InstallRoot string
+}
+
+func (m *TestPackageManager) GetSSMPackage() artifact.Package {
+	return artifact.NewPackageSource(
+		artifact.NewCmd("not-used", "install", "amazon-ssm-agent"),
+		artifact.NewCmd("rm", "-rf", filepath.Join(m.InstallRoot, "/usr/bin/ssm-agent-worker")),
+		artifact.NewCmd("not-used", "update", "amazon-ssm-agent"),
+	)
+}
+
+func TestUninstall(t *testing.T) {
+	tests := []struct {
+		name                              string
+		registration                      ssm.HybridInstanceRegistration
+		registrationErr                   error
+		describeInstanceInformationOutput *awsSsm.DescribeInstanceInformationOutput
+		describeInstanceInformationErr    error
+		deregisterManagedInstanceOutput   *awsSsm.DeregisterManagedInstanceOutput
+		deregisterManagedInstanceErr      error
+		wantErr                           string
+	}{
+		{
+			name:            "registration file does not exist",
+			registrationErr: os.ErrNotExist,
+			wantErr:         "",
+		},
+		{
+			name: "instance is managed and deregister succeeds",
+			registration: ssm.HybridInstanceRegistration{
+				ManagedInstanceID: "i-1234567890abcdef0",
+				Region:            "us-west-2",
+			},
+			describeInstanceInformationOutput: &awsSsm.DescribeInstanceInformationOutput{
+				InstanceInformationList: []types.InstanceInformation{
+					{
+						InstanceId: aws.String("i-1234567890abcdef0"),
+					},
+				},
+			},
+			deregisterManagedInstanceOutput: &awsSsm.DeregisterManagedInstanceOutput{},
+		},
+		{
+			name: "instance is managed but deregister fails",
+			registration: ssm.HybridInstanceRegistration{
+				ManagedInstanceID: "i-1234567890abcdef0",
+				Region:            "us-west-2",
+			},
+			describeInstanceInformationOutput: &awsSsm.DescribeInstanceInformationOutput{
+				InstanceInformationList: []types.InstanceInformation{
+					{
+						InstanceId: aws.String("i-1234567890abcdef0"),
+					},
+				},
+			},
+			deregisterManagedInstanceOutput: &awsSsm.DeregisterManagedInstanceOutput{},
+			deregisterManagedInstanceErr:    fmt.Errorf("deregister failed"),
+			wantErr:                         "deregistering ssm managed instance: deregister failed",
+		},
+		{
+			name: "instance is not managed",
+			registration: ssm.HybridInstanceRegistration{
+				ManagedInstanceID: "i-1234567890abcdef0",
+				Region:            "us-west-2",
+			},
+			describeInstanceInformationOutput: &awsSsm.DescribeInstanceInformationOutput{
+				InstanceInformationList: []types.InstanceInformation{},
+			},
+			wantErr: "",
+		},
+		{
+			name: "check managed status fails",
+			registration: ssm.HybridInstanceRegistration{
+				ManagedInstanceID: "i-1234567890abcdef0",
+				Region:            "us-west-2",
+			},
+			describeInstanceInformationErr: fmt.Errorf("check managed status failed"),
+			wantErr:                        "getting managed instance information: check managed status failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			tmpDir := t.TempDir()
+			var registrationFile string
+			// Create registration file if needed
+			if tt.registration.ManagedInstanceID != "" {
+				registrationFile = filepath.Join(tmpDir, "/var/lib/amazon/ssm/registration")
+				data, err := json.Marshal(tt.registration)
+				g.Expect(err).NotTo(HaveOccurred())
+				err = os.MkdirAll(filepath.Dir(registrationFile), 0o755)
+				g.Expect(err).NotTo(HaveOccurred())
+				err = os.WriteFile(registrationFile, data, 0o644)
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+
+			// not matter if the instnace is registered or not, the aws config files should be removed
+			err := os.MkdirAll(filepath.Join(tmpDir, "/root/.aws"), 0o755)
+			g.Expect(err).NotTo(HaveOccurred())
+			err = os.MkdirAll(filepath.Join(tmpDir, "/eks-hybrid/.aws"), 0o755)
+			g.Expect(err).NotTo(HaveOccurred())
+			err = os.MkdirAll(filepath.Join(tmpDir, "/etc/amazon"), 0o755)
+			g.Expect(err).NotTo(HaveOccurred())
+			// ensure the ssm-agent-worker file is removed via the testpkgsource removal
+			err = os.MkdirAll(filepath.Join(tmpDir, "/usr/bin"), 0o755)
+			g.Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(filepath.Join(tmpDir, "/usr/bin/ssm-agent-worker"), []byte(""), 0o644)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Create and setup mock SSM client
+			mockSSM := MockSSMClient{
+				g:                                 g,
+				instanceId:                        tt.registration.ManagedInstanceID,
+				describeInstanceInformationOutput: tt.describeInstanceInformationOutput,
+				describeInstanceInformationErr:    tt.describeInstanceInformationErr,
+				deregisterManagedInstanceOutput:   tt.deregisterManagedInstanceOutput,
+				deregisterManagedInstanceErr:      tt.deregisterManagedInstanceErr,
+			}
+
+			err = ssm.Uninstall(context.Background(), ssm.UninstallOptions{
+				Logger:          zap.NewNop(),
+				SSMRegistration: ssm.NewSSMRegistration(ssm.WithInstallRoot(tmpDir)),
+				SSMClient:       &mockSSM,
+				PkgSource: &TestPackageManager{
+					InstallRoot: tmpDir,
+				},
+				InstallRoot: tmpDir,
+			})
+
+			if tt.wantErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+
+			if tt.registration.ManagedInstanceID != "" {
+				g.Expect(registrationFile).NotTo(BeAnExistingFile())
+			}
+			g.Expect(filepath.Join(tmpDir, "/etc/amazon")).NotTo(BeADirectory())
+			g.Expect(filepath.Join(tmpDir, "/root/.aws")).NotTo(BeADirectory())
+			g.Expect(filepath.Join(tmpDir, "/eks-hybrid/.aws")).NotTo(BeADirectory())
+			g.Expect(filepath.Join(tmpDir, "/usr/bin/ssm-agent-worker")).NotTo(BeAnExistingFile())
 		})
 	}
 }

--- a/internal/ssm/registration.go
+++ b/internal/ssm/registration.go
@@ -1,0 +1,129 @@
+package ssm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	awsSsm "github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+const registrationFilePath = "/var/lib/amazon/ssm/registration"
+
+type SSMRegistration struct {
+	installRoot string
+}
+
+type SSMRegistrationOption func(*SSMRegistration)
+
+func NewSSMRegistration(opts ...SSMRegistrationOption) *SSMRegistration {
+	c := &SSMRegistration{}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+type SSMClient interface {
+	DescribeInstanceInformation(ctx context.Context, params *awsSsm.DescribeInstanceInformationInput, optFns ...func(*awsSsm.Options)) (*awsSsm.DescribeInstanceInformationOutput, error)
+	DeregisterManagedInstance(ctx context.Context, params *awsSsm.DeregisterManagedInstanceInput, optFns ...func(*awsSsm.Options)) (*awsSsm.DeregisterManagedInstanceOutput, error)
+}
+
+func WithInstallRoot(installRoot string) SSMRegistrationOption {
+	return func(c *SSMRegistration) {
+		c.installRoot = installRoot
+	}
+}
+
+func Deregister(ctx context.Context, registration *SSMRegistration, ssmClient SSMClient, logger *zap.Logger) error {
+	instanceId, err := registration.GetManagedHybridInstanceId()
+
+	// If uninstall is being run just after running install and before running init
+	// SSM would not be fully installed and registered, hence it's not required to run
+	// deregister instance.
+	if err != nil && os.IsNotExist(err) {
+		logger.Info("Skipping SSM deregistration - node is not registered")
+		return nil
+	}
+	if err != nil {
+		return errors.Wrapf(err, "reading ssm registration file")
+	}
+
+	managed, err := isInstanceManaged(ssmClient, instanceId)
+	if err != nil {
+		return errors.Wrapf(err, "getting managed instance information")
+	}
+
+	// Only deregister the instance if init/ssm init was run and
+	// if instances is actively listed as managed
+	if managed {
+		if err := deregister(ssmClient, instanceId); err != nil {
+			return errors.Wrapf(err, "deregistering ssm managed instance")
+		}
+	}
+	return nil
+}
+
+func (r *SSMRegistration) getManagedHybridInstanceIdAndRegion() (string, string, error) {
+	data, err := os.ReadFile(r.RegistrationFilePath())
+	if err != nil {
+		return "", "", err
+	}
+
+	var registration HybridInstanceRegistration
+	err = json.Unmarshal(data, &registration)
+	if err != nil {
+		return "", "", err
+	}
+	return registration.ManagedInstanceID, registration.Region, nil
+}
+
+// GetRegion returns the region of the managed hybrid instance
+// If the instance is not registered, it returns an empty string
+// errors are ignored and an empty string is returned
+func (r *SSMRegistration) GetRegion() string {
+	registered, err := r.isRegistered()
+	if err != nil || !registered {
+		return ""
+	}
+	_, region, err := r.getManagedHybridInstanceIdAndRegion()
+	if err != nil {
+		return ""
+	}
+	return region
+}
+
+func (r *SSMRegistration) GetManagedHybridInstanceId() (string, error) {
+	data, err := os.ReadFile(r.RegistrationFilePath())
+	if err != nil {
+		return "", err
+	}
+
+	var registration HybridInstanceRegistration
+	err = json.Unmarshal(data, &registration)
+	if err != nil {
+		return "", err
+	}
+	return registration.ManagedInstanceID, nil
+}
+
+func (r *SSMRegistration) isRegistered() (bool, error) {
+	_, err := r.GetManagedHybridInstanceId()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading ssm registration file: %w", err)
+	}
+	return true, nil
+}
+
+// RegistrationFilePath returns the path to the SSM registration file
+// If installRoot is not set, it will return the path starting from the disk root
+func (r *SSMRegistration) RegistrationFilePath() string {
+	return filepath.Join(r.installRoot, registrationFilePath)
+}

--- a/test/integration/cases/init-with-ssm/config.yaml
+++ b/test/integration/cases/init-with-ssm/config.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+    region: us-west-2
+  hybrid:
+    enableCredentialsFile: true
+    ssm:
+      activationCode: ys25k3gpt8zzyl9jhn6gq8rj3519owjelyz7
+      activationId: 57be8cce-1137-32d4-ce32-ba044ea5df48

--- a/test/integration/cases/init-with-ssm/run.sh
+++ b/test/integration/cases/init-with-ssm/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+wait::dbus-ready
+
+# remove previously installed containerd to test installation via nodeadm
+dnf remove -y containerd
+
+nodeadm install 1.31 --credential-provider ssm
+
+mock::ssm
+nodeadm init --skip run,preprocess,node-ip-validation --config-source file://config.yaml
+
+assert::path-exists /root/.aws
+assert::path-exists /eks-hybrid/.aws
+
+# remove ssm registration so ssm skips trying to deregister during uninstall
+rm /var/lib/amazon/ssm/registration
+nodeadm uninstall --skip node-validation,pod-validation
+
+# Verify AWS config and symlink are removed after uninstall
+assert::path-not-exist /root/.aws
+assert::path-not-exist /eks-hybrid/.aws
+assert::path-not-exist /usr/bin/ssm-agent-worker
+assert::path-not-exist /etc/amazon
+assert::path-not-exist /var/lib/amazon/ssm/registration
+

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -270,12 +270,12 @@ function mock::aws_signing_helper() {
 
 function mock::ssm() {
   # mock ssm agent binary
-  if [ -e  /usr/bin/amazon-ssm-agent]; then
+  if [ -e  /usr/bin/amazon-ssm-agent ]; then
     printf "#!/usr/bin/env bash\necho SSM" > /usr/bin/amazon-ssm-agent
     chmod +x /usr/bin/amazon-ssm-agent
   fi
 
-  if [ -e  /snap/amazon-ssm-agent/current/amazon-ssm-agent]; then
+  if [ -e  /snap/amazon-ssm-agent/current/amazon-ssm-agent ]; then
     printf "#!/usr/bin/env bash\necho SSM" > /snap/amazon-ssm-agent/current/amazon-ssm-agent"
     chmod +x /snap/amazon-ssm-agent/current/amazon-ssm-agent"
   fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Weve seen an issue in our e2e tests where when a node rejoins, after running uninstall, ssm can sometimes take a few iterations of its cred refresh loop to get the new creds for the newly activated hybrid node.  While this is happening, kubelet has already exec'd iam-auth to get creds which are for the previous hybrid activation, which is still valid.  These valid creds are cached, but the kubelet cant use them to register itself because its using the old nodes creds.

This removes the aws config file and symlink that we create for ssm to ensure that on uninstall, the creds are all removed and cant be reused after reinstalling. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

