### PR TITLE
Set timeoutSeconds and periodSeconds for readiness probe

### DIFF
--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -107,6 +107,8 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 						// default value for initialDelaySeconds is 0 and for periodSeconds is 10
 						// it would fail readiness probe after 5 failures (50 seconds)
 						FailureThreshold: 5,
+						TimeoutSeconds:   20,
+						PeriodSeconds:    20,
 					},
 				},
 			},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fine tune timeoutSeconds and periodSeconds to improve reliability for pod identity test.
Default timeoutSeconds is 1 so our probe considers the command execution `aws sts get-caller-identity` failed if it does not receive response within 1 seconds. However this is a remote call, which can takes more than 1 seconds to complete. Without this change, current setting for probe causes pod in `NotReady` state.   

*Testing (if applicable):*
Manually triggered the CI in dev stack and it succeeded multiple times. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

