### PR TITLE
updates golangci-lint to v2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,9 +23,9 @@ jobs:
           check-latest: true
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.61.0
+          version: v2.0.2
           # Disable package caching to avoid a double cache with setup-go.
           skip-pkg-cache: true
           args: --timeout 10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,39 @@
+version: "2"
 run:
-  timeout: 5m
   build-tags:
     - e2e
-issues:
-  exclude-files:
-  - "zz_generated.*\\.go$"
 linters:
+  exclusions:
+    presets:
+      - std-error-handling
+    paths:
+      - zz_generated.*\.go$
+  settings:
+    staticcheck:
+        checks:
+        - all # default
+        - '-ST1000' # default       
+        - '-ST1003' # default
+        - '-ST1016' # default
+        - '-ST1020' # default
+        - '-ST1021' # default
+        - '-ST1022' # default
+        - '-ST1001' # ST1001: should not use dot imports
+        - '-ST1005' # ST1005: error strings should not be capitalized
+formatters:
   enable:
-    - gofumpt
     - gci
-linters-settings:
-  gofumpt:
-    extra-rules: true
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/aws/eks-hybrid)
-    custom-order: true
-    skip-generated: false
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/aws/eks-hybrid)
+      custom-order: true
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    paths:
+      - zz_generated.*\.go$
+

--- a/internal/aws/ec2/instance_waiter.go
+++ b/internal/aws/ec2/instance_waiter.go
@@ -96,7 +96,7 @@ func (w *InstanceConditionWaiter) WaitForOutput(ctx context.Context, params *ec2
 	}
 
 	if options.MinDelay > options.MaxDelay {
-		return nil, fmt.Errorf("minimum waiter delay %v must be lesser than or equal to maximum waiter delay of %v.", options.MinDelay, options.MaxDelay)
+		return nil, fmt.Errorf("minimum waiter delay %v must be lesser than or equal to maximum waiter delay of %v", options.MinDelay, options.MaxDelay)
 	}
 
 	ctx, cancelFn := context.WithTimeout(ctx, maxWaitDur)
@@ -172,7 +172,7 @@ func instanceRetryable(err error) (bool, error) {
 			return false, fmt.Errorf("expected err to be of type smithy.APIError, got %w", err)
 		}
 
-		if "InvalidInstanceID.NotFound" == apiErr.ErrorCode() {
+		if apiErr.ErrorCode() == "InvalidInstanceID.NotFound" {
 			return true, nil
 		}
 	}

--- a/internal/containerd/install.go
+++ b/internal/containerd/install.go
@@ -75,13 +75,14 @@ func Upgrade(ctx context.Context, source Source) error {
 
 func ValidateContainerdSource(source SourceName) error {
 	osName := system.GetOsName()
-	if source == ContainerdSourceNone {
+	switch source {
+	case ContainerdSourceNone:
 		return nil
-	} else if source == ContainerdSourceDocker {
+	case ContainerdSourceDocker:
 		if osName == system.AmazonOsName {
 			return fmt.Errorf("docker source for containerd is not supported on AL2023. Please provide `none` or `distro` to the --containerd-source flag")
 		}
-	} else if source == ContainerdSourceDistro {
+	case ContainerdSourceDistro:
 		if osName == system.RhelOsName {
 			return fmt.Errorf("distro source for containerd is not supported on RHEL. Please provide `none` or `docker` to the --containerd-source flag")
 		}

--- a/internal/ssm/install_test.go
+++ b/internal/ssm/install_test.go
@@ -103,12 +103,13 @@ func TestInstall(t *testing.T) {
 					return
 				}
 
-				if r.URL.Path == "/latest/linux_amd64/ssm-setup-cli" {
+				switch r.URL.Path {
+				case "/latest/linux_amd64/ssm-setup-cli":
 					if _, err := w.Write(tt.installerData); err != nil {
 						w.WriteHeader(http.StatusInternalServerError)
 						return
 					}
-				} else if r.URL.Path == "/latest/linux_amd64/ssm-setup-cli.sig" {
+				case "/latest/linux_amd64/ssm-setup-cli.sig":
 					if _, err := w.Write(tt.signature); err != nil {
 						w.WriteHeader(http.StatusInternalServerError)
 						return

--- a/internal/validation/reader_test.go
+++ b/internal/validation/reader_test.go
@@ -70,11 +70,11 @@ func TestFileCaptureInit(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(fileCapture.File).NotTo(BeNil())
 
-	_, err = fileCapture.File.WriteString("line 1\n")
+	_, err = fileCapture.WriteString("line 1\n")
 	g.Expect(err).To(BeNil())
-	_, err = fileCapture.File.WriteString("line 2\n")
+	_, err = fileCapture.WriteString("line 2\n")
 	g.Expect(err).To(BeNil())
-	_, err = fileCapture.File.WriteString("line 3\n")
+	_, err = fileCapture.WriteString("line 3\n")
 	g.Expect(err).To(BeNil())
 
 	g.Expect(<-out).To(Equal("line 1"))

--- a/test/e2e/addon/podidentitybucket.go
+++ b/test/e2e/addon/podidentitybucket.go
@@ -12,7 +12,7 @@ import (
 	e2eErrors "github.com/aws/eks-hybrid/test/e2e/errors"
 )
 
-var PodIdentityBucketNotFound = errors.New("pod identity bucket not found")
+var ErrPodIdentityBucketNotFound = errors.New("pod identity bucket not found")
 
 // PodIdentityBucket returns the pod identity bucket for the given cluster.
 func PodIdentityBucket(ctx context.Context, client *s3.Client, cluster string) (string, error) {
@@ -58,7 +58,7 @@ func PodIdentityBucket(ctx context.Context, client *s3.Client, cluster string) (
 	}
 
 	if len(foundBuckets) == 0 {
-		return "", PodIdentityBucketNotFound
+		return "", ErrPodIdentityBucketNotFound
 	}
 
 	return foundBuckets[0], nil

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -378,7 +378,7 @@ func (s *stack) delete(ctx context.Context, clusterName string) error {
 func (s *stack) emptyPodIdentityS3Bucket(ctx context.Context, clusterName string) error {
 	podIdentityBucket, err := addon.PodIdentityBucket(ctx, s.s3Client, clusterName)
 	if err != nil {
-		if errors.Is(err, addon.PodIdentityBucketNotFound) {
+		if errors.Is(err, addon.ErrPodIdentityBucketNotFound) {
 			return nil
 		}
 		return fmt.Errorf("getting pod identity s3 bucket: %w", err)

--- a/test/e2e/kubernetes/node.go
+++ b/test/e2e/kubernetes/node.go
@@ -314,7 +314,7 @@ func CordonNode(ctx context.Context, k8s kubernetes.Interface, node *corev1.Node
 	// drain, its possible (common) during our tests that pods get scheduled on the node after
 	// drain gets the list of pods to evict and before the taint has been fully applied
 	// leading to an error during nodeadm upgrade/uninstall due to non-daemonset pods running
-	nodeName := node.ObjectMeta.Name
+	nodeName := node.Name
 	consecutiveErrors := 0
 	err = wait.PollUntilContextTimeout(ctx, nodeCordonDelayInterval, nodeCordonTimeout, true, func(ctx context.Context) (done bool, err error) {
 		node, err := k8s.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})

--- a/test/e2e/kubernetes/pod.go
+++ b/test/e2e/kubernetes/pod.go
@@ -73,8 +73,8 @@ func CreateNginxPodInNode(ctx context.Context, k8s kubernetes.Interface, nodeNam
 }
 
 func CreatePod(ctx context.Context, k8s kubernetes.Interface, pod *corev1.Pod, logger logr.Logger) error {
-	podName := pod.ObjectMeta.Name
-	namespace := pod.ObjectMeta.Namespace
+	podName := pod.Name
+	namespace := pod.Namespace
 
 	_, err := k8s.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -37,7 +37,7 @@ func templateFuncMap() map[string]interface{} {
 	return map[string]interface{}{
 		"indent": func(spaces int, v string) string {
 			pad := strings.Repeat(" ", spaces)
-			return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+			return pad + strings.ReplaceAll(v, "\n", "\n"+pad)
 		},
 	}
 }

--- a/test/e2e/ssm/command.go
+++ b/test/e2e/ssm/command.go
@@ -24,7 +24,7 @@ const (
 
 // ssm commands run as root user on jumpbox
 func makeSshCommand(instanceIP string, commands []string) string {
-	return fmt.Sprintf("ssh %s \"%s\"", instanceIP, strings.Replace(strings.Join(commands, ";"), "\"", "\\\"", -1))
+	return fmt.Sprintf("ssh %s \"%s\"", instanceIP, strings.ReplaceAll(strings.Join(commands, ";"), "\"", "\\\""))
 }
 
 type SSHOnSSM struct {

--- a/test/e2e/suite/flaky_code.go
+++ b/test/e2e/suite/flaky_code.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 )
 
@@ -31,12 +30,12 @@ type FlakeRun struct {
 type retryable struct {
 	panicableError error
 	retryableError error
-	testGoMega     gomega.Gomega
+	testGoMega     Gomega
 }
 
 func newRetryable(attempt, maxAttempts int) *retryable {
 	return &retryable{
-		testGoMega: gomega.NewGomega(func(message string, callerSkip ...int) {
+		testGoMega: NewGomega(func(message string, callerSkip ...int) {
 			skip := 0
 			if len(callerSkip) > 0 {
 				skip = callerSkip[0]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I noticed the open https://github.com/aws/eks-hybrid/pull/434 bumping to the newer github action for golint, but it fails because we are still on v1 of golangci-lint.

This PR updates to v2. I ran the `golangci-lint migrate` to generate the new config file.  There were some newly triggered code lint issues, this could be because the config is not exactly like it was before or the defaults have changed.  I updated the ones i felt were minor (error messages ending in ., using switch instead of if, using replaceall, skipping composed struct keys).  I disabled:

- '-ST1001' # ST1001: should not use dot imports - since we use this for gomega/gingko
- '-ST1005' # ST1005: error strings should not be capitalized - we have a few places in nodeadm where the error is returned to the user capitalized, left these.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

