### PR TITLE
Make node identity validation conditional on k8s

### DIFF
--- a/cmd/nodeadm/debug/debug.go
+++ b/cmd/nodeadm/debug/debug.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/eks-hybrid/internal/configprovider"
 	"github.com/aws/eks-hybrid/internal/creds"
 	"github.com/aws/eks-hybrid/internal/errors"
+	"github.com/aws/eks-hybrid/internal/kubelet"
 	"github.com/aws/eks-hybrid/internal/kubernetes"
 	"github.com/aws/eks-hybrid/internal/logger"
 	"github.com/aws/eks-hybrid/internal/node"
@@ -89,7 +90,7 @@ func (c *debug) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	os.Stderr = printer.File
 
 	runner := validation.NewRunner[*api.NodeConfig](printer)
-	apiServerValidator := node.NewAPIServerValidator()
+	apiServerValidator := node.NewAPIServerValidator(kubelet.New())
 
 	runner.Register(creds.Validations(awsConfig, nodeConfig)...)
 	runner.Register(

--- a/internal/kubelet/kubeconfig.go
+++ b/internal/kubelet/kubeconfig.go
@@ -128,3 +128,16 @@ func GetKubeClientFromKubeConfig() (kubernetes.Interface, error) {
 func KubeconfigPath() string {
 	return kubeconfigPath
 }
+
+// Kubeconfig is the default kubeconfig generated for the kubelet.
+type Kubeconfig struct{}
+
+// Path returns the path to the kubeconfig file used by the kubelet.
+func (d Kubeconfig) Path() string {
+	return KubeconfigPath()
+}
+
+// BuildClient builds a new Kubernetes client from the kubeconfig.
+func (d Kubeconfig) BuildClient() (kubernetes.Interface, error) {
+	return GetKubeClientFromKubeConfig()
+}

--- a/internal/kubelet/kubelet.go
+++ b/internal/kubelet/kubelet.go
@@ -1,0 +1,29 @@
+package kubelet
+
+import "k8s.io/client-go/kubernetes"
+
+// Kubelet groups several helpers so it can be injected in other
+// packages without creating a dependency on this one and facilitating
+// testing withouthaving to read the disk.
+type Kubelet struct {
+	Kubeconfig
+}
+
+func New() Kubelet {
+	return Kubelet{}
+}
+
+// BuildClient builds a new Kubernetes client from the kubelet's kubeconfig.
+func (k Kubelet) BuildClient() (kubernetes.Interface, error) {
+	return k.Kubeconfig.BuildClient()
+}
+
+// KubeconfigPath returns the path to the kubelet's kubeconfig.
+func (k Kubelet) KubeconfigPath() string {
+	return k.Path()
+}
+
+// Version returns the version of the kubelet.
+func (k Kubelet) Version() (string, error) {
+	return GetKubeletVersion()
+}


### PR DESCRIPTION
*Description of changes:*
EKS Kubernetes 1.27 and earlier don't allow for nodes to make SelfSubjectReview requests. In those versions, we skip this validation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

