### PR TITLE
Enable one ubuntu docker test

### DIFF
--- a/hack/SKIPPED_TESTS.yaml
+++ b/hack/SKIPPED_TESTS.yaml
@@ -1,4 +1,3 @@
 skipped_tests:
   - "ubuntu2004-amd64-docker.*"
   - "ubuntu2204-amd64-docker.*"
-  - "ubuntu2404-amd64-docker.*"

--- a/hack/SKIPPED_TESTS.yaml
+++ b/hack/SKIPPED_TESTS.yaml
@@ -1,3 +1,4 @@
 skipped_tests:
   - "ubuntu2004-amd64-docker.*"
   - "ubuntu2204-amd64-docker.*"
+  - "ubuntu2404-amd64-docker.*ssm.*"


### PR DESCRIPTION
*Description of changes:*
We currently do not run any ubuntu-docker repo test, this enables simple flow docker tests on ubuntu 2404

*Testing (if applicable):*
```
With OS ubuntu2404-amd64-docker and with Credential Provider iam-ra [ubuntu2404-amd64-docker, iam-ra, simpleflow, init]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

