### PR TITLE
fails e2e if debug command fails

### DIFF
--- a/test/e2e/nodeadm/commands.go
+++ b/test/e2e/nodeadm/commands.go
@@ -74,3 +74,20 @@ func RunLogCollector(ctx context.Context, runner commands.RemoteCommandRunner, i
 
 	return nil
 }
+
+func RunNodeadmDebug(ctx context.Context, runner commands.RemoteCommandRunner, instanceIP string) error {
+	commands := []string{
+		"/tmp/nodeadm debug -c file:///nodeadm-config.yaml",
+	}
+
+	output, err := runner.Run(ctx, instanceIP, commands)
+	if err != nil {
+		return fmt.Errorf("running remote command: %w", err)
+	}
+
+	if output.Status != "Success" {
+		return fmt.Errorf("nodeadm debug remote command did not succeed")
+	}
+
+	return nil
+}

--- a/test/e2e/os/testdata/nodeadm-init.sh
+++ b/test/e2e/os/testdata/nodeadm-init.sh
@@ -10,12 +10,6 @@ PROVDER="$3"
 REGION="$4"
 NODEADM_ADDITIONAL_ARGS="${5-}"
 
-function run_debug(){
-    /tmp/nodeadm debug -c file:///nodeadm-config.yaml || true
-}
-
-trap "run_debug" EXIT
-
 # nodeadmin uninstall does not remove this folder, which contains the cilium/calico config
 # which kubelet uses to determine if a node is "Ready"
 # if we do not remove this folder, the node will flip to ready on re-join immediately


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We have been running `nodeadm debug` at the end of the cloud-init in our e2e tests. The exit code has been ignored.

We recently found that one of the validations only works for 1.28+ and another one that broke in 1.32.  This change moves the debug call to after the node has joined (or timed out) and will fail the test if the debug command returns a non-zero exit code.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

