### PR TITLE
Refresh systemd after adding iam-ra unit file

### DIFF
--- a/internal/iamrolesanywhere/daemon.go
+++ b/internal/iamrolesanywhere/daemon.go
@@ -46,6 +46,10 @@ func (s *SigningHelperDaemon) Configure() error {
 	if err := util.WriteFileWithDir(SigningHelperServiceFilePath, service, 0o644); err != nil {
 		return fmt.Errorf("writing aws_signing_helper_update service file %s: %v", EksHybridAwsCredentialsPath, err)
 	}
+
+	if err := s.daemonManager.DaemonReload(); err != nil {
+		return fmt.Errorf("reloading systemd daemon: %v", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
*Description of changes:*
When enabling iam-ra service, we write the systemd file but dont refresh the systemd metadata. Subsequent start requests would fail without reloading daemons.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

