### PR TITLE
Bump up cluster create and delete timeouts to 15 min

### DIFF
--- a/test/e2e/cleanup/eks.go
+++ b/test/e2e/cleanup/eks.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	activeClusterTimeout = 12 * time.Minute
-	deleteClusterTimeout = 8 * time.Minute
+	activeClusterTimeout = 15 * time.Minute
+	deleteClusterTimeout = 15 * time.Minute
 )
 
 type EKSClusterCleanup struct {


### PR DESCRIPTION
*Description of changes:*
Bump up cluster create and delete timeouts to 15 min

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

