### PR TITLE
Refactor: use Interface instead of Clientset for kubernetes APIs in e2e

### DIFF
--- a/test/e2e/addon/podidentityaddon.go
+++ b/test/e2e/addon/podidentityaddon.go
@@ -39,7 +39,7 @@ func NewPodIdentityAddon(cluster, roleArn string) PodIdentityAddon {
 	}
 }
 
-func (p PodIdentityAddon) Create(ctx context.Context, logger logr.Logger, eksClient *eks.Client, k8sClient *clientgo.Clientset) error {
+func (p PodIdentityAddon) Create(ctx context.Context, logger logr.Logger, eksClient *eks.Client, k8sClient clientgo.Interface) error {
 	if err := p.Addon.Create(ctx, eksClient, logger); err != nil {
 		return err
 	}

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -32,7 +32,7 @@ type VerifyPodIdentityAddon struct {
 	Cluster             string
 	NodeIP              string
 	PodIdentityS3Bucket string
-	K8S                 *clientgo.Clientset
+	K8S                 clientgo.Interface
 	EKSClient           *eks.Client
 	IAMClient           *iam.Client
 	S3Client            *s3.Client

--- a/test/e2e/kubernetes/verify.go
+++ b/test/e2e/kubernetes/verify.go
@@ -18,7 +18,7 @@ const (
 // VerifyNode checks that a node is healthy, can run pods, extract logs and run commands on them.
 type VerifyNode struct {
 	ClientConfig *rest.Config
-	K8s          *clientgo.Clientset
+	K8s          clientgo.Interface
 	Logger       logr.Logger
 	Region       string
 

--- a/test/e2e/nodeadm/uninstall.go
+++ b/test/e2e/nodeadm/uninstall.go
@@ -13,7 +13,7 @@ import (
 
 // CleanNode runs the process to unregister a node from the cluster and uninstall all the installed kubernetes dependencies.
 type CleanNode struct {
-	K8s                 *clientgo.Clientset
+	K8s                 clientgo.Interface
 	RemoteCommandRunner commands.RemoteCommandRunner
 	Verifier            UninstallVerifier
 	Logger              logr.Logger

--- a/test/e2e/nodeadm/upgrade.go
+++ b/test/e2e/nodeadm/upgrade.go
@@ -15,7 +15,7 @@ import (
 // This assumes the current node's version meets the version skew policy and it can actually
 // be upgraded to the target version.
 type UpgradeNode struct {
-	K8s                 *clientgo.Clientset
+	K8s                 clientgo.Interface
 	RemoteCommandRunner commands.RemoteCommandRunner
 	Logger              logr.Logger
 

--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -205,7 +205,7 @@ type NodeCleanup struct {
 	SSM                 *ssm.Client
 	S3                  *s3sdk.Client
 	EC2                 *ec2sdk.Client
-	K8s                 *clientgo.Clientset
+	K8s                 clientgo.Interface
 	Logger              logr.Logger
 	RemoteCommandRunner commands.RemoteCommandRunner
 

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -76,7 +76,7 @@ type peeredVPCTest struct {
 	ec2Client       *ec2v2.Client
 	ssmClient       *ssmv2.Client
 	cfnClient       *cloudformation.Client
-	k8sClient       *clientgo.Clientset
+	k8sClient       clientgo.Interface
 	k8sClientConfig *rest.Config
 	s3Client        *s3v2.Client
 	iamClient       *iam.Client


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR only refactors kubernetes API call to use `Interface` instead of `Clientset`. There is no functional change. 

This is to make PR #363 smaller and easier to review and test. 


*Testing (if applicable):*
Tested locally

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

