### PR TITLE
Add force flag to nodeadm uninstall

### DIFF
--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/utils/strings/slices"
 
+	"github.com/aws/eks-hybrid/internal/cleanup"
 	"github.com/aws/eks-hybrid/internal/cli"
 	"github.com/aws/eks-hybrid/internal/cni"
 	"github.com/aws/eks-hybrid/internal/containerd"
@@ -44,6 +45,7 @@ func NewCommand() cli.Command {
 	fc.Description = "Uninstall components installed using the install sub-command"
 	fc.AdditionalHelpAppend = uninstallHelpText
 	fc.StringSlice(&cmd.skipPhases, "s", "skip", "Phases of uninstall to skip. Allowed values: [pod-validation, node-validation].")
+	fc.Bool(&cmd.force, "f", "force", "Force delete additional directories that might contain leftovers from the node process. WARNING: This will delete all contents in default Kubernetes and CNI directories (/var/lib/kubelet, /var/lib/cni, etc). Do not use this flag if you store your own data in these locations.")
 	cmd.flaggy = fc
 
 	return &cmd
@@ -52,6 +54,7 @@ func NewCommand() cli.Command {
 type command struct {
 	flaggy     *flaggy.Subcommand
 	skipPhases []string
+	force      bool
 }
 
 func (c *command) Flaggy() *flaggy.Subcommand {
@@ -127,5 +130,17 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		CNIUninstall:   cni.Uninstall,
 	}
 
-	return uninstaller.Run(ctx)
+	if err := uninstaller.Run(ctx); err != nil {
+		return err
+	}
+
+	if c.force {
+		log.Info("Force mode enabled, cleaning up additional directories...")
+		cleanupManager := cleanup.New(log)
+		if err := cleanupManager.Cleanup(); err != nil {
+			return fmt.Errorf("cleaning up additional directories: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -1,0 +1,61 @@
+package cleanup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+// Directories to clean up when force flag is enabled
+var cleanupDirs = []string{
+	"/var/lib/kubelet",
+	"/var/lib/cni",
+	"/etc/cni/net.d",
+}
+
+// Force handles the cleanup of leftover directories.
+type Force struct {
+	logger  *zap.Logger
+	rootDir string
+}
+
+// Option is a function that configures a Force instance.
+type Option func(*Force)
+
+// WithRootDir sets a custom root directory for testing purposes.
+func WithRootDir(rootDir string) Option {
+	return func(f *Force) {
+		f.rootDir = rootDir
+	}
+}
+
+// New creates a new Force.
+func New(logger *zap.Logger, opts ...Option) *Force {
+	f := &Force{
+		logger:  logger,
+		rootDir: "/", // Default root directory
+	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	return f
+}
+
+// Cleanup removes all configured directories.
+func (c *Force) Cleanup() error {
+	for _, dir := range cleanupDirs {
+		fullPath := filepath.Join(c.rootDir, strings.TrimPrefix(dir, "/"))
+		if err := c.removeDir(fullPath); err != nil {
+			return fmt.Errorf("removing directory %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func (c *Force) removeDir(dir string) error {
+	c.logger.Info("Removing directory", zap.String("path", dir))
+	return os.RemoveAll(dir)
+}

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -1,0 +1,64 @@
+package cleanup_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/aws/eks-hybrid/internal/cleanup"
+)
+
+func TestCleanup(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupDirs   []string
+		expectError string
+	}{
+		{
+			name: "cleanup existing directories",
+			setupDirs: []string{
+				"/var/lib/kubelet",
+				"/var/lib/cni",
+				"/etc/cni/net.d",
+			},
+		},
+		{
+			name:      "cleanup non-existent directories",
+			setupDirs: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			tmpRoot := t.TempDir()
+
+			for _, dir := range tt.setupDirs {
+				fullPath := filepath.Join(tmpRoot, dir)
+				g.Expect(os.MkdirAll(fullPath, 0o755)).To(Succeed(), "Failed to create test directory %s", fullPath)
+				testFile := filepath.Join(fullPath, "test.txt")
+				g.Expect(os.WriteFile(testFile, []byte("test"), 0o644)).To(Succeed(), "Failed to create test file %s", testFile)
+			}
+
+			logger := zaptest.NewLogger(t)
+			force := cleanup.New(logger, cleanup.WithRootDir(tmpRoot))
+			err := force.Cleanup()
+
+			if tt.expectError == "" {
+				g.Expect(err).ToNot(HaveOccurred(), "Unexpected error occurred")
+			} else {
+				g.Expect(err).To(HaveOccurred(), "Expected error but got none")
+				g.Expect(err).To(MatchError(ContainSubstring(tt.expectError), "Error message does not match expected"))
+			}
+
+			for _, dir := range tt.setupDirs {
+				fullPath := filepath.Join(tmpRoot, dir)
+				_, err := os.Stat(fullPath)
+				g.Expect(os.IsNotExist(err)).To(BeTrue(), "Directory %s should not exist", fullPath)
+			}
+		})
+	}
+}

--- a/test/integration/cases/uninstall-with-force/run.sh
+++ b/test/integration/cases/uninstall-with-force/run.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+wait::dbus-ready
+
+# remove previously installed containerd to test installation via nodeadm
+dnf remove -y containerd
+
+# Install a version to test uninstall
+nodeadm install 1.30 --credential-provider ssm
+
+# Create some test files in directories that should be cleaned up by force
+mkdir -p /var/lib/kubelet/test
+echo "test" > /var/lib/kubelet/test/file
+echo "test" > /var/lib/kubelet/kubeconfig
+mkdir -p /etc/kubernetes/test
+echo "test" > /etc/kubernetes/test/file
+mkdir -p /var/lib/cni/test
+echo "test" > /var/lib/cni/test/file
+mkdir -p /etc/cni/net.d/test
+echo "test" > /etc/cni/net.d/test/file
+
+# First uninstall without force - these directories should remain
+nodeadm uninstall --skip node-validation,pod-validation
+
+# These two files are removed even without force
+assert::path-not-exist /etc/kubernetes/test/file
+assert::path-not-exist /var/lib/kubelet/kubeconfig
+
+assert::path-exists /var/lib/kubelet/test/file
+assert::path-exists /var/lib/cni/test/file
+assert::path-exists /etc/cni/net.d/test/file
+
+# Install again to test force uninstall
+nodeadm install 1.30 --credential-provider ssm
+
+# Recreate test files
+mkdir -p /var/lib/kubelet/test
+echo "test" > /var/lib/kubelet/test/file
+mkdir -p /etc/kubernetes/test
+echo "test" > /etc/kubernetes/test/file
+mkdir -p /var/lib/cni/test
+echo "test" > /var/lib/cni/test/file
+mkdir -p /etc/cni/net.d/test
+echo "test" > /etc/cni/net.d/test/file
+
+# Now uninstall with force - these directories should be removed
+nodeadm uninstall --skip node-validation,pod-validation --force
+
+assert::path-not-exist /var/lib/kubelet/test/file
+assert::path-not-exist /etc/kubernetes/test/file
+assert::path-not-exist /var/lib/cni/test/file
+assert::path-not-exist /etc/cni/net.d/test/file


### PR DESCRIPTION
## Description of changes

Adds a new  flag to the  command that enables additional cleanup of leftover directories from the node process. This is useful when a complete cleanup is needed, such as when repurposing a node or troubleshooting persistent issues.

The cleanup is opt-in to prevent accidental deletion of user data in these directories, as they may contain custom configurations or other important files that should be preserved by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

