### PR TITLE
ignore NoSuchTagSet when finding s3 buckets to cleanup

### DIFF
--- a/test/e2e/addon/podidentitybucket.go
+++ b/test/e2e/addon/podidentitybucket.go
@@ -28,7 +28,7 @@ func PodIdentityBucket(ctx context.Context, client *s3.Client, cluster string) (
 		getBucketTaggingOutput, err := client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
 			Bucket: bucket.Name,
 		})
-		if err != nil && e2eErrors.IsS3BucketNotFound(err) {
+		if err != nil && (e2eErrors.IsS3BucketNotFound(err) || e2eErrors.IsAwsError(err, "NoSuchTagSet")) {
 			// We have to pull all buckets and then get the tags
 			// the bucket could get deleted between the list and get tags call
 			continue

--- a/test/e2e/cleanup/s3.go
+++ b/test/e2e/cleanup/s3.go
@@ -40,7 +40,7 @@ func (s *S3Cleaner) ListBuckets(ctx context.Context, filterInput FilterInput) ([
 			tags, err := s.s3Client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
 				Bucket: bucket.Name,
 			})
-			if err != nil && errors.IsS3BucketNotFound(err) {
+			if err != nil && (errors.IsS3BucketNotFound(err) || errors.IsAwsError(err, "NoSuchTagSet")) {
 				// skipping log since we are possiblying checking buckets we do not
 				// intend to delete
 				continue

--- a/test/e2e/errors/aws.go
+++ b/test/e2e/errors/aws.go
@@ -27,3 +27,9 @@ func IsS3BucketNotFound(err error) bool {
 	return errors.As(err, &ae) &&
 		ae.ErrorCode() == "NoSuchBucket"
 }
+
+func IsAwsError(err error, code string) bool {
+	var awsErr smithy.APIError
+	ok := errors.As(err, &awsErr)
+	return err != nil && ok && awsErr.ErrorCode() == code
+}

--- a/test/e2e/errors/type.go
+++ b/test/e2e/errors/type.go
@@ -1,6 +1,8 @@
 package errors
 
-import "errors"
+import (
+	"errors"
+)
 
 // IsType returns true if any errors in the chain are of the specified type.
 func IsType[T error](err error, targetType T) bool {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We are seeing cases where the pre test sweeper is running to try and find old resources. Since s3 buckets require a second call to get the tags, we currently check for bucketnotexist when getting tags to handle the case where the bucket is deleted between the call of getting the buckets and the call to get the tags.  This changes now handles the opposite case where the bucket is created but the tagging is done yet.

Also added a check for a 403 when trying to delete the cluster, which happens when using the CI role which is limited by tags if the cluster is already deleted.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

