### PR TITLE
changes ssm managed instnace cleanup to use register date

### DIFF
--- a/test/e2e/cleanup/ssm.go
+++ b/test/e2e/cleanup/ssm.go
@@ -229,7 +229,7 @@ func shouldDeleteManagedInstance(instance *types.InstanceInformation, tags []typ
 
 	resource := ResourceWithTags{
 		ID:           *instance.InstanceId,
-		CreationTime: aws.ToTime(instance.LastPingDateTime),
+		CreationTime: aws.ToTime(instance.RegistrationDate),
 		Tags:         customTags,
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We ran into a case where we deleted an instance right after it was created in another test because the LastPingDate was not set yet and default date is 1/1/0000


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

