### PR TITLE
allows printJson to take any for printing e2eresult

### DIFF
--- a/test/e2e/run/e2e.go
+++ b/test/e2e/run/e2e.go
@@ -111,7 +111,7 @@ func (e *E2E) Run(ctx context.Context) (E2EResult, error) {
 
 	phases, err := e.preTestSetup()
 	if err != nil {
-		return E2EResult{Phases: phases}, err
+		return E2EResult{Phases: phases, NodeadmE2eTestResultJSON: true}, err
 	}
 
 	// save 5 minutes for cleanup and 2 minutes for reporting/s3 uploading
@@ -138,6 +138,7 @@ func (e *E2E) Run(ctx context.Context) (E2EResult, error) {
 	phases = append(phases, uploadPhases...)
 
 	e2eResult.Phases = phases
+	e2eResult.NodeadmE2eTestResultJSON = true
 	var allErrors error
 	for _, phase := range phases {
 		if phase.Error != nil {

--- a/test/e2e/run/output.go
+++ b/test/e2e/run/output.go
@@ -13,8 +13,7 @@ type E2EOutput struct {
 	ClusterRegion       string
 }
 
-func (e *E2EOutput) PrintJSON(e2eResult E2EResult) error {
-	e2eResult.NodeadmE2eTestResultJSON = true
+func (e *E2EOutput) PrintJSON(e2eResult any) error {
 	buf := new(bytes.Buffer)
 	encoder := json.NewEncoder(buf)
 	encoder.SetEscapeHTML(false)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the canary we would like to add additional data to the printed json blob.  This should allow us to use a different struct, wrapping the E2EResult, and then pass that to the PrintJSON func.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

