### PR TITLE
Improve pod identity bucket name

### DIFF
--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -24,8 +24,7 @@ const (
 	podIdentityDaemonSet      = "eks-pod-identity-agent-hybrid"
 	podIdentityToken          = "eks-pod-identity-token"
 	policyName                = "pod-identity-association-role-policy"
-	PodIdentityS3Bucket       = "PodIdentityS3Bucket"
-	PodIdentityS3BucketPrefix = "podidentitys3bucket"
+	PodIdentityS3BucketPrefix = "podid"
 )
 
 type VerifyPodIdentityAddon struct {

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -420,20 +420,10 @@ Resources:
     Properties:
       # use a predictable prefix for PodIdentity S3 bucket while maintaining uniqueness requirement for S3 bucket name
       BucketName:
-        Fn::Join:
-        - '-'
-        - - !Ref PodIdentityS3BucketPrefix
-          - !Ref AWS::AccountId
-          - !Ref AWS::Region
-          - Fn::Select:
-            - 0
-            - Fn::Split:
-              - '-'
-              - Fn::Select:
-                - 2
-                - Fn::Split:
-                  - /
-                  - !Ref AWS::StackId
+        !Sub
+          - '${PodIdentityS3BucketPrefix}-${AWS::AccountId}${TrimmedRegion}${UUID}' # podid-111111111uswest26d51lki0f4111f0b84e0a85c34565b7
+          - TrimmedRegion: !Join ['', !Split ['-', !Ref AWS::Region ]] # us-west-2 -> uswest2
+            UUID: !Join ['', !Split ['-', !Select [2, !Split [/, !Ref AWS::StackId ]]]] # arn:aws:cloudformation:us-west-2:111111111:stack/EKSHybridCI-Arch-name/6d51lki0-0f41-11f0-b84e-0a85c34565b7 -> 6d51lki0f4111f0b84e0a85c34565b7
       Tags:
         - Key: !Ref TestClusterTagKey
           Value: !Ref ClusterName

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -151,7 +151,7 @@ func (s *stack) prepareStackParameters(test TestResources) []types.Parameter {
 		},
 		{
 			ParameterKey:   aws.String("PodIdentityS3BucketPrefix"),
-			ParameterValue: aws.String(strings.ToLower(addon.PodIdentityS3Bucket)),
+			ParameterValue: aws.String(addon.PodIdentityS3BucketPrefix),
 		},
 		{
 			ParameterKey:   aws.String("RolePathPrefix"),


### PR DESCRIPTION
*Description of changes:*
With the previous code there was a chance of collision between stacks if their UUIDs started with the same segment. Now we use the full UUID so collisions should not happen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

