### PR TITLE
Bump pod identity timeout to 10 mins

### DIFF
--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	getAddonTimeout           = 2 * time.Minute
+	getAddonTimeout           = 8 * time.Minute
 	podIdentityDaemonSet      = "eks-pod-identity-agent-hybrid"
 	podIdentityToken          = "eks-pod-identity-token"
 	policyName                = "pod-identity-association-role-policy"

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	getAddonTimeout           = 8 * time.Minute
+	getAddonTimeout           = 10 * time.Minute
 	podIdentityDaemonSet      = "eks-pod-identity-agent-hybrid"
 	podIdentityToken          = "eks-pod-identity-token"
 	policyName                = "pod-identity-association-role-policy"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump timeout to 10 mins for pod identity add on since we're seeing lots of context exceeded errors due to 2 minute timeout; from logs it has looked like it's taken up to 7 mins to add on to be ready (often due to waiting on a single pod in daemonset to be in ready state)

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

