### PR TITLE
Add instance type param to node create command

### DIFF
--- a/cmd/e2e-test/node/create.go
+++ b/cmd/e2e-test/node/create.go
@@ -31,6 +31,7 @@ type create struct {
 	configFile    string
 	instanceName  string
 	instanceSize  string
+	instanceType  string
 	credsProvider string
 	os            string
 	arch          string
@@ -51,6 +52,7 @@ func NewCreateCommand() cli.Command {
 	createCmd.String(&cmd.os, "o", "os", "OS to use (al23, ubuntu2004, ubuntu2204, ubuntu2404, rhel8, rhel9).")
 	createCmd.String(&cmd.arch, "a", "arch", "Architecture to use (amd64, arm64).")
 	createCmd.String(&cmd.instanceSize, "s", "instance-size", "Instance size to use (Large, XLarge).")
+	createCmd.String(&cmd.instanceType, "t", "instance-type", "Instance type to use (t3.large, g4dn.xlarge, etc). If provided, instance size would be ignored.")
 
 	cmd.flaggy = createCmd
 
@@ -149,6 +151,7 @@ func (c *create) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	peerdNode, err := node.Create(ctx, &peered.NodeSpec{
 		InstanceName:   c.instanceName,
 		InstanceSize:   instanceSize,
+		InstanceType:   c.instanceType,
 		NodeK8sVersion: cluster.KubernetesVersion,
 		NodeName:       c.instanceName,
 		OS:             nodeOS,

--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -46,6 +46,7 @@ type NodeSpec struct {
 	EKSEndpoint        string
 	InstanceName       string
 	InstanceSize       e2e.InstanceSize
+	InstanceType       string
 	InstanceProfileARN string
 	NodeK8sVersion     string
 	NodeName           string
@@ -134,12 +135,16 @@ func (c NodeCreate) Create(ctx context.Context, spec *NodeSpec) (PeerdNode, erro
 		return PeerdNode{}, fmt.Errorf("expected to successfully retrieve ami id: %w", err)
 	}
 
-	instanceSize := spec.InstanceSize
+	instanceType := spec.InstanceType
+	if instanceType == "" {
+		instanceType = spec.OS.InstanceType(c.Cluster.Region, spec.InstanceSize)
+	}
+
 	ec2Input := ec2.InstanceConfig{
 		ClusterName:        c.Cluster.Name,
 		InstanceName:       spec.InstanceName,
 		AmiID:              amiId,
-		InstanceType:       spec.OS.InstanceType(c.Cluster.Region, instanceSize),
+		InstanceType:       instanceType,
 		VolumeSize:         ec2VolumeSize,
 		SubnetID:           c.Cluster.SubnetID,
 		SecurityGroupID:    c.Cluster.SecurityGroupID,


### PR DESCRIPTION
*Issue #, if available:*

We can't use the `node create` to create ec2 instance with different instance types. This is inconvenient when I need to create EC2 GPU instance.

*Description of changes:*

With this PR, now we can pass instance type to `node create` command. Sample command:
```
./_bin/e2e-test node create -c ssm -f e2e-param.yaml -o al23 -a amd64 -t g4dn.xlarge al23-2
```

*Testing (if applicable):*
Tested manually


