### PR TITLE
Print logs with readable time and disable stack

### DIFF
--- a/internal/cli/logger.go
+++ b/internal/cli/logger.go
@@ -2,15 +2,20 @@ package cli
 
 import (
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func NewLogger(opts *GlobalOptions) *zap.Logger {
 	var logger *zap.Logger
 	var err error
+
 	if opts.DevelopmentMode {
 		logger, err = zap.NewDevelopment()
 	} else {
-		logger, err = zap.NewProduction()
+		config := zap.NewProductionConfig()
+		config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+		config.DisableStacktrace = true
+		logger, err = config.Build()
 	}
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
*Description of changes:*
Although perhaps easier to parse, timestamps in epoch is almos unreadable. ISO8601 should make easier to debug timing issues.

In addition, I find quite annoying to have the stacktrace on the fatal print line and the end when the command files because this is captured where Fatal is called and not where the error originated. Hence, it's always "main.go.....runtime/proc.go...". This is useless and creates noise when trying to figure out what the actual error is.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

