### PR TITLE
Generate attribution as part of prod release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,9 @@ generate-attribution:
 .PHONY: generate-attribution-in-docker
 generate-attribution-in-docker:
 	mkdir -p _output/.go/mod/cache
+	chmod -R 777 _output
 	docker run --rm --pull=always -e GOPROXY=$(GOPROXY) -e GOMODCACHE=/mod-cache -v  $$(pwd)/_output/.go/mod/cache:/mod-cache -v $$(pwd):/eks-hybrid public.ecr.aws/eks-distro-build-tooling/builder-base:standard-latest.al23 make -C /eks-hybrid generate-attribution
+	rm -rf _output
 
 ##@ Build Dependencies
 

--- a/buildspecs/prod-release-nodeadm.yml
+++ b/buildspecs/prod-release-nodeadm.yml
@@ -47,6 +47,11 @@ phases:
       - aws s3 cp --no-progress _bin/amd64/nodeadm.sha512 s3://${PROD_BUCKET}/latest/bin/linux/amd64/nodeadm.sha512 --profile artifacts-production
       - aws s3 cp --no-progress _bin/arm64/nodeadm.sha512 s3://${PROD_BUCKET}/latest/bin/linux/arm64/nodeadm.sha512 --profile artifacts-production
 
+      - echo "Generating and uploading attribution..."
+      - make generate-attribution
+      - aws s3 cp --no-progress ATTRIBUTION.txt s3://${PROD_BUCKET}/releases/${VERSION}/ATTRIBUTION.txt --profile artifacts-production
+      - aws s3 cp --no-progress ATTRIBUTION.txt s3://${PROD_BUCKET}/latest/ATTRIBUTION.txt --profile artifacts-production 
+
   post_build:
     commands:
       - echo "Invalidating CloudFront cache..."

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -68,7 +68,7 @@ function gather_licenses() {
   # data about each dependency to generate the amazon approved attribution.txt files
   # go-deps is needed for module versions
   # go-licenses are all the dependencies found from the module(s) that were passed in via patterns
-  go list -deps=true -json ./... | jq -s ''  > "${outputdir}/attribution/go-deps.json"
+  go list -deps=true -json ./... | jq -s '.'  > "${outputdir}/attribution/go-deps.json"
 
   go-licenses save --force $patterns --save_path="${outputdir}/LICENSES"
 


### PR DESCRIPTION
*Description of changes:*
Generates attribution file as part of prod release. Also has few fixes to run attribution generation on AL2023 base image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

