### PR TITLE
Accept both 403 and 401 when making unauth request

### DIFF
--- a/internal/kubernetes/unauthenticated.go
+++ b/internal/kubernetes/unauthenticated.go
@@ -52,8 +52,10 @@ func MakeUnauthenticatedRequest(ctx context.Context, endpoint string, caCertific
 		return fmt.Errorf("unmarshalling unauthenticated request response: %w", err)
 	}
 
-	if resp.StatusCode != http.StatusForbidden {
-		return validation.WithRemediation(fmt.Errorf("expected status code from unauthenticated request %d, got %d. Message: %s", http.StatusForbidden, resp.StatusCode, apiServerResp.Message),
+	// We allow both Forbidden and Unauthorized status codes because the API server will return
+	// The kube-API server used to return Forbidden but in k8s 1.32 it started returning Unauthorized.
+	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusUnauthorized {
+		return validation.WithRemediation(fmt.Errorf("expected status code from unauthenticated request %d or %d, got %d. Message: %s", http.StatusForbidden, http.StatusUnauthorized, resp.StatusCode, apiServerResp.Message),
 			"Ensure the Kubernetes API server endpoint provided is correct and the CA certificate is valid for that endpoint.",
 		)
 	}


### PR DESCRIPTION
*Description of changes:*
Older Kubernetes versions returned 403, with 1.32 now it returns 401.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

