### PR TITLE
Remove private subnet from hybrid VPC for e2e

### DIFF
--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -278,16 +278,6 @@ Resources:
       RouteTableId: !Ref HybridNodeRouteTable
       SubnetId: !Ref HybridNodeVPCPublicSubnet
 
-  HybridNodePrivateRouteTable:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref HybridNodeVPC
-      Tags:
-        - Key: Name
-          Value: !Sub ${ClusterName}-hybrid-private-route-table
-        - Key: !Ref TestClusterTagKey
-          Value: !Ref ClusterName
-
   HybridNodeDefaultSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
@@ -445,17 +435,6 @@ Resources:
     DependsOn: HybridNodeVPCAttachment
     Properties:
       RouteTableId: !Ref HybridNodeRouteTable
-      DestinationCidrBlock: !Ref ClusterVPCCidr
-      TransitGatewayId: !Ref ClusterToHybridTGW
-
-  HybridNodePrivateRouteToCluster:
-    Type: AWS::EC2::Route
-    # This explicit dep is needed to ensure the TransitGatewayAttachment is created before the route is created
-    # CFN can't infer this because the route links to the TGW instead of the attachment, so it doesn't know the attachment is a dependency
-    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html#gatewayattachment
-    DependsOn: HybridNodeVPCAttachment
-    Properties:
-      RouteTableId: !Ref HybridNodePrivateRouteTable
       DestinationCidrBlock: !Ref ClusterVPCCidr
       TransitGatewayId: !Ref ClusterToHybridTGW
 

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -34,10 +34,6 @@ Parameters:
     Type: String
     Description: EKS Hybrid Nodes public subnet VPC CIDR block
 
-  HybridNodePrivateSubnetCidr:
-    Type: String
-    Description: EKS Hybrid Nodes public subnet VPC CIDR block
-
   TestClusterTagKey:
     Type: String
     Description: Tag key of all the resources
@@ -238,20 +234,6 @@ Resources:
           Value: !Ref CreationTime
       VpcId: !Ref HybridNodeVPC
 
-  HybridNodeVPCPrivateSubnet:
-    Type: AWS::EC2::Subnet
-    Properties:
-      AvailabilityZone: !Select [1, !GetAZs '']
-      CidrBlock: !Ref HybridNodePrivateSubnetCidr
-      Tags:
-        - Key: Name
-          Value: !Sub ${ClusterName}-hybrid-private-subnet
-        - Key: !Ref TestClusterTagKey
-          Value: !Ref ClusterName
-        - Key: !Ref CreationTimeTagKey
-          Value: !Ref CreationTime
-      VpcId: !Ref HybridNodeVPC
-
   HybridNodePublicSubnetInternetGateway:
     Type: AWS::EC2::InternetGateway
     Properties:
@@ -305,12 +287,6 @@ Resources:
           Value: !Sub ${ClusterName}-hybrid-private-route-table
         - Key: !Ref TestClusterTagKey
           Value: !Ref ClusterName
-
-  HybridNodePrivateSubnetRouteTableAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref HybridNodePrivateRouteTable
-      SubnetId: !Ref HybridNodeVPCPrivateSubnet
 
   HybridNodeDefaultSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -377,9 +353,6 @@ Resources:
       TransitGatewayId: !Ref ClusterToHybridTGW
       VpcId: !Ref HybridNodeVPC
       SubnetIds:
-        # These 2 subnets are in different AZs so we need both
-        # Adding a subnet in an AZ gives the TGW the ability to route to all subnets in that AZ
-        - !Ref HybridNodeVPCPrivateSubnet
         - !Ref HybridNodeVPCPublicSubnet
       Tags:
         - Key: Name

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -237,10 +237,9 @@ func SetTestResourcesDefaults(testResources TestResources) TestResources {
 	}
 	if testResources.HybridNetwork == (NetworkConfig{}) {
 		testResources.HybridNetwork = NetworkConfig{
-			VpcCidr:           "10.1.0.0/16",
-			PublicSubnetCidr:  "10.1.1.0/24",
-			PrivateSubnetCidr: "10.1.2.0/24",
-			PodCidr:           "10.2.0.0/16",
+			VpcCidr:          "10.1.0.0/16",
+			PublicSubnetCidr: "10.1.1.0/24",
+			PodCidr:          "10.2.0.0/16",
 		}
 	}
 

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -139,10 +139,6 @@ func (s *stack) prepareStackParameters(test TestResources, eks EKSConfig) []type
 			ParameterValue: aws.String(test.HybridNetwork.PublicSubnetCidr),
 		},
 		{
-			ParameterKey:   aws.String("HybridNodePrivateSubnetCidr"),
-			ParameterValue: aws.String(test.HybridNetwork.PrivateSubnetCidr),
-		},
-		{
 			ParameterKey:   aws.String("HybridNodePodCidr"),
 			ParameterValue: aws.String(test.HybridNetwork.PodCidr),
 		},


### PR DESCRIPTION
*Issue #, if available:*

While testing metrics server, I found the availability for metrics server endpoint bounce between true and false. It turns out that when it fails, the network traffic is routed to private subnet of hybrid VPC eventually, which doesn't have pod CIDR route.

*Description of changes:*

In this PR, I am removing private subnet from hybrid VPC for now. Current setup for E2E doesn't require private subnet at this point. 

*Testing (if applicable):*

Tested manually.

*Documentation added/planned (if applicable):*
