### PR TITLE
Upload nodeadm induvidually during test stage

### DIFF
--- a/ATTRIBUTION.txt
+++ b/ATTRIBUTION.txt
@@ -5,10 +5,10 @@ https://github.com/aws/aws-sdk-go
 ** github.com/aws/aws-sdk-go-v2; version v1.36.3 --
 https://github.com/aws/aws-sdk-go-v2
 
-** github.com/aws/aws-sdk-go-v2/config; version v1.29.8 --
+** github.com/aws/aws-sdk-go-v2/config; version v1.29.14 --
 https://github.com/aws/aws-sdk-go-v2/config
 
-** github.com/aws/aws-sdk-go-v2/credentials; version v1.17.61 --
+** github.com/aws/aws-sdk-go-v2/credentials; version v1.17.67 --
 https://github.com/aws/aws-sdk-go-v2/credentials
 
 ** github.com/aws/aws-sdk-go-v2/feature/ec2/imds; version v1.16.30 --
@@ -23,13 +23,13 @@ https://github.com/aws/aws-sdk-go-v2/internal/endpoints/v2
 ** github.com/aws/aws-sdk-go-v2/internal/ini; version v1.8.3 --
 https://github.com/aws/aws-sdk-go-v2/internal/ini
 
-** github.com/aws/aws-sdk-go-v2/service/ec2; version v1.206.0 --
+** github.com/aws/aws-sdk-go-v2/service/ec2; version v1.211.3 --
 https://github.com/aws/aws-sdk-go-v2/service/ec2
 
-** github.com/aws/aws-sdk-go-v2/service/ecr; version v1.42.0 --
+** github.com/aws/aws-sdk-go-v2/service/ecr; version v1.43.3 --
 https://github.com/aws/aws-sdk-go-v2/service/ecr
 
-** github.com/aws/aws-sdk-go-v2/service/eks; version v1.59.0 --
+** github.com/aws/aws-sdk-go-v2/service/eks; version v1.63.2 --
 https://github.com/aws/aws-sdk-go-v2/service/eks
 
 ** github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding; version v1.12.3 --
@@ -38,25 +38,25 @@ https://github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding
 ** github.com/aws/aws-sdk-go-v2/service/internal/presigned-url; version v1.12.15 --
 https://github.com/aws/aws-sdk-go-v2/service/internal/presigned-url
 
-** github.com/aws/aws-sdk-go-v2/service/rolesanywhere; version v1.17.0 --
+** github.com/aws/aws-sdk-go-v2/service/rolesanywhere; version v1.17.2 --
 https://github.com/aws/aws-sdk-go-v2/service/rolesanywhere
 
-** github.com/aws/aws-sdk-go-v2/service/ssm; version v1.57.0 --
+** github.com/aws/aws-sdk-go-v2/service/ssm; version v1.58.2 --
 https://github.com/aws/aws-sdk-go-v2/service/ssm
 
-** github.com/aws/aws-sdk-go-v2/service/sso; version v1.25.0 --
+** github.com/aws/aws-sdk-go-v2/service/sso; version v1.25.3 --
 https://github.com/aws/aws-sdk-go-v2/service/sso
 
-** github.com/aws/aws-sdk-go-v2/service/ssooidc; version v1.29.0 --
+** github.com/aws/aws-sdk-go-v2/service/ssooidc; version v1.30.1 --
 https://github.com/aws/aws-sdk-go-v2/service/ssooidc
 
-** github.com/aws/aws-sdk-go-v2/service/sts; version v1.33.16 --
+** github.com/aws/aws-sdk-go-v2/service/sts; version v1.33.19 --
 https://github.com/aws/aws-sdk-go-v2/service/sts
 
 ** github.com/aws/smithy-go; version v1.22.3 --
 https://github.com/aws/smithy-go
 
-** github.com/containerd/containerd/integration; version v1.7.26 --
+** github.com/containerd/containerd/integration; version v1.7.27 --
 https://github.com/containerd/containerd
 
 ** github.com/coreos/go-systemd/v22/dbus; version v22.5.0 --
@@ -92,7 +92,7 @@ https://github.com/modern-go/concurrent
 ** github.com/modern-go/reflect2; version v1.0.2 --
 https://github.com/modern-go/reflect2
 
-** github.com/prometheus/client_golang/prometheus; version v1.21.0 --
+** github.com/prometheus/client_golang/prometheus; version v1.21.1 --
 https://github.com/prometheus/client_golang
 
 ** github.com/prometheus/client_model/go; version v0.6.1 --
@@ -113,49 +113,52 @@ https://github.com/open-telemetry/opentelemetry-go
 ** go.opentelemetry.io/otel/trace; version v1.34.0 --
 https://github.com/open-telemetry/opentelemetry-go
 
-** google.golang.org/genproto/googleapis/rpc/status; version v0.0.0-20250227231956-55c901821b1e --
+** google.golang.org/genproto/googleapis/rpc/status; version v0.0.0-20250303144028-a0af3efb3deb --
 https://github.com/googleapis/go-genproto
 
-** google.golang.org/grpc; version v1.70.0 --
+** google.golang.org/grpc; version v1.71.0 --
 https://github.com/grpc/grpc-go
 
-** k8s.io/api; version v0.32.2 --
+** k8s.io/api; version v0.32.3 --
 https://github.com/kubernetes/api
 
-** k8s.io/apimachinery/pkg; version v0.32.2 --
+** k8s.io/apimachinery/pkg; version v0.32.3 --
 https://github.com/kubernetes/apimachinery
 
-** k8s.io/client-go; version v0.32.2 --
+** k8s.io/client-go; version v0.32.3 --
 https://github.com/kubernetes/client-go
 
-** k8s.io/component-base; version v0.32.2 --
+** k8s.io/component-base; version v0.32.3 --
 https://github.com/kubernetes/component-base
 
-** k8s.io/cri-api/pkg/apis/runtime/v1; version v0.32.2 --
+** k8s.io/cri-api/pkg/apis/runtime/v1; version v0.32.3 --
 https://github.com/kubernetes/cri-api
 
 ** k8s.io/klog/v2; version v2.130.1 --
 https://github.com/kubernetes/klog
 
-** k8s.io/kube-openapi/pkg; version v0.0.0-20241212222426-2c72e554b1e7 --
+** k8s.io/kube-openapi/pkg; version v0.0.0-20250304201544-e5f78fe3ede9 --
 https://github.com/kubernetes/kube-openapi
 
-** k8s.io/kube-openapi/pkg/validation/spec; version v0.0.0-20241212222426-2c72e554b1e7 --
+** k8s.io/kube-openapi/pkg/validation/spec; version v0.0.0-20250304201544-e5f78fe3ede9 --
 https://github.com/kubernetes/kube-openapi
 
-** k8s.io/kubelet/config/v1beta1; version v0.32.2 --
+** k8s.io/kubelet/config/v1beta1; version v0.32.3 --
 https://github.com/kubernetes/kubelet
 
 ** k8s.io/utils; version v0.0.0-20241210054802-24370beab758 --
 https://github.com/kubernetes/utils
 
-** sigs.k8s.io/controller-runtime/pkg/scheme; version v0.20.2 --
+** sigs.k8s.io/controller-runtime/pkg/scheme; version v0.20.4 --
 https://github.com/kubernetes-sigs/controller-runtime
 
 ** sigs.k8s.io/json; version v0.0.0-20241014173422-cfa47c3a1cc8 --
 https://github.com/kubernetes-sigs/json
 
-** sigs.k8s.io/structured-merge-diff/v4; version v4.5.0 --
+** sigs.k8s.io/randfill; version v1.0.0 --
+https://github.com/kubernetes-sigs/randfill
+
+** sigs.k8s.io/structured-merge-diff/v4; version v4.6.0 --
 https://github.com/kubernetes-sigs/structured-merge-diff
 
 ** sigs.k8s.io/yaml; version v1.4.0 --
@@ -446,6 +449,33 @@ This product includes software developed at
 SoundCloud Ltd. (http://soundcloud.com/).
 
 
+* For sigs.k8s.io/randfill see also this required NOTICE:
+When donating the randfill project to the CNCF, we could not reach all the
+gofuzz contributors to sign the CNCF CLA. As such, according to the CNCF rules
+to donate a repository, we must add a NOTICE referencing section 7 of the CLA
+with a list of developers who could not be reached.
+
+`7. Should You wish to submit work that is not Your original creation, You may
+submit it to the Foundation separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which you are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".`
+
+Submitted on behalf of a third-party: @dnephin (Daniel Nephin)
+Submitted on behalf of a third-party: @AlekSi (Alexey Palazhchenko)
+Submitted on behalf of a third-party: @bbigras (Bruno Bigras)
+Submitted on behalf of a third-party: @samirkut (Samir)
+Submitted on behalf of a third-party: @posener (Eyal Posener)
+Submitted on behalf of a third-party: @Ashikpaul (Ashik Paul)
+Submitted on behalf of a third-party: @kwongtailau (Kwongtai)
+Submitted on behalf of a third-party: @ericcornelissen (Eric Cornelissen)
+Submitted on behalf of a third-party: @eclipseo (Robert-André Mauchin)
+Submitted on behalf of a third-party: @yanzhoupan (Andrew Pan)
+Submitted on behalf of a third-party: @STRRL (Zhiqiang ZHOU)
+Submitted on behalf of a third-party: @disconnect3d (Disconnect3d)
+
+
 * For sigs.k8s.io/yaml/goyaml.v2 see also this required NOTICE:
 Copyright 2011-2016 Canonical Ltd.
 
@@ -597,13 +627,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ** github.com/aws/aws-sdk-go/internal/sync/singleflight; version v1.55.6 --
 https://github.com/aws/aws-sdk-go
 
-** github.com/ProtonMail/go-crypto; version v1.1.6 --
+** github.com/ProtonMail/go-crypto; version v1.2.0 --
 https://github.com/ProtonMail/go-crypto
 
-** golang.org/go; version go1.23.6 --
+** golang.org/go; version go1.23.8 --
 https://github.com/golang/go
 
-** k8s.io/apimachinery/third_party/forked/golang; version v0.32.2 --
+** k8s.io/apimachinery/third_party/forked/golang; version v0.32.3 --
 https://github.com/kubernetes/apimachinery
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -910,7 +940,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil; version v1.21.0 --
+** github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil; version v1.21.1 --
 https://github.com/prometheus/client_golang
 
 Copyright (c) 2013 The Go Authors. All rights reserved.
@@ -977,25 +1007,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/x/crypto; version v0.35.0 --
+** golang.org/x/crypto; version v0.37.0 --
 https://golang.org/x/crypto
 
-** golang.org/x/mod/semver; version v0.23.0 --
+** golang.org/x/mod/semver; version v0.24.0 --
 https://golang.org/x/mod
 
-** golang.org/x/net; version v0.35.0 --
+** golang.org/x/net; version v0.37.0 --
 https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.27.0 --
 https://golang.org/x/oauth2
 
-** golang.org/x/sys; version v0.30.0 --
+** golang.org/x/sys; version v0.32.0 --
 https://golang.org/x/sys
 
-** golang.org/x/term; version v0.29.0 --
+** golang.org/x/term; version v0.31.0 --
 https://golang.org/x/term
 
-** golang.org/x/text; version v0.22.0 --
+** golang.org/x/text; version v0.24.0 --
 https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.10.0 --
@@ -1129,7 +1159,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json; version v0.0.0-20241212222426-2c72e554b1e7 --
+** k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json; version v0.0.0-20250304201544-e5f78fe3ede9 --
 https://github.com/kubernetes/kube-openapi
 
 Copyright (c) 2020 The Go Authors. All rights reserved.
@@ -1284,7 +1314,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ------
 
-** github.com/ProtonMail/gopenpgp/v3; version v3.1.3 --
+** github.com/ProtonMail/gopenpgp/v3; version v3.2.0 --
 https://github.com/ProtonMail/gopenpgp/v3
 Copyright (c) 2019 Proton Technologies AG
 

--- a/buildspecs/build-nodeadm.yml
+++ b/buildspecs/build-nodeadm.yml
@@ -4,8 +4,6 @@ phases:
   build:
     commands:
     - make build-cross-platform build-cross-e2e-tests-binary build-cross-e2e-test install-cross-ginkgo
-    - aws s3 sync --no-progress _bin/amd64/ s3://$ARTIFACTS_BUCKET/latest-pre/linux/amd64/
-    - aws s3 sync --no-progress _bin/arm64/ s3://$ARTIFACTS_BUCKET/latest-pre/linux/arm64/
     - echo $GIT_VERSION >> _bin/GIT_VERSION
 
 cache:

--- a/buildspecs/test-nodeadm.yml
+++ b/buildspecs/test-nodeadm.yml
@@ -6,10 +6,22 @@ env:
     RHEL_PASSWORD: "nodeadm-e2e-tests-redhat-credentials:password"
 
 phases:
+  pre_build:
+    commands:
+      - echo "Setting up for e2e tests..."
+      - export BUILD_NUMBER=${CODEBUILD_BUILD_NUMBER:-1}
+      - export VERSION="build-${BUILD_NUMBER}"
+
   build:
     commands:
-    - SANITIZED_CODEBUILD_BUILD_ID=$(echo $CODEBUILD_BUILD_ID | tr ':' '-')
-    - ./hack/run-e2e.sh $SANITIZED_CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/latest-pre/linux/amd64/nodeadm s3://$ARTIFACTS_BUCKET/latest-pre/linux/arm64/nodeadm $LOGS_BUCKET e2e-artifacts
+      # Upload binaries to versioned paths
+      - echo "Uploading binaries for e2e tests..."
+      - aws s3 cp --no-progress _bin/amd64/nodeadm s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/amd64/nodeadm
+      - aws s3 cp --no-progress _bin/arm64/nodeadm s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/arm64/nodeadm
+      
+      # Run the e2e tests with versioned paths
+      - SANITIZED_CODEBUILD_BUILD_ID=$(echo $CODEBUILD_BUILD_ID | tr ':' '-')
+      - ./hack/run-e2e.sh $SANITIZED_CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/amd64/nodeadm s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/arm64/nodeadm $LOGS_BUCKET e2e-artifacts
 
 reports:
   e2e-reports:


### PR DESCRIPTION
*Description of changes:*
We have multiple pipelines that re-use the build stage/buildspec, which uploads the binaries to s3 buckets. These are later used in the test stages. Due to having multiple build stages, the binaries get overwritten during test stage and could result in faulty test results. This change seperate the logic where build stage only builds and passes on the binaries to the next stages. The test stage uploads the binaries to a versioned path which they later consume during their tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

