### PR TITLE
node monitoring agent test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ cover.out
 coverage.out
 .idea
 .vscode
+.zed
 .DS_Store
 vendor
 e2e-artifacts

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GIT_VERSION?=0.0.0
 MANIFEST_HOST?=hybrid-assets.eks.amazonaws.com
 HYBRID_MANIFEST_URL=https://$(MANIFEST_HOST)/manifest.yaml
 
-E2E_SUITES?=./test/e2e/suite/nodeadm ./test/e2e/suite/conformance
+E2E_SUITES?=./test/e2e/suite/nodeadm ./test/e2e/suite/conformance ./test/e2e/suite/addons
 
 .PHONY: all
 all: crds generate fmt vet build
@@ -70,7 +70,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: ## Run validate tests.
-	$(GO) test ./... 
+	$(GO) test ./...
 
 COVERAGEFILE = $(LOCALBIN)/coverage.out
 .PHONY: coverage

--- a/internal/kubernetes/wait.go
+++ b/internal/kubernetes/wait.go
@@ -57,8 +57,13 @@ func GetAndWait[O runtime.Object](ctx context.Context, timeout time.Duration, ge
 // It will retry until the timeout is reached or the condition is met.
 // To allow for longer wait times while avoiding to retry non-transient errors,
 // we only retry up to 3 consecutive errors coming from the API server.
-func ListAndWait[O runtime.Object](ctx context.Context, timeout time.Duration, list Lister[O], ready func(O) bool) (O, error) {
+func ListAndWait[O runtime.Object](ctx context.Context, timeout time.Duration, list Lister[O], ready func(O) bool, opts ...ListOption) (O, error) {
+	listOpt := &ListOptions{}
+	for _, opt := range opts {
+		opt(listOpt)
+	}
+
 	return WaitFor(ctx, timeout, func(ctx context.Context) (O, error) {
-		return list.List(ctx, metav1.ListOptions{})
+		return list.List(ctx, listOpt.ListOptions)
 	}, ready)
 }

--- a/test/e2e/addon/nodemonitoringagent.go
+++ b/test/e2e/addon/nodemonitoringagent.go
@@ -1,0 +1,178 @@
+package addon
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	clientgo "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	ik8s "github.com/aws/eks-hybrid/internal/kubernetes"
+	"github.com/aws/eks-hybrid/test/e2e/commands"
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+)
+
+const (
+	nodeMonitoringAgentNamespace = "kube-system"
+	nodeMonitoringAgentName      = "eks-node-monitoring-agent"
+	lockupDaemonSetName          = "kernel-soft-lockup"
+	lockupContainerNamespace     = "default"
+
+	nodeMonitoringAgentWaitTimeout = 1 * time.Minute
+)
+
+type NodeMonitoringAgentTest struct {
+	Cluster       string
+	addon         *Addon
+	K8S           clientgo.Interface
+	EKSClient     *eks.Client
+	K8SConfig     *rest.Config
+	Logger        logr.Logger
+	CommandRunner commands.RemoteCommandRunner
+}
+
+func (n *NodeMonitoringAgentTest) Create(ctx context.Context) error {
+	n.addon = &Addon{
+		Cluster:   n.Cluster,
+		Namespace: nodeMonitoringAgentNamespace,
+		Name:      nodeMonitoringAgentName,
+	}
+
+	if err := n.addon.CreateAndWaitForActive(ctx, n.EKSClient, n.K8S, n.Logger); err != nil {
+		return err
+	}
+
+	if _, err := ik8s.GetAndWait(ctx, nodeMonitoringAgentWaitTimeout, n.K8S.AppsV1().DaemonSets(n.addon.Namespace), n.addon.Name, func(ds *appsv1.DaemonSet) bool {
+		return ds.Status.DesiredNumberScheduled == ds.Status.NumberReady
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (n *NodeMonitoringAgentTest) runKernelError(ctx context.Context, nodes *v1.NodeList) error {
+	for _, node := range nodes.Items {
+		ip := kubernetes.GetNodeInternalIP(&node)
+		if ip == "" {
+			return fmt.Errorf("failed to get internal IP for node %s", node.Name)
+		}
+		// This command simulates a kernel error on the node
+		// Node Monitoring Agent should detect this and create an event for SoftLockup
+		// citing KernelReady as the reason.
+		if _, err := n.CommandRunner.Run(ctx, ip, []string{"echo 'watchdog: BUG: soft lockup - CPU#6 stuck for 23s! [VM Thread:4054]' | tee -a /dev/kmsg"}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (n *NodeMonitoringAgentTest) Validate(ctx context.Context) error {
+	nodes, err := ik8s.ListRetry(ctx, n.K8S.CoreV1().Nodes())
+	if err != nil {
+		return err
+	}
+
+	if err := n.runKernelError(ctx, nodes); err != nil {
+		return err
+	}
+
+	for _, node := range nodes.Items {
+		nodeLogger := n.Logger.WithValues("node", node.Name)
+
+		if err := validateNodeConditions(node, nodeLogger); err != nil {
+			return err
+		}
+
+		if err := validateNodeEvents(ctx, n.K8S, node, nodeLogger); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateNodeConditions(node v1.Node, nodeLogger logr.Logger) error {
+	foundMonitoringConditions := false
+	for _, condition := range node.Status.Conditions {
+		if isMonitoringAgentCondition(condition) {
+			foundMonitoringConditions = true
+			nodeLogger.Info("Found monitoring agent condition",
+				"type", condition.Type,
+				"status", condition.Status,
+				"message", condition.Message)
+			break
+		}
+	}
+
+	if !foundMonitoringConditions {
+		return fmt.Errorf("no monitoring agent conditions found")
+	}
+
+	return nil
+}
+
+func validateNodeEvents(ctx context.Context, k8s clientgo.Interface, node v1.Node, nodeLogger logr.Logger) error {
+	fieldSelector := fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Node", node.Name)
+
+	_, err := ik8s.ListAndWait(ctx, nodeMonitoringAgentWaitTimeout, k8s.CoreV1().Events(""), func(events *v1.EventList) bool {
+		foundMonitoringEvents := false
+		for _, event := range events.Items {
+			if isMonitoringAgentEvent(event) {
+				foundMonitoringEvents = true
+				nodeLogger.Info("Found monitoring agent event",
+					"message", event.Message,
+					"reason", event.Reason,
+					"count", event.Count)
+				break
+			}
+		}
+		return foundMonitoringEvents
+	}, func(opts *ik8s.ListOptions) { opts.FieldSelector = fieldSelector })
+	if err != nil {
+		return fmt.Errorf("failed to get kernel error event for node %s after retries: %v", node.Name, err)
+	}
+
+	return nil
+}
+
+// Helper function to identify monitoring agent conditions
+func isMonitoringAgentCondition(condition v1.NodeCondition) bool {
+	monitoringConditionTypes := []string{
+		"StorageReady",
+		"NetworkingReady",
+		"KernelReady",
+		"ContainerRuntimeReady",
+	}
+
+	return slices.Contains(monitoringConditionTypes, string(condition.Type))
+}
+
+func isMonitoringAgentEvent(event v1.Event) bool {
+	return strings.Contains(strings.ToLower(event.Source.Component), nodeMonitoringAgentName)
+}
+
+func (n *NodeMonitoringAgentTest) PrintLogs(ctx context.Context) error {
+	logs, err := kubernetes.FetchLogs(ctx, n.K8S, n.addon.Name, n.addon.Namespace, func(opts *ik8s.ListOptions) {
+		opts.LabelSelector = fmt.Sprintf("%s=%s", "app.kubernetes.io/name", n.addon.Name)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to collect logs for %s: %v", n.addon.Name, err)
+	}
+
+	n.Logger.Info("Logs for node monitoring agent", "controller", logs)
+	return nil
+}
+
+func (n *NodeMonitoringAgentTest) Delete(ctx context.Context) error {
+	return n.addon.Delete(ctx, n.EKSClient, n.Logger)
+}

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -62,7 +62,7 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, getAddonTimeout)
 	defer cancel()
 
-	if err := podIdentityAddon.WaitUtilActive(timeoutCtx, v.EKSClient, v.Logger); err != nil {
+	if err := podIdentityAddon.WaitUntilActive(timeoutCtx, v.EKSClient, v.Logger); err != nil {
 		return fmt.Errorf("waiting for pod identity add-on to be active: %w", err)
 	}
 

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -1,0 +1,41 @@
+package suite
+
+import (
+	"github.com/aws/eks-hybrid/test/e2e/addon"
+	"github.com/aws/eks-hybrid/test/e2e/ssm"
+)
+
+// AddonEc2Test is a wrapper around the fields needed for addon tests
+// that decouples the PeeredVPCTest from specific addon test implementations.
+type AddonEc2Test struct {
+	*PeeredVPCTest
+}
+
+// NewNodeMonitoringAgentTest creates a new NodeMonitoringAgentTest
+func (a *AddonEc2Test) NewNodeMonitoringAgentTest() *addon.NodeMonitoringAgentTest {
+	commandRunner := ssm.NewSSHOnSSMCommandRunner(a.SSMClient, a.JumpboxInstanceId, a.Logger)
+	return &addon.NodeMonitoringAgentTest{
+		Cluster:       a.Cluster.Name,
+		K8S:           a.k8sClient,
+		EKSClient:     a.eksClient,
+		K8SConfig:     a.K8sClientConfig,
+		Logger:        a.Logger,
+		CommandRunner: commandRunner,
+	}
+}
+
+// NewVerifyPodIdentityAddon creates a new VerifyPodIdentityAddon
+func (a *AddonEc2Test) NewVerifyPodIdentityAddon(nodeName string) *addon.VerifyPodIdentityAddon {
+	return &addon.VerifyPodIdentityAddon{
+		Cluster:             a.Cluster.Name,
+		NodeName:            nodeName,
+		PodIdentityS3Bucket: a.podIdentityS3Bucket,
+		K8S:                 a.k8sClient,
+		EKSClient:           a.eksClient,
+		IAMClient:           a.iamClient,
+		S3Client:            a.s3Client,
+		Logger:              a.Logger,
+		K8SConfig:           a.K8sClientConfig,
+		Region:              a.Cluster.Region,
+	}
+}

--- a/test/e2e/suite/addons/addons_test.go
+++ b/test/e2e/suite/addons/addons_test.go
@@ -1,0 +1,117 @@
+//go:build e2e
+// +build e2e
+
+package addons
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+
+	"github.com/aws/eks-hybrid/test/e2e"
+	"github.com/aws/eks-hybrid/test/e2e/suite"
+)
+
+var (
+	filePath    string
+	suiteConfig *suite.SuiteConfiguration
+)
+
+const numberOfNodes = 1
+
+func init() {
+	flag.StringVar(&filePath, "filepath", "", "Path to configuration")
+}
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Addon Smoke Test Suite")
+}
+
+var _ = SynchronizedBeforeSuite(
+	func(ctx context.Context) []byte {
+		suiteConfig := suite.BeforeSuiteCredentialSetup(ctx, filePath)
+		test := suite.BeforeVPCTest(ctx, &suiteConfig)
+		credentialProviders := suite.AddClientsToCredentialProviders(suite.CredentialProviders(), test)
+		osList := suite.OSProviderList(credentialProviders)
+
+		// pick 3 random OS/Version/Provider combinations for metricsServer tests worker nodes
+		nodesToCreate := make([]suite.NodeCreate, 0, numberOfNodes)
+
+		rand.Shuffle(len(osList), func(i, j int) {
+			osList[i], osList[j] = osList[j], osList[i]
+		})
+
+		for i := range numberOfNodes {
+			os := osList[i].OS
+			provider := osList[i].Provider
+			nodesToCreate = append(nodesToCreate, suite.NodeCreate{
+				OS:           os,
+				Provider:     provider,
+				InstanceName: test.InstanceName("addon-smoke-test", os, provider),
+				InstanceSize: e2e.Large,
+				NodeName:     fmt.Sprintf("addon-test-node-%s-%s", provider.Name(), os.Name()),
+			})
+		}
+		suite.CreateNodes(ctx, test, nodesToCreate)
+
+		suiteJson, err := yaml.Marshal(suiteConfig)
+		Expect(err).NotTo(HaveOccurred(), "suite config should be marshalled successfully")
+		return suiteJson
+	},
+	// This function runs on all processes, and it receives the data from
+	// the first process (a json serialized struct)
+	// The only thing that we want to do here is unmarshal the data into
+	// a struct that we can make accessible from the tests. We leave the rest
+	// for the per tests setup code.
+	func(ctx context.Context, data []byte) {
+		suiteConfig = suite.BeforeSuiteCredentialUnmarshal(ctx, data)
+	},
+)
+
+var _ = Describe("Hybrid Nodes", func() {
+	When("using peered VPC", func() {
+		var addonEc2Test *suite.AddonEc2Test
+
+		BeforeEach(func(ctx context.Context) {
+			addonEc2Test = &suite.AddonEc2Test{PeeredVPCTest: suite.BeforeVPCTest(ctx, suiteConfig)}
+		})
+
+		When("using ec2 instance as hybrid nodes", func() {
+			It("runs node monitoring agent tests", func(ctx context.Context) {
+				nodeMonitoringAgent := addonEc2Test.NewNodeMonitoringAgentTest()
+
+				DeferCleanup(func(ctx context.Context) {
+					Expect(nodeMonitoringAgent.Delete(ctx)).To(Succeed(), "should cleanup node monitoring agent successfully")
+				})
+
+				Expect(nodeMonitoringAgent.Create(ctx)).To(
+					Succeed(), "node monitoring agent should have created successfully",
+				)
+
+				DeferCleanup(func(ctx context.Context) {
+					// only print logs after addon successfully created
+					report := CurrentSpecReport()
+					if report.State.Is(types.SpecStateFailed) {
+						err := nodeMonitoringAgent.PrintLogs(ctx)
+						if err != nil {
+							// continue cleanup even if logs collection fails
+							GinkgoWriter.Printf("Failed to get node monitoring agent logs: %v\n", err)
+						}
+					}
+				})
+
+				Expect(nodeMonitoringAgent.Validate(ctx)).To(
+					Succeed(), "node monitoring agent should have been validated successfully",
+				)
+			}, Label("node-monitoring-agent"))
+		})
+	})
+})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds end-to-end tests for the EKS Node Monitoring Agent addon. Key changes include:

**Added**
- New smoke test suite for addons testing
- Node Monitoring Agent E2E test implementation
- Support for validating node conditions and events created by monitoring agent
- Log collection capabilities to addon struct for debugging failures


*Testing (if applicable):*
Tested with k8s 1.31 and Cilium

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

