### PR TITLE
only count Its in TestFailed counter

### DIFF
--- a/test/e2e/run/report.go
+++ b/test/e2e/run/report.go
@@ -115,6 +115,7 @@ func (e *E2EReport) parseJSONReport(reportPath string) (E2EResult, error) {
 			continue
 		}
 
+		e2eResult.TestFailed = e2eResult.TestFailed + 1
 		if failedTest.InstanceName == "" {
 			reportErrors = append(reportErrors, fmt.Errorf("no instance name found for test"))
 			continue
@@ -130,8 +131,6 @@ func (e *E2EReport) parseJSONReport(reportPath string) (E2EResult, error) {
 		e2eResult.SetupLog = e2eResult.ArtifactsBucketPath + testSetupLogFile
 		e2eResult.CleanupLog = e2eResult.ArtifactsBucketPath + testCleanupLogFile
 	}
-
-	e2eResult.TestFailed = len(e2eResult.FailedTests)
 
 	return e2eResult, errors.Join(reportErrors...)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In ginkgo's output json, beforesuite/defercleanup are included in the "specs" and if they fail will show up in the "failedtest" slice and ultimately included in the slack message.  Leaving that for now, but improving the test count to only include `It`s which are the actual test in the numbers.  If we see lots of slack messages with the before/after stuff included in the failed tests and its confusing for people, we can look at rendering those differently.  

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

