### PR TITLE
Increase deleteClusterTimeout for e2e stack cleanup to 8 mins

### DIFF
--- a/test/e2e/cleanup/eks.go
+++ b/test/e2e/cleanup/eks.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/eks-hybrid/test/e2e/errors"
 )
 
-const deleteClusterTimeout = 5 * time.Minute
+const deleteClusterTimeout = 8 * time.Minute
 
 type EKSClusterCleanup struct {
 	eksClient *eks.Client


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Increases timeout to 8 mins to reduce chance of timeout due to slow cluster deletion

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

