### PR TITLE
Remove k8s 1.25 from e2e tests

### DIFF
--- a/hybrid-nodes-cdk/lib/constants.ts
+++ b/hybrid-nodes-cdk/lib/constants.ts
@@ -1,5 +1,5 @@
 export const builderBaseImage = 'public.ecr.aws/eks-distro-build-tooling/builder-base:standard-latest.al2';
-export const kubernetesVersions = ['1.25', '1.26', '1.27', '1.28', '1.29', '1.30', '1.31', '1.32'];
+export const kubernetesVersions = ['1.26', '1.27', '1.28', '1.29', '1.30', '1.31', '1.32'];
 export const betaKubeVersions: Array<string> = [];
 export const cnis = ['calico', 'cilium'];
 export const eksHybridBetaBucketARN = 'arn:aws:s3:::eks-hybrid-beta';

--- a/test/e2e/kubernetes/version.go
+++ b/test/e2e/kubernetes/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	MinimumVersion = "1.25"
+	MinimumVersion = "1.26"
 )
 
 func PreviousVersion(kubernetesVersion string) (string, error) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removes k8s 1.25 from e2e tests as its no longer in extended EKS support.

https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

