### PR TITLE
adds nodeadm version as e2e test report entry

### DIFF
--- a/test/e2e/constants/constants.go
+++ b/test/e2e/constants/constants.go
@@ -15,6 +15,7 @@ const (
 	TestConformancePath             = "TestConformancePath"
 	TestLogBundleFile               = "TestLogBundleFile"
 	TestSerialOutputLogFile         = "TestSerialOutputLogFile"
+	TestNodeadmVersion              = "TestNodeadmVersion"
 	TestS3LogsFolder                = "logs"
 	SerialOutputLogFile             = "serial-output.log"
 	TestInstanceNameKubernetesLabel = "test.eks-hybrid.amazonaws.com/node-name"

--- a/test/e2e/nodeadm/commands.go
+++ b/test/e2e/nodeadm/commands.go
@@ -3,6 +3,7 @@ package nodeadm
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/eks-hybrid/test/e2e/commands"
 )
@@ -90,4 +91,21 @@ func RunNodeadmDebug(ctx context.Context, runner commands.RemoteCommandRunner, i
 	}
 
 	return nil
+}
+
+func RunNodeadmVersion(ctx context.Context, runner commands.RemoteCommandRunner, instanceIP string) (string, error) {
+	commands := []string{
+		"/tmp/nodeadm version",
+	}
+
+	output, err := runner.Run(ctx, instanceIP, commands)
+	if err != nil {
+		return "", fmt.Errorf("running remote command: %w", err)
+	}
+
+	if output.Status != "Success" {
+		return "", fmt.Errorf("nodeadm version remote command did not succeed")
+	}
+
+	return strings.TrimSpace(output.StandardOutput), nil
 }

--- a/test/e2e/run/e2e.go
+++ b/test/e2e/run/e2e.go
@@ -64,6 +64,7 @@ type FailedTest struct {
 	InstanceName        string `json:"instanceName"`
 	GinkgoLog           string `json:"ginkgoLog"`
 	Name                string `json:"name"`
+	NodeadmVersion      string `json:"nodeadmVersion"`
 	SerialLog           string `json:"serialLog"`
 	State               string `json:"state"`
 }

--- a/test/e2e/run/report.go
+++ b/test/e2e/run/report.go
@@ -117,6 +117,11 @@ func (e *E2EReport) parseJSONReport(reportPath string) (E2EResult, error) {
 			failedTest.CollectorLogsBundle = collectorLogsURL
 		}
 
+		nodeadmVersion := getReportEntry(spec, constants.TestNodeadmVersion)
+		if nodeadmVersion != "" {
+			failedTest.NodeadmVersion = nodeadmVersion
+		}
+
 		e2eResult.FailedTests = append(e2eResult.FailedTests, failedTest)
 
 		// Only process "It" test nodes for detailed logs

--- a/test/e2e/suite/test_node.go
+++ b/test/e2e/suite/test_node.go
@@ -94,6 +94,10 @@ func (n *testNode) Start(ctx context.Context) error {
 		n.serialOutput.It("joins the cluster", func() {
 			n.waitForNodeToJoin(ctx, flakeRun)
 		})
+		version, err := nodeadm.RunNodeadmVersion(ctx, n.PeeredNode.RemoteCommandRunner, n.node.Instance.IP)
+		Expect(err).NotTo(HaveOccurred(), "nodeadm version should have been retrieved successfully")
+		Expect(version).NotTo(BeEmpty(), "nodeadm version should not be empty")
+		AddReportEntry(constants.TestNodeadmVersion, version)
 	})
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds the nodeadm version as a report entry and e2e-result field so we can easily see the version of nodeadm used by the e2e test.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

