### PR TITLE
adds support to override eks endpoint and SPs

### DIFF
--- a/cmd/e2e-test/node/create.go
+++ b/cmd/e2e-test/node/create.go
@@ -7,7 +7,6 @@ import (
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/aws/aws-sdk-go-v2/service/eks"
 	s3sdk "github.com/aws/aws-sdk-go-v2/service/s3"
 	ssmsdk "github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/go-logr/logr"
@@ -78,7 +77,7 @@ func (c *create) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return fmt.Errorf("setting up test infrastructure: %w", err)
 	}
 
-	eksClient := eks.NewFromConfig(aws)
+	eksClient := e2e.NewEKSClient(aws, config.Endpoint)
 	ec2Client := ec2.NewFromConfig(aws)
 	ssmClient := ssmsdk.NewFromConfig(aws)
 	s3Client := s3sdk.NewFromConfig(aws)

--- a/cmd/e2e-test/rune2e/command.go
+++ b/cmd/e2e-test/rune2e/command.go
@@ -36,7 +36,6 @@ type command struct {
 	artifactsDir      string
 	clusterName       string
 	cni               string
-	endpoint          string
 	ginkgoBinaryPath  string
 	k8sVersion        string
 	logsBucket        string
@@ -63,7 +62,6 @@ func NewCommand() *command {
 		nodeadmAMDURL:     defaultNodeadmAMDURL,
 		nodeadmARMURL:     defaultNodeadmARMURL,
 		skipCleanup:       false,
-		region:            defaultRegion,
 		subCmd:            flaggy.NewSubcommand("run-e2e"),
 		testProcs:         defaultTestProcs,
 		timeout:           defaultTimeout,
@@ -78,7 +76,6 @@ func NewCommand() *command {
 	cmd.subCmd.String(&cmd.nodeadmARMURL, "", "nodeadm-arm-url", "NodeADM ARM URL (optional)")
 	cmd.subCmd.String(&cmd.logsBucket, "b", "logs-bucket", "S3 bucket for logs (optional)")
 	cmd.subCmd.String(&cmd.artifactsDir, "a", "artifacts-dir", "Directory for artifacts (optional, defaults to a new temp directory)")
-	cmd.subCmd.String(&cmd.endpoint, "e", "endpoint", "AWS endpoint (optional)")
 	cmd.subCmd.String(&cmd.skippedTests, "s", "skipped-tests", "ginkgo regex to skip tests (optional)")
 	cmd.subCmd.Duration(&cmd.timeout, "", "timeout", "Timeout for the test (optional)")
 	cmd.subCmd.String(&cmd.testLabelFilter, "f", "test-filter", "Filter for the test (optional)")
@@ -107,6 +104,9 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	awsCfg, err := e2e.NewAWSConfig(ctx, config.WithRegion(c.region))
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)
+	}
+	if c.region == "" {
+		c.region = awsCfg.Region
 	}
 
 	testResources, err := c.loadSetupConfig(logger)
@@ -188,7 +188,6 @@ func (c *command) loadSetupConfig(logger logr.Logger) (cluster.TestResources, er
 		ClusterRegion:     c.region,
 		KubernetesVersion: c.k8sVersion,
 		Cni:               c.cni,
-		Endpoint:          c.endpoint,
 		ClusterNetwork: cluster.NetworkConfig{
 			VpcCidr:           "10.0.0.0/16",
 			PublicSubnetCidr:  "10.0.10.0/24",
@@ -208,9 +207,8 @@ func (c *command) loadSetupConfig(logger logr.Logger) (cluster.TestResources, er
 		if c.clusterName != defaultClusterName ||
 			c.region != defaultRegion ||
 			c.k8sVersion != defaultK8sVersion ||
-			c.cni != defaultCNI ||
-			c.endpoint != "" {
-			return testResources, fmt.Errorf("cannot specify both setup-config file and individual cluster resource flags (name, region, kubernetes-version, cni, endpoint)")
+			c.cni != defaultCNI {
+			return testResources, fmt.Errorf("cannot specify both setup-config file and individual cluster resource flags (name, region, kubernetes-version, cni, eks-endpoint)")
 		}
 
 		// Load test resources from file
@@ -235,10 +233,10 @@ func (c *command) loadTestConfig(testResources cluster.TestResources, logger log
 	testConfig := e2e.TestConfig{
 		ClusterName:   testResources.ClusterName,
 		ClusterRegion: testResources.ClusterRegion,
-		Endpoint:      testResources.Endpoint,
 		NodeadmUrlAMD: c.nodeadmAMDURL,
 		NodeadmUrlARM: c.nodeadmARMURL,
 		LogsBucket:    c.logsBucket,
+		Endpoint:      testResources.EKS.Endpoint,
 	}
 
 	if c.testConfigFile != "" {

--- a/cmd/e2e-test/setup/setup.go
+++ b/cmd/e2e-test/setup/setup.go
@@ -61,7 +61,7 @@ func (s *Command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 
 	logger := e2e.NewLogger()
-	create := cluster.NewCreate(aws, logger, testResources.Endpoint)
+	create := cluster.NewCreate(aws, logger, testResources.EKS.Endpoint)
 
 	logger.Info("Creating cluster infrastructure for E2E tests...")
 	if err := create.Run(ctx, testResources); err != nil {

--- a/cmd/e2e-test/sweeper/sweeper.go
+++ b/cmd/e2e-test/sweeper/sweeper.go
@@ -20,6 +20,7 @@ type SweeperCommand struct {
 	ageThreshold  time.Duration
 	dryRun        bool
 	all           bool
+	eksEndpoint   string
 }
 
 func NewSweeperCommand() *SweeperCommand {
@@ -36,6 +37,7 @@ func NewSweeperCommand() *SweeperCommand {
 	sweeper.Duration(&cmd.ageThreshold, "", "age", "Age threshold for instance deletion")
 	sweeper.Bool(&cmd.dryRun, "", "dry-run", "Simulate the cleanup without making any changes")
 	sweeper.Bool(&cmd.all, "", "all", "Include all resources based on the age threshold in the cleanup")
+	sweeper.String(&cmd.eksEndpoint, "e", "eks-endpoint", "EKS API endpoint")
 
 	cmd.flaggy = sweeper
 
@@ -74,7 +76,7 @@ func (s *SweeperCommand) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return fmt.Errorf("reading AWS configuration: %w", err)
 	}
 
-	sweeper := cleanup.NewSweeper(aws, logger)
+	sweeper := cleanup.NewSweeper(aws, logger, s.eksEndpoint)
 	input := cleanup.SweeperInput{
 		AllClusters:          s.all,
 		ClusterNamePrefix:    s.clusterPrefix,

--- a/test/e2e/cleanup/sweeper.go
+++ b/test/e2e/cleanup/sweeper.go
@@ -14,6 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/go-logr/logr"
+
+	"github.com/aws/eks-hybrid/test/e2e"
 )
 
 type SweeperInput struct {
@@ -43,11 +45,11 @@ type FilterInput struct {
 	DryRun               bool
 }
 
-func NewSweeper(aws aws.Config, logger logr.Logger) Sweeper {
+func NewSweeper(aws aws.Config, logger logr.Logger, endpoint string) Sweeper {
 	return Sweeper{
 		cfn:           cloudformation.NewFromConfig(aws),
 		ec2Client:     ec2.NewFromConfig(aws),
-		eks:           eks.NewFromConfig(aws),
+		eks:           e2e.NewEKSClient(aws, endpoint),
 		iam:           iam.NewFromConfig(aws),
 		logger:        logger,
 		ssm:           ssm.NewFromConfig(aws),

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -58,6 +58,14 @@ Parameters:
     Type: String
     Description: Tag key for the creation time of the stack
 
+  EKSClusterRoleSP:
+    Type: String
+    Description: The Service Principal for the EKS Hybrid Cluster Role
+
+  EKSPodIdentitySP:
+    Type: String
+    Description: The Service Principal for the EKS Pod Identity Association Role
+
 Resources:
   ClusterRole:
     Type: AWS::IAM::Role
@@ -67,7 +75,7 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              Service: eks.amazonaws.com
+              Service: !Ref EKSClusterRoleSP
         Version: '2012-10-17'
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
@@ -440,7 +448,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: 'pods.eks.amazonaws.com'
+              Service: !Ref EKSPodIdentitySP
             Action:
               - sts:AssumeRole
               - sts:TagSession

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -28,7 +28,12 @@ type TestResources struct {
 	HybridNetwork     NetworkConfig `yaml:"hybridNetwork"`
 	KubernetesVersion string        `yaml:"kubernetesVersion"`
 	Cni               string        `yaml:"cni"`
-	Endpoint          string        `yaml:"endpoint"`
+	EKS               EKSConfig     `yaml:"eks"`
+}
+type EKSConfig struct {
+	Endpoint      string `yaml:"endpoint"`
+	ClusterRoleSP string `yaml:"clusterRoleSP"`
+	PodIdentitySP string `yaml:"podIdentitySP"`
 }
 
 type NetworkConfig struct {
@@ -56,9 +61,7 @@ type Create struct {
 func NewCreate(aws aws.Config, logger logr.Logger, endpoint string) Create {
 	return Create{
 		logger: logger,
-		eks: eks.NewFromConfig(aws, func(o *eks.Options) {
-			o.EndpointResolverV2 = &e2e.EksResolverV2{Endpoint: endpoint}
-		}),
+		eks:    e2e.NewEKSClient(aws, endpoint),
 		stack: &stack{
 			iamClient: iam.NewFromConfig(aws),
 			cfn:       cloudformation.NewFromConfig(aws),

--- a/test/e2e/cluster/delete.go
+++ b/test/e2e/cluster/delete.go
@@ -33,11 +33,7 @@ type Delete struct {
 func NewDelete(aws aws.Config, logger logr.Logger, endpoint string) Delete {
 	return Delete{
 		logger: logger,
-		eks: eks.NewFromConfig(aws, func(o *eks.Options) {
-			o.EndpointResolverV2 = &e2e.EksResolverV2{
-				Endpoint: endpoint,
-			}
-		}),
+		eks:    e2e.NewEKSClient(aws, endpoint),
 		stack: &stack{
 			iamClient: iam.NewFromConfig(aws),
 			cfn:       cloudformation.NewFromConfig(aws),

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -33,6 +33,8 @@ var setupTemplateBody []byte
 
 const (
 	creationTimeParameterKey = "CreationTime"
+	defaultClusterRoleSP     = "eks.amazonaws.com"
+	defaultPodIdentitySP     = "pods.eks.amazonaws.com"
 	stackWaitTimeout         = 7 * time.Minute
 	stackWaitInterval        = 10 * time.Second
 )
@@ -67,7 +69,7 @@ type stack struct {
 func (s *stack) deploy(ctx context.Context, test TestResources) (*resourcesStackOutput, error) {
 	stackName := stackName(test.ClusterName)
 
-	params := s.prepareStackParameters(test)
+	params := s.prepareStackParameters(test, test.EKS)
 
 	// There are occasional race conditions when creating the cfn stack
 	// retrying once allows to potentially resolve them on the second attempt
@@ -108,7 +110,15 @@ func (s *stack) deploy(ctx context.Context, test TestResources) (*resourcesStack
 	return result, nil
 }
 
-func (s *stack) prepareStackParameters(test TestResources) []types.Parameter {
+func (s *stack) prepareStackParameters(test TestResources, eks EKSConfig) []types.Parameter {
+	clusterRoleSP := defaultClusterRoleSP
+	if eks.ClusterRoleSP != "" {
+		clusterRoleSP = eks.ClusterRoleSP
+	}
+	podIdentitySP := defaultPodIdentitySP
+	if eks.PodIdentitySP != "" {
+		podIdentitySP = eks.PodIdentitySP
+	}
 	return []types.Parameter{
 		{
 			ParameterKey:   aws.String("ClusterName"),
@@ -171,6 +181,14 @@ func (s *stack) prepareStackParameters(test TestResources) []types.Parameter {
 		{
 			ParameterKey:   aws.String("CreationTimeTagKey"),
 			ParameterValue: aws.String(constants.CreationTimeTagKey),
+		},
+		{
+			ParameterKey:   aws.String("EKSClusterRoleSP"),
+			ParameterValue: aws.String(clusterRoleSP),
+		},
+		{
+			ParameterKey:   aws.String("EKSPodIdentitySP"),
+			ParameterValue: aws.String(podIdentitySP),
 		},
 	}
 }

--- a/test/e2e/credentials/setup.go
+++ b/test/e2e/credentials/setup.go
@@ -26,9 +26,7 @@ type Infrastructure struct {
 // Setup creates the necessary infrastructure for credentials providers to be used by nodeadm. Endpoint is
 // used by EKS client and will use default endpoint if an empty string is passed.
 func Setup(ctx context.Context, logger logr.Logger, config aws.Config, clusterName, endpoint string) (*Infrastructure, error) {
-	eksClient := eks.NewFromConfig(config, func(o *eks.Options) {
-		o.EndpointResolverV2 = &e2e.EksResolverV2{Endpoint: endpoint}
-	})
+	eksClient := e2e.NewEKSClient(config, endpoint)
 	cfnClient := cloudformation.NewFromConfig(config)
 	iamClient := iam.NewFromConfig(config)
 

--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -21,6 +21,7 @@ type NodeadmOS interface {
 
 type UserDataInput struct {
 	CredsProviderName string
+	EKSEndpoint       string
 	KubernetesVersion string
 	NodeadmUrls       NodeadmURLs
 	NodeadmConfigYaml string

--- a/test/e2e/os/arch.go
+++ b/test/e2e/os/arch.go
@@ -3,6 +3,7 @@ package os
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"text/template"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -39,13 +40,20 @@ func (a architecture) amd() bool {
 func populateBaseScripts(userDataInput *e2e.UserDataInput) error {
 	logCollector, err := executeTemplate(logCollectorScript, userDataInput)
 	if err != nil {
-		return err
+		return fmt.Errorf("generating log collector script: %w", err)
 	}
-
 	userDataInput.Files = append(userDataInput.Files,
 		e2e.File{Content: string(nodeAdmInitScript), Path: "/tmp/nodeadm-init.sh", Permissions: "0755"},
 		e2e.File{Content: string(logCollector), Path: "/tmp/log-collector.sh", Permissions: "0755"},
 	)
+
+	if userDataInput.EKSEndpoint != "" {
+		nodeadmWrapper, err := executeTemplate(nodeadmWrapperScript, userDataInput)
+		if err != nil {
+			return fmt.Errorf("generating nodeadm wrapper: %w", err)
+		}
+		userDataInput.Files = append(userDataInput.Files, e2e.File{Content: string(nodeadmWrapper), Path: "/tmp/nodeadm-wrapper.sh", Permissions: "0755"})
+	}
 	return nil
 }
 

--- a/test/e2e/os/testdata/nodeadm-init.sh
+++ b/test/e2e/os/testdata/nodeadm-init.sh
@@ -28,6 +28,12 @@ for i in {1..5}; do curl --fail -s --retry 5 -L "$NODEADM_URL" -o /tmp/nodeadm &
 
 chmod +x /tmp/nodeadm
 
+# we may have a custom eks endpoint in the nodeadm wrapper
+if [ -f /tmp/nodeadm-wrapper.sh ]; then
+    mv /tmp/nodeadm /tmp/nodeadm-bin
+    mv /tmp/nodeadm-wrapper.sh /tmp/nodeadm
+fi
+
 echo "Installing kubernetes components"
 /tmp/nodeadm install $KUBERNETES_VERSION $NODEADM_ADDITIONAL_ARGS --credential-provider $PROVDER --region $REGION
 

--- a/test/e2e/os/testdata/nodeadm-wrapper.sh
+++ b/test/e2e/os/testdata/nodeadm-wrapper.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+AWS_ENDPOINT_URL_EKS={{ .EKSEndpoint }} /tmp/nodeadm-bin "$@"

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -26,6 +26,9 @@ var nodeAdmInitScript []byte
 //go:embed testdata/log-collector.sh
 var logCollectorScript []byte
 
+//go:embed testdata/nodeadm-wrapper.sh
+var nodeadmWrapperScript []byte
+
 type ubuntuCloudInitData struct {
 	e2e.UserDataInput
 	NodeadmUrl            string

--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -43,6 +43,7 @@ type Node struct {
 
 // NodeSpec configures the Hybrid Node.
 type NodeSpec struct {
+	EKSEndpoint        string
 	InstanceName       string
 	InstanceProfileARN string
 	NodeK8sVersion     string
@@ -113,6 +114,7 @@ func (c NodeCreate) Create(ctx context.Context, spec *NodeSpec) (PeerdNode, erro
 	}
 
 	userdata, err := spec.OS.BuildUserData(e2e.UserDataInput{
+		EKSEndpoint:       spec.EKSEndpoint,
 		KubernetesVersion: spec.NodeK8sVersion,
 		NodeadmUrls:       c.NodeadmURLs,
 		NodeadmConfigYaml: string(nodeadmConfigYaml),

--- a/test/e2e/run/cleanup.go
+++ b/test/e2e/run/cleanup.go
@@ -42,12 +42,12 @@ func (e *E2ECleanup) Run(ctx context.Context) []Phase {
 }
 
 func (e *E2ECleanup) clusterStackCleanup(ctx context.Context) error {
-	delete := cluster.NewDelete(e.AwsCfg, e.Logger, e.TestResources.Endpoint)
+	delete := cluster.NewDelete(e.AwsCfg, e.Logger, e.TestResources.EKS.Endpoint)
 	e.Logger.Info("Cleaning up E2E cluster resources via Stack deletion")
 	deleteCluster := cluster.DeleteInput{
 		ClusterName:   e.TestResources.ClusterName,
 		ClusterRegion: e.TestResources.ClusterRegion,
-		Endpoint:      e.TestResources.Endpoint,
+		Endpoint:      e.TestResources.EKS.Endpoint,
 	}
 	if err := delete.Run(ctx, deleteCluster); err != nil {
 		return fmt.Errorf("cleaning up e2e resources: %w", err)
@@ -58,7 +58,7 @@ func (e *E2ECleanup) clusterStackCleanup(ctx context.Context) error {
 }
 
 func (e *E2ECleanup) clusterSweeperCleanup(ctx context.Context) error {
-	sweeper := cleanup.NewSweeper(e.AwsCfg, e.Logger)
+	sweeper := cleanup.NewSweeper(e.AwsCfg, e.Logger, e.TestResources.EKS.Endpoint)
 	e.Logger.Info("Cleaning up E2E cluster resources via Sweeper")
 	err := sweeper.Run(ctx, cleanup.SweeperInput{ClusterName: e.TestResources.ClusterName})
 	if err != nil {

--- a/test/e2e/run/runner.go
+++ b/test/e2e/run/runner.go
@@ -63,7 +63,7 @@ func (e *E2ERunner) Run(ctx context.Context) []Phase {
 
 func (e *E2ERunner) setupTestInfrastructure(ctx context.Context) error {
 	logger := newFileLogger(e.Paths.SetupLog, e.NoColor)
-	create := cluster.NewCreate(e.AwsCfg, logger, e.TestResources.Endpoint)
+	create := cluster.NewCreate(e.AwsCfg, logger, e.TestResources.EKS.Endpoint)
 
 	logger.Info("Creating cluster infrastructure for E2E tests...")
 	if err := create.Run(ctx, e.TestResources); err != nil {

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -72,6 +72,7 @@ func TestE2E(t *testing.T) {
 
 type peeredVPCTest struct {
 	aws             aws.Config // TODO: move everything to aws sdk v2
+	eksEndpoint     string
 	eksClient       *eks.Client
 	ec2Client       *ec2v2.Client
 	ssmClient       *ssmv2.Client
@@ -274,6 +275,7 @@ var _ = Describe("Hybrid Nodes", func() {
 							flakyCode.It(ctx, "Creates a node", 3, func(ctx context.Context, flakeRun FlakeRun) {
 								var err error
 								node, err = peeredNode.Create(ctx, &peered.NodeSpec{
+									EKSEndpoint:    test.eksEndpoint,
 									InstanceName:   instanceName,
 									NodeK8sVersion: k8sVersion,
 									NodeName:       nodeName,
@@ -398,6 +400,7 @@ var _ = Describe("Hybrid Nodes", func() {
 							flakyCode.It(ctx, "Creates a node", 3, func(ctx context.Context, flakeRun FlakeRun) {
 								var err error
 								node, err = peeredNode.Create(ctx, &peered.NodeSpec{
+									EKSEndpoint:    test.eksEndpoint,
 									InstanceName:   instanceName,
 									NodeK8sVersion: nodeKubernetesVersion,
 									NodeName:       nodeName,
@@ -473,6 +476,7 @@ var _ = Describe("Hybrid Nodes", func() {
 func buildPeeredVPCTestForSuite(ctx context.Context, suite *suiteConfiguration) (*peeredVPCTest, error) {
 	pausableLogger := newLoggerForTests()
 	test := &peeredVPCTest{
+		eksEndpoint:            suite.TestConfig.Endpoint,
 		stackOut:               suite.CredentialsStackOutput,
 		logger:                 pausableLogger.Logger,
 		loggerControl:          pausableLogger,
@@ -490,7 +494,7 @@ func buildPeeredVPCTestForSuite(ctx context.Context, suite *suiteConfiguration) 
 	}
 
 	test.aws = aws
-	test.eksClient = eks.NewFromConfig(aws)
+	test.eksClient = e2e.NewEKSClient(aws, suite.TestConfig.Endpoint)
 	test.ec2Client = ec2v2.NewFromConfig(aws)
 	test.ssmClient = ssmv2.NewFromConfig(aws)
 	test.s3Client = s3v2.NewFromConfig(aws)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When testing agasinst other environments, the endpoint overriding was not complete.  This adds the ability to also overwrite the SPs and passes the endpoint url to the nodeadm call on the node.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

