### PR TITLE
improves run-e2e flow and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 _dist
 _bin
-
+__debug_bin*
 cover.out
 coverage.out
 .idea

--- a/test/e2e/run/e2e.go
+++ b/test/e2e/run/e2e.go
@@ -108,29 +108,24 @@ func (e *E2E) Run(ctx context.Context) (E2EResult, error) {
 	}
 
 	// After this point we are going to run as much as we can regardeless of potential errors
-	// and will collect all errors to return them at the end
-	allErrors := []error{}
-
-	runTestsPhases, err := e.runTests(ctx)
-	if err != nil {
-		allErrors = append(allErrors, err)
-	}
+	runTestsPhases := e.runTests(ctx)
 	phases = append(phases, runTestsPhases...)
 
-	e2eResult, err := e.parseReport(ctx)
-	phases, err = phaseCompleted(phases, phaseNameParseReport, "parsing report", err)
-	if err != nil {
-		allErrors = append(allErrors, err)
-	}
+	cleanupPhases := e.runCleanup(ctx)
+	phases = append(phases, cleanupPhases...)
 
-	err = e.uploadArtifactsToS3(ctx)
-	phases, err = phaseCompleted(phases, phaseNameUploadArtifactsToS3, "uploading logs to s3", err)
-	if err != nil {
-		allErrors = append(allErrors, err)
-	}
+	e2eResult, parsePhases := e.parseReport(ctx)
+	phases = append(phases, parsePhases...)
+
+	uploadPhases := e.uploadArtifactsToS3(ctx)
+	phases = append(phases, uploadPhases...)
 
 	e2eResult.Phases = phases
-	return e2eResult, errors.Join(allErrors...)
+	var allErrors error
+	for _, phase := range phases {
+		allErrors = errors.Join(allErrors, phase.Error)
+	}
+	return e2eResult, allErrors
 }
 
 func (e *E2E) initPaths() {
@@ -145,27 +140,27 @@ func (e *E2E) initPaths() {
 	e.Paths.SetupLog = filepath.Join(e.TestConfig.ArtifactsFolder, testSetupLogFile)
 }
 
-func phaseCompleted(phases []Phase, name, message string, err error) ([]Phase, error) {
+func phaseCompleted(phases []Phase, name, message string, err error) []Phase {
 	phase := Phase{Name: name, Status: "success"}
 	if err != nil {
 		phase.Error = fmt.Errorf("%s: %w", message, err)
 		phase.FailureMessage = err.Error()
 		phase.Status = "failure"
 	}
-	return append(phases, phase), phase.Error
+	return append(phases, phase)
 }
 
 // preTestSetup sets up the directories and writes the test configs
 // it returns the failed phase and an error if one occurred
 func (e *E2E) preTestSetup() ([]Phase, error) {
 	err := e.setupDirectories()
-	phases, err := phaseCompleted([]Phase{}, phaseNameSetupDirectories, "setting up directories", err)
+	phases := phaseCompleted([]Phase{}, phaseNameSetupDirectories, "setting up directories", err)
 	if err != nil {
 		return phases, err
 	}
 
 	err = e.writeTestConfigs()
-	phases, err = phaseCompleted(phases, phaseNameWriteTestConfigs, "creating test config", err)
+	phases = phaseCompleted(phases, phaseNameWriteTestConfigs, "creating test config", err)
 	if err != nil {
 		return phases, err
 	}
@@ -173,7 +168,7 @@ func (e *E2E) preTestSetup() ([]Phase, error) {
 	return phases, nil
 }
 
-func (e *E2E) runTests(ctx context.Context) ([]Phase, error) {
+func (e *E2E) runTests(ctx context.Context) []Phase {
 	runner := E2ERunner{
 		AwsCfg:          e.AwsCfg,
 		Logger:          e.Logger,
@@ -183,23 +178,47 @@ func (e *E2E) runTests(ctx context.Context) ([]Phase, error) {
 		TestProcs:       e.TestProcs,
 		TestTimeout:     e.TestTimeout,
 		TestResources:   e.TestResources,
-		SkipCleanup:     e.SkipCleanup,
 		SkippedTests:    e.SkippedTests,
 	}
-	return runner.Run(ctx)
+	phases := runner.Run(ctx)
+	for _, phase := range phases {
+		if phase.Error != nil {
+			e.Logger.Error(phase.Error, "Failed test running phase", "phase", phase.Name)
+		}
+	}
+	return phases
+}
+
+func (e *E2E) runCleanup(ctx context.Context) []Phase {
+	if e.SkipCleanup {
+		e.Logger.Info("Skipping cluster and infrastructure cleanup via stack deletion")
+		return []Phase{}
+	}
+
+	cleaner := E2ECleanup{
+		AwsCfg:        e.AwsCfg,
+		Logger:        newFileLogger(e.Paths.CleanupLog, e.NoColor),
+		TestResources: e.TestResources,
+	}
+	return cleaner.Run(ctx)
 }
 
 // parseReport parses the report and returns the E2EResult
 // on error an empty E2EResult is returned
-func (e *E2E) parseReport(ctx context.Context) (E2EResult, error) {
+func (e *E2E) parseReport(ctx context.Context) (E2EResult, []Phase) {
 	report := E2EReport{
 		ArtifactsFolder: e.TestConfig.ArtifactsFolder,
 	}
 
-	return report.Parse(ctx, e.Paths.ReportsFileJSON)
+	e2eResult, err := report.Parse(ctx, e.Paths.ReportsFileJSON)
+	phases := phaseCompleted([]Phase{}, phaseNameParseReport, "parsing report", err)
+	if err != nil {
+		e.Logger.Error(err, "Failed to parse report")
+	}
+	return e2eResult, phases
 }
 
-func (e *E2E) uploadArtifactsToS3(ctx context.Context) error {
+func (e *E2E) uploadArtifactsToS3(ctx context.Context) []Phase {
 	artifacts := E2EArtifacts{
 		ArtifactsFolder: e.TestConfig.ArtifactsFolder,
 		AwsCfg:          e.AwsCfg,
@@ -207,7 +226,12 @@ func (e *E2E) uploadArtifactsToS3(ctx context.Context) error {
 		LogsBucket:      e.TestConfig.LogsBucket,
 		LogsBucketPath:  e.Paths.LogsBucketPath,
 	}
-	return artifacts.Upload(ctx)
+	err := artifacts.Upload(ctx)
+	phases := phaseCompleted([]Phase{}, phaseNameUploadArtifactsToS3, "uploading artifacts to s3", err)
+	if err != nil {
+		e.Logger.Error(err, "Failed to upload artifacts to s3")
+	}
+	return phases
 }
 
 func (e *E2E) PrintResults(ctx context.Context, e2eResult E2EResult) error {
@@ -257,4 +281,8 @@ func (e *E2E) writeTestConfigs() error {
 		return fmt.Errorf("writing test resources: %w", err)
 	}
 	return nil
+}
+
+func newFileLogger(fileName string, noColor bool) logr.Logger {
+	return e2e.NewLogger(e2e.LoggerConfig{NoColor: noColor}, e2e.WithOutputFile(fileName))
 }

--- a/test/e2e/run/runner.go
+++ b/test/e2e/run/runner.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/go-logr/logr"
 
-	"github.com/aws/eks-hybrid/test/e2e"
 	"github.com/aws/eks-hybrid/test/e2e/cluster"
 )
 
@@ -27,50 +25,27 @@ type E2ERunner struct {
 	TestProcs       int
 	TestTimeout     string
 	TestResources   cluster.TestResources
-	SkipCleanup     bool
 	SkippedTests    string
 }
 
 // Run runs the E2E tests and returns the failure phase with the error
-func (e *E2ERunner) Run(ctx context.Context) ([]Phase, error) {
+func (e *E2ERunner) Run(ctx context.Context) []Phase {
 	phases := []Phase{}
-	// After this point, return err so that the defer cleanup can combine all potential
-	// errors into what is finally returned
-	var err error
-	defer func() {
-		if e.SkipCleanup {
-			e.Logger.Info("Skipping cluster and infrastructure cleanup via stack deletion")
-			return
-		}
-		cleaner := E2ECleanup{
-			AwsCfg:        e.AwsCfg,
-			Logger:        e.newFileLogger(e.Paths.CleanupLog),
-			TestResources: e.TestResources,
-		}
-		cleanupErr := cleaner.Run(ctx)
-		phases, cleanupErr = phaseCompleted(phases, phaseNameCleanupCluster, "cleaning up cluster", cleanupErr)
-		if cleanupErr != nil {
-			err = errors.Join(err, cleanupErr)
-		}
-	}()
 
-	setupErr := e.setupTestInfrastructure(ctx)
-	phases, setupErr = phaseCompleted(phases, phaseNameSetupTestInfrastructure, "setting up test infrastructure", setupErr)
-	if setupErr != nil {
-		err = setupErr
-		return phases, err
+	err := e.setupTestInfrastructure(ctx)
+	phases = phaseCompleted(phases, phaseNameSetupTestInfrastructure, "setting up test infrastructure", err)
+	if err != nil {
+		return phases
 	}
-	testsErr := e.executeTests(ctx)
-	phases, testsErr = phaseCompleted(phases, phaseNameExecuteTests, "executing tests", testsErr)
-	if testsErr != nil {
-		err = testsErr
-		return phases, err
-	}
-	return phases, nil
+
+	err = e.executeTests(ctx)
+	phases = phaseCompleted(phases, phaseNameExecuteTests, "executing tests", err)
+
+	return phases
 }
 
 func (e *E2ERunner) setupTestInfrastructure(ctx context.Context) error {
-	logger := e.newFileLogger(e.Paths.SetupLog)
+	logger := newFileLogger(e.Paths.SetupLog, e.NoColor)
 	create := cluster.NewCreate(e.AwsCfg, logger, e.TestResources.Endpoint)
 
 	logger.Info("Creating cluster infrastructure for E2E tests...")
@@ -150,8 +125,4 @@ func (e *E2ERunner) executeTests(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (e *E2ERunner) newFileLogger(fileName string) logr.Logger {
-	return e2e.NewLogger(e2e.LoggerConfig{NoColor: e.NoColor}, e2e.WithOutputFile(fileName))
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add more logging local to where the error may have happened to make tracking logs easier.  Improves use of the Phase concept and phaseComplete method by returning Phase, which already included the error, instead of both Phase, err.  The error return is now limited to the main entry point of the run-e2e command.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

