### PR TITLE
adds --timeout to nodeadm install in e2e tests

### DIFF
--- a/test/e2e/os/testdata/nodeadm-init.sh
+++ b/test/e2e/os/testdata/nodeadm-init.sh
@@ -25,7 +25,10 @@ mv /tmp/nodeadm-wrapper.sh /tmp/nodeadm
 
 
 echo "Installing kubernetes components"
-/tmp/nodeadm install $KUBERNETES_VERSION $NODEADM_ADDITIONAL_ARGS --credential-provider $PROVDER --region $REGION
+# the test will wait up to 10 minutes for the node to become ready
+# we give install 8 minutes, which should be more than enough, but in case it does
+# timeout due to issues downloading the artifacts, the logs will more clearly indicate this as the cause of the failure
+/tmp/nodeadm install $KUBERNETES_VERSION $NODEADM_ADDITIONAL_ARGS --credential-provider $PROVDER --region $REGION --timeout 8m
 
 echo "Initializing the node"
 /tmp/nodeadm init -c file:///nodeadm-config.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We have seen failures where the install will hang and the test will timeout and the resulting logs are a bit confusing to follow, they look like the node just died.  This doesn't fix anything, but it will make it more clear when there the install process takes more than 8 mins that something in that process was the issue and not a node dying.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

