### PR TITLE
Add different user-agent for the e2e test pieces

### DIFF
--- a/cmd/e2e-test/cleanup/cleanup.go
+++ b/cmd/e2e-test/cleanup/cleanup.go
@@ -56,7 +56,12 @@ func (s *Command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return fmt.Errorf("unmarshaling cleanup config: %w", err)
 	}
 
-	aws, err := e2e.NewAWSConfig(ctx, config.WithRegion(deleteCluster.ClusterRegion))
+	aws, err := e2e.NewAWSConfig(ctx,
+		config.WithRegion(deleteCluster.ClusterRegion),
+		// We use a custom AppId so the requests show that they were
+		// made by this cleanup in the user-agent
+		config.WithAppID("nodeadm-e2e-test-cleanup-cmd"),
+	)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)
 	}

--- a/cmd/e2e-test/rune2e/command.go
+++ b/cmd/e2e-test/rune2e/command.go
@@ -101,7 +101,12 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	ctx := context.Background()
 	logger := e2e.NewLogger(e2e.LoggerConfig{NoColor: c.noColor})
 
-	awsCfg, err := e2e.NewAWSConfig(ctx, config.WithRegion(c.region))
+	awsCfg, err := e2e.NewAWSConfig(ctx,
+		config.WithRegion(c.region),
+		// We use a custom AppId so the requests show that they were
+		// made by this command in the user-agent
+		config.WithAppID("nodeadm-e2e-test-run-cmd"),
+	)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)
 	}

--- a/cmd/e2e-test/setup/setup.go
+++ b/cmd/e2e-test/setup/setup.go
@@ -48,7 +48,12 @@ func (s *Command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return fmt.Errorf("failed to load test resources: %w", err)
 	}
 
-	aws, err := e2e.NewAWSConfig(ctx, config.WithRegion(testResources.ClusterRegion))
+	aws, err := e2e.NewAWSConfig(ctx,
+		config.WithRegion(testResources.ClusterRegion),
+		// We use a custom AppId so the requests show that they were
+		// made by this command in the user-agent
+		config.WithAppID("nodeadm-e2e-test-setup-cmd"),
+	)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)
 	}

--- a/cmd/e2e-test/sweeper/sweeper.go
+++ b/cmd/e2e-test/sweeper/sweeper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 
@@ -71,7 +72,11 @@ func (s *SweeperCommand) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	if s.clusterPrefix == "" && s.clusterName == "" && !s.all {
 		return fmt.Errorf("either --cluster-prefix, --cluster-name, or --all must be specified")
 	}
-	aws, err := e2e.NewAWSConfig(ctx)
+	aws, err := e2e.NewAWSConfig(ctx,
+		// We use a custom AppId so the requests show that they were
+		// made by this command in the user-agent
+		config.WithAppID("nodeadm-e2e-test-sweeper-cmd"),
+	)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)
 	}

--- a/test/e2e/run/e2e.go
+++ b/test/e2e/run/e2e.go
@@ -206,8 +206,12 @@ func (e *E2E) runCleanup(ctx context.Context) []Phase {
 		return nil
 	}
 
+	// We use a custom AppId so the requests show that they were
+	// made by this cleanup in the user-agent
+	aws := e.AwsCfg.Copy()
+	aws.AppID = "nodeadm-e2e-test-run-cleanup"
 	cleaner := E2ECleanup{
-		AwsCfg:        e.AwsCfg,
+		AwsCfg:        aws,
 		Logger:        newFileLogger(e.Paths.CleanupLog, e.NoColor),
 		TestResources: e.TestResources,
 	}

--- a/test/e2e/suite/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm_test.go
@@ -50,7 +50,12 @@ var _ = SynchronizedBeforeSuite(
 		Expect(err).NotTo(HaveOccurred(), "should read valid test configuration")
 
 		logger := newLoggerForTests().Logger
-		aws, err := e2e.NewAWSConfig(ctx, awsconfig.WithRegion(config.ClusterRegion))
+		aws, err := e2e.NewAWSConfig(ctx,
+			awsconfig.WithRegion(config.ClusterRegion),
+			// We use a custom AppId so the requests show that they were
+			// made by the e2e suite in the user-agent
+			awsconfig.WithAppID("nodeadm-e2e-test-suite"),
+		)
 		Expect(err).NotTo(HaveOccurred())
 
 		infra, err := peered.Setup(ctx, logger, aws, config.ClusterName, config.Endpoint)

--- a/test/e2e/suite/peered_vpc.go
+++ b/test/e2e/suite/peered_vpc.go
@@ -94,7 +94,11 @@ func buildPeeredVPCTestForSuite(ctx context.Context, suite *suiteConfiguration) 
 		skipCleanup:            suite.SkipCleanup,
 	}
 
-	aws, err := e2e.NewAWSConfig(ctx, awsconfig.WithRegion(suite.TestConfig.ClusterRegion))
+	aws, err := e2e.NewAWSConfig(ctx, awsconfig.WithRegion(suite.TestConfig.ClusterRegion),
+		// We use a custom AppId so the requests show that they were
+		// made by this test in the user-agent
+		awsconfig.WithAppID("nodeadm-e2e-test"),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
*Description of changes:*
This is useful when debugging calls in cloudtrail, specially for concurrent runs and conflicts with cleanups.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

