### PR TITLE
removes kubelet cert on uninstall

### DIFF
--- a/internal/flows/uninstall.go
+++ b/internal/flows/uninstall.go
@@ -60,7 +60,7 @@ func (u *Uninstaller) uninstallDaemons(ctx context.Context) error {
 		if err := u.DaemonManager.StopDaemon(kubelet.KubeletDaemonName); err != nil {
 			return err
 		}
-		if err := kubelet.Uninstall(); err != nil {
+		if err := kubelet.Uninstall(kubelet.UninstallOptions{}); err != nil {
 			return err
 		}
 	}

--- a/internal/kubelet/install_test.go
+++ b/internal/kubelet/install_test.go
@@ -1,0 +1,105 @@
+package kubelet_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-hybrid/internal/kubelet"
+)
+
+func TestUninstall(t *testing.T) {
+	tests := []struct {
+		name                 string
+		makeReadOnly         string // path to make read-only to simulate deletion failure
+		noCurrentKubeletCert bool
+		wantErr              string
+	}{
+		{
+			name: "successful uninstallation",
+		},
+		{
+			name:                 "no kubelet cert",
+			noCurrentKubeletCert: true,
+		},
+		{
+			name:         "partial failure - one file fails to delete",
+			makeReadOnly: kubelet.BinPath,
+			wantErr:      "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			tmpDir := t.TempDir()
+
+			// Create test files
+			actualCertFile := "/var/lib/kubelet/pki/kubelet-server-2024-01-01.pem"
+			currentCertFile := "/var/lib/kubelet/pki/kubelet-server-current.pem"
+			setupFiles := []string{
+				kubelet.BinPath,
+				kubelet.UnitPath,
+				"/var/lib/kubelet/kubeconfig",
+				"/etc/kubernetes/kubelet/config.json",
+			}
+
+			if !tt.noCurrentKubeletCert {
+				setupFiles = append(setupFiles, actualCertFile)
+			}
+
+			for _, file := range setupFiles {
+				fullPath := filepath.Join(tmpDir, file)
+				err := os.MkdirAll(filepath.Dir(fullPath), 0o755)
+				g.Expect(err).NotTo(HaveOccurred())
+				err = os.WriteFile(fullPath, []byte("test"), 0o644)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				// If this is the file we want to make read-only
+				if file == tt.makeReadOnly {
+					// Make parent directory read-only to prevent deletion
+					err = os.Chmod(filepath.Dir(fullPath), 0o555)
+					g.Expect(err).NotTo(HaveOccurred())
+				}
+			}
+
+			if !tt.noCurrentKubeletCert {
+				g.Expect(os.Symlink(filepath.Join(tmpDir, actualCertFile), filepath.Join(tmpDir, currentCertFile))).NotTo(HaveOccurred())
+			}
+
+			err := kubelet.Uninstall(kubelet.UninstallOptions{
+				InstallRoot: tmpDir,
+			})
+
+			// Restore permissions to allow cleanup
+			if tt.makeReadOnly != "" {
+				readOnlyPath := filepath.Join(tmpDir, tt.makeReadOnly)
+				err := os.Chmod(filepath.Dir(readOnlyPath), 0o755)
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+
+			if tt.wantErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.wantErr))
+
+				// For partial failure case, verify the read-only file still exists
+				if tt.makeReadOnly != "" {
+					readOnlyPath := filepath.Join(tmpDir, tt.makeReadOnly)
+					g.Expect(readOnlyPath).To(BeAnExistingFile())
+					g.Expect(os.RemoveAll(readOnlyPath)).NotTo(HaveOccurred())
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+
+			for _, file := range setupFiles {
+				fullPath := filepath.Join(tmpDir, file)
+				g.Expect(fullPath).NotTo(BeAnExistingFile())
+			}
+			g.Expect(filepath.Join(tmpDir, currentCertFile)).NotTo(BeAnExistingFile())
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove the kubelet cert on uninstall to avoid ever trying to use an old cert if nodeadm init is ran again on the same node against a different cluster.

part 1 of #413 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

