### PR TITLE
Clean up transit gateways in sweeper

### DIFF
--- a/test/e2e/cleanup/sweeper.go
+++ b/test/e2e/cleanup/sweeper.go
@@ -136,6 +136,10 @@ func (c *Sweeper) Run(ctx context.Context, input SweeperInput) error {
 			FailureMessage: "cleaning up network interfaces",
 		},
 		{
+			Cleanup:        c.cleanupTransitGateways,
+			FailureMessage: "cleaning up transit gateways",
+		},
+		{
 			Cleanup:        c.cleanupSubnets,
 			FailureMessage: "cleaning up subnets",
 		},
@@ -635,6 +639,26 @@ func (c *Sweeper) cleanupSecurityGroups(ctx context.Context, filterInput FilterI
 	for _, securityGroupID := range securityGroupIDs {
 		if err := vpcCleaner.DeleteSecurityGroup(ctx, securityGroupID); err != nil {
 			return fmt.Errorf("deleting security group %s: %w", securityGroupID, err)
+		}
+	}
+	return nil
+}
+
+func (c *Sweeper) cleanupTransitGateways(ctx context.Context, filterInput FilterInput) error {
+	vpcCleaner := NewVPCCleaner(c.ec2Client, c.logger)
+	transitGatewayIDs, err := vpcCleaner.ListTransitGateways(ctx, filterInput)
+	if err != nil {
+		return fmt.Errorf("listing transit gateways: %w", err)
+	}
+
+	c.logger.Info("Deleting transit gateways", "transitGatewayIDs", transitGatewayIDs)
+	if filterInput.DryRun {
+		return nil
+	}
+
+	for _, transitGatewayID := range transitGatewayIDs {
+		if err := vpcCleaner.DeleteTransitGateway(ctx, transitGatewayID); err != nil {
+			return fmt.Errorf("deleting transit gateway %s: %w", transitGatewayID, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds functionality to clean up tgw in sweeper. If somehow cfn fails to clean up transit gateway after #363 is merged, it can be cleaned up in sweeper.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

