### PR TITLE
use regional ecr for awscli image

### DIFF
--- a/buildspecs/ecr-cache.yml
+++ b/buildspecs/ecr-cache.yml
@@ -7,3 +7,4 @@ phases:
     - ./test/e2e/cni/testdata/cilium/mirror-cilium.sh
     - ./test/e2e/cni/testdata/calico/mirror-calico.sh
     - for region in "us-west-2" "us-west-1"; do docker buildx imagetools inspect "381492195191.dkr.ecr.${region}.amazonaws.com/ecr-public/nginx/nginx:latest"; done
+    - for region in "us-west-2" "us-west-1"; do docker buildx imagetools inspect "381492195191.dkr.ecr.${region}.amazonaws.com/ecr-public/aws-cli/aws-cli:latest"; done

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -15,6 +15,7 @@ import (
 	clientgo "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/aws/eks-hybrid/test/e2e/constants"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 )
 
@@ -37,6 +38,7 @@ type VerifyPodIdentityAddon struct {
 	S3Client            *s3.Client
 	Logger              logr.Logger
 	K8SConfig           *rest.Config
+	Region              string
 }
 
 type PolicyDocument struct {
@@ -90,7 +92,7 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 			Containers: []corev1.Container{
 				{
 					Name:  podName,
-					Image: "public.ecr.aws/aws-cli/aws-cli",
+					Image: fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/ecr-public/aws-cli/aws-cli:latest", constants.EcrAccounId, v.Region),
 					Command: []string{
 						"/bin/bash",
 						"-c",

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -595,6 +595,7 @@ func (t *peeredVPCTest) newVerifyPodIdentityAddon(nodeIP string) *addon.VerifyPo
 		S3Client:            t.s3Client,
 		Logger:              t.logger,
 		K8SConfig:           t.k8sClientConfig,
+		Region:              t.cluster.Region,
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Match nginx and cni images by using regional ecr repos.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

