### PR TITLE
include cred stack failure reason in error

### DIFF
--- a/test/e2e/cfn/cloudformation.go
+++ b/test/e2e/cfn/cloudformation.go
@@ -1,0 +1,81 @@
+package cfn
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/aws/eks-hybrid/test/e2e/errors"
+)
+
+func GetStackFailureReason(ctx context.Context, client *cloudformation.Client, stackName string) (string, error) {
+	resp, err := client.DescribeStackEvents(ctx, &cloudformation.DescribeStackEventsInput{
+		StackName: &stackName,
+	})
+	if err != nil {
+		return "", fmt.Errorf("describing events for stack %s: %w", stackName, err)
+	}
+	firstFailedEventTimestamp := time.Now()
+	var firstFailedEventReason string
+	for _, event := range resp.StackEvents {
+		if event.ResourceStatus == types.ResourceStatusCreateFailed ||
+			event.ResourceStatus == types.ResourceStatusUpdateFailed ||
+			event.ResourceStatus == types.ResourceStatusDeleteFailed {
+			if event.ResourceStatusReason == nil {
+				continue
+			}
+
+			timestamp := aws.ToTime(event.Timestamp)
+			if timestamp.Before(firstFailedEventTimestamp) {
+				firstFailedEventTimestamp = timestamp
+
+				var resourceID string
+				if event.LogicalResourceId != nil {
+					resourceID = *event.LogicalResourceId
+				} else {
+					resourceID = "UnknownResource"
+				}
+				firstFailedEventReason = fmt.Sprintf("%s for %s: %s", event.ResourceStatus, resourceID, *event.ResourceStatusReason)
+			}
+		}
+	}
+
+	return firstFailedEventReason, nil
+}
+
+// WaitForStackOperation waits for a stack to reach Create/Update/Delete Complete
+// when the operation fails, it will attempt to gather the failure reason and include it in the error
+func WaitForStackOperation(ctx context.Context, client *cloudformation.Client, stackName string, stackWaitInterval, stackWaitTimeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(ctx, stackWaitInterval, stackWaitTimeout, true, func(ctx context.Context) (bool, error) {
+		stackOutput, err := client.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
+			StackName: aws.String(stackName),
+		})
+		if err != nil {
+			if errors.IsCFNStackNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+
+		stackStatus := stackOutput.Stacks[0].StackStatus
+		switch stackStatus {
+		case types.StackStatusCreateComplete, types.StackStatusUpdateComplete, types.StackStatusDeleteComplete:
+			return true, nil
+		case types.StackStatusCreateInProgress, types.StackStatusUpdateInProgress, types.StackStatusDeleteInProgress, types.StackStatusUpdateCompleteCleanupInProgress:
+			return false, nil
+		default:
+			failureReason, err := GetStackFailureReason(ctx, client, stackName)
+			if err != nil {
+				return false, fmt.Errorf("stack %s failed with status %s. Failed getting failure reason: %w", stackName, stackStatus, err)
+			}
+			return false, fmt.Errorf("stack %s failed with status: %s. Potential root cause: [%s]", stackName, stackStatus, failureReason)
+		}
+	})
+
+	return err
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We had a failure during the beforesuite, due to the role name conflicting, but we werent including the failure reason for the cred stack. We were already doing this for the infra stack.

This moves the code around a bit to reuse the same waitFor/failurereason logic in both the cred and infra stack as well as the stack cleanup.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

