### PR TITLE
Add retries around kubernetes validations

### DIFF
--- a/internal/aws/sts/validate.go
+++ b/internal/aws/sts/validate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/network"
+	"github.com/aws/eks-hybrid/internal/retry"
 	"github.com/aws/eks-hybrid/internal/validation"
 )
 
@@ -24,7 +25,10 @@ func CheckEndpointAccess(ctx context.Context, config aws.Config) error {
 		return fmt.Errorf("resolving sts endpoint: %w", err)
 	}
 
-	if err := network.CheckConnectionToHost(ctx, endpoint.URI); err != nil {
+	err = retry.NetworkRequest(ctx, func(ctx context.Context) error {
+		return network.CheckConnectionToHost(ctx, endpoint.URI)
+	})
+	if err != nil {
 		return fmt.Errorf("checking connection to sts endpoint: %w", err)
 	}
 
@@ -59,7 +63,11 @@ func (a AuthenticationValidator) Run(ctx context.Context, informer validation.In
 	}()
 
 	client := sts_sdk.NewFromConfig(a.aws)
-	_, err = client.GetCallerIdentity(ctx, &sts_sdk.GetCallerIdentityInput{})
+
+	err = retry.NetworkRequest(ctx, func(ctx context.Context) error {
+		_, err := client.GetCallerIdentity(ctx, &sts_sdk.GetCallerIdentityInput{})
+		return err
+	})
 	if err != nil {
 		err = validation.WithRemediation(err, "Check your AWS configuration and make sure you can obtain valid AWS credentials.")
 		return err

--- a/internal/aws/sts/validate_test.go
+++ b/internal/aws/sts/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/gomega"
@@ -31,7 +32,7 @@ func TestCheckEndpointAccessSuccess(t *testing.T) {
 
 func TestCheckEndpointAccessFailure(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, 10*time.Millisecond)
 
 	config := aws.Config{
 		BaseEndpoint: aws.String("https://localhost:1234"),
@@ -65,7 +66,7 @@ func TestAccessValidatorRunSuccess(t *testing.T) {
 
 func TestAccessValidatorRunFailCheckingEndpoint(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, 10*time.Millisecond)
 
 	config := aws.Config{
 		BaseEndpoint: aws.String("https://localhost:1234"),
@@ -82,7 +83,7 @@ func TestAccessValidatorRunFailCheckingEndpoint(t *testing.T) {
 
 func TestAccessValidatorRunErrorFromGetCaller(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, 10*time.Millisecond)
 
 	server := test.NewHTTPSServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)

--- a/internal/iamrolesanywhere/validate.go
+++ b/internal/iamrolesanywhere/validate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/network"
+	"github.com/aws/eks-hybrid/internal/retry"
 	"github.com/aws/eks-hybrid/internal/validation"
 )
 
@@ -24,7 +25,10 @@ func CheckEndpointAccess(ctx context.Context, config aws.Config) error {
 		return fmt.Errorf("resolving IAM Roles Anywhere endpoint: %w", err)
 	}
 
-	if err := network.CheckConnectionToHost(ctx, endpoint.URI); err != nil {
+	err = retry.NetworkRequest(ctx, func(ctx context.Context) error {
+		return network.CheckConnectionToHost(ctx, endpoint.URI)
+	})
+	if err != nil {
 		return fmt.Errorf("checking connection to IAM Roles Anywhere endpoint: %w", err)
 	}
 

--- a/internal/iamrolesanywhere/validate_test.go
+++ b/internal/iamrolesanywhere/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/gomega"
@@ -31,7 +32,7 @@ func TestCheckEndpointAccessSuccess(t *testing.T) {
 
 func TestCheckEndpointAccessFailure(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, 10*time.Millisecond)
 
 	config := aws.Config{
 		BaseEndpoint: aws.String("https://localhost:1234"),
@@ -64,7 +65,7 @@ func TestAccessValidatorRunSuccess(t *testing.T) {
 
 func TestAccessValidatorRunFail(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, 10*time.Millisecond)
 
 	config := aws.Config{
 		BaseEndpoint: aws.String("https://localhost:1234"),

--- a/internal/kubernetes/access_test.go
+++ b/internal/kubernetes/access_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
@@ -51,7 +52,7 @@ func TestAccessValidatorRunFailSuccess(t *testing.T) {
 
 func TestAccessValidatorRunFailReadingClusterDetails(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, 10*time.Millisecond)
 	informer := test.NewFakeInformer()
 
 	unauthResponse := &apiServerResponse{
@@ -92,7 +93,7 @@ func TestAccessValidatorRunFailReadingClusterDetails(t *testing.T) {
 
 func TestAccessValidatorRunFailValidatingAccess(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, 10*time.Millisecond)
 	informer := test.NewFakeInformer()
 
 	unauthResponse := &apiServerResponse{

--- a/internal/kubernetes/connection.go
+++ b/internal/kubernetes/connection.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/network"
+	"github.com/aws/eks-hybrid/internal/retry"
 	"github.com/aws/eks-hybrid/internal/validation"
 )
 
@@ -23,7 +24,10 @@ func CheckConnection(ctx context.Context, informer validation.Informer, node *ap
 		return err
 	}
 
-	if err = network.CheckConnectionToHost(ctx, *endpoint); err != nil {
+	err = retry.NetworkRequest(ctx, func(ctx context.Context) error {
+		return network.CheckConnectionToHost(ctx, *endpoint)
+	})
+	if err != nil {
 		err = validation.WithRemediation(err, "Ensure your network configuration allows the node to access the Kubernetes API endpoint.")
 		return err
 	}

--- a/internal/kubernetes/connection_test.go
+++ b/internal/kubernetes/connection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -34,7 +35,7 @@ func TestCheckConnectionSuccess(t *testing.T) {
 
 func TestCheckConnectionInvalidURL(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, 10*time.Millisecond)
 	informer := test.NewFakeInformer()
 
 	config := &api.NodeConfig{
@@ -54,7 +55,7 @@ func TestCheckConnectionInvalidURL(t *testing.T) {
 
 func TestCheckConnectionFailureWithAccess(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, 10*time.Millisecond)
 	informer := test.NewFakeInformer()
 
 	config := &api.NodeConfig{
@@ -68,6 +69,6 @@ func TestCheckConnectionFailureWithAccess(t *testing.T) {
 	err := kubernetes.CheckConnection(ctx, informer, config)
 	g.Expect(err).NotTo(Succeed())
 	g.Expect(informer.Started).To(BeTrue())
-	g.Expect(informer.DoneWith).To(HaveOccurred())
+	g.Expect(informer.DoneWith).To(MatchError(ContainSubstring("connect: connection refused")))
 	g.Expect(validation.Remediation(informer.DoneWith)).To(Equal("Ensure your network configuration allows the node to access the Kubernetes API endpoint."))
 }

--- a/internal/kubernetes/unauthenticated_test.go
+++ b/internal/kubernetes/unauthenticated_test.go
@@ -47,7 +47,7 @@ func TestMakeUnauthenticatedRequestSuccess(t *testing.T) {
 
 func TestMakeUnauthenticatedRequestBadCA(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, time.Second)
 
 	resp := &apiServerResponse{
 		Status:  "Failure",
@@ -65,7 +65,7 @@ func TestMakeUnauthenticatedRequestBadCA(t *testing.T) {
 
 func TestMakeUnauthenticatedRequestBadEndpoint(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, time.Second)
 
 	resp := &apiServerResponse{
 		Status:  "Failure",
@@ -83,7 +83,7 @@ func TestMakeUnauthenticatedRequestBadEndpoint(t *testing.T) {
 
 func TestMakeUnauthenticatedRequestEndpointDown(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, time.Second)
 
 	resp := &apiServerResponse{
 		Status:  "Failure",
@@ -96,12 +96,13 @@ func TestMakeUnauthenticatedRequestEndpointDown(t *testing.T) {
 
 	err := kubernetes.MakeUnauthenticatedRequest(ctx, "https://my-cluster.example.com", server.CAPEM())
 	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("no such host"))
 	g.Expect(validation.Remediation(err)).To(Equal("Ensure the provided Kubernetes API server endpoint is correct and the CA certificate is valid for that endpoint."))
 }
 
 func TestMakeUnauthenticatedRequestNotForbidden(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, time.Second)
 
 	resp := &apiServerResponse{
 		Status:  "Failure",
@@ -119,7 +120,7 @@ func TestMakeUnauthenticatedRequestNotForbidden(t *testing.T) {
 
 func TestMakeUnauthenticatedRequestUnauthorized(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, time.Second)
 
 	resp := &apiServerResponse{
 		Status:  "Failure",
@@ -163,7 +164,7 @@ func TestCheckUnauthenticatedAccessSuccess(t *testing.T) {
 
 func TestCheckUnauthenticatedAccessError(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, time.Second)
 	informer := test.NewFakeInformer()
 
 	resp := &apiServerResponse{

--- a/internal/node/validations.go
+++ b/internal/node/validations.go
@@ -3,66 +3,17 @@ package node
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/aws/eks-hybrid/internal/kubelet"
+	k8s "github.com/aws/eks-hybrid/internal/kubernetes"
 	"github.com/aws/eks-hybrid/internal/node/hybrid"
 )
 
 const defaultStaticPodManifestPath = "/etc/kubernetes/manifest"
-
-const (
-	nodeValidationInterval   = 10 * time.Second
-	nodeValidationTimeout    = 1 * time.Minute
-	nodeValidationMaxRetries = 5
-)
-
-// NodeValidationOptions are options to configure node validations.
-type NodeValidationOptions struct {
-	ValidationInterval time.Duration
-	ValidationTimeout  time.Duration
-	MaxRetries         int
-}
-
-// NodeValidationOption defines a function type for setting options.
-type NodeValidationOption func(*NodeValidationOptions)
-
-// DefaultNodeValidationOptions returns the default configuration options.
-func DefaultNodeValidationOptions() NodeValidationOptions {
-	return NodeValidationOptions{
-		ValidationInterval: nodeValidationInterval,
-		ValidationTimeout:  nodeValidationTimeout,
-		MaxRetries:         nodeValidationMaxRetries,
-	}
-}
-
-// WithValidationInterval sets the validation interval.
-func WithValidationInterval(interval time.Duration) NodeValidationOption {
-	return func(opts *NodeValidationOptions) {
-		opts.ValidationInterval = interval
-	}
-}
-
-// WithValidationTimeout sets the validation timeout.
-func WithValidationTimeout(timeout time.Duration) NodeValidationOption {
-	return func(opts *NodeValidationOptions) {
-		opts.ValidationTimeout = timeout
-	}
-}
-
-// WithMaxRetries sets the maximum number of retries.
-func WithMaxRetries(maxRetries int) NodeValidationOption {
-	return func(opts *NodeValidationOptions) {
-		opts.MaxRetries = maxRetries
-	}
-}
 
 func IsUnscheduled(ctx context.Context) error {
 	node, err := getCurrentNode(ctx)
@@ -129,30 +80,5 @@ func getCurrentNode(ctx context.Context) (*v1.Node, error) {
 		return nil, err
 	}
 
-	return getNode(ctx, nodeName, clientset)
-}
-
-func getNode(ctx context.Context, nodeName string, clientset kubernetes.Interface, options ...NodeValidationOption) (*v1.Node, error) {
-	opts := DefaultNodeValidationOptions()
-
-	for _, option := range options {
-		option(&opts)
-	}
-
-	var node *v1.Node
-	var err error
-	consecutiveErrors := 0
-	err = wait.PollUntilContextTimeout(ctx, opts.ValidationInterval, opts.ValidationTimeout, true, func(ctx context.Context) (bool, error) {
-		node, err = clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-		if err != nil {
-			consecutiveErrors += 1
-			if consecutiveErrors == opts.MaxRetries {
-				return false, errors.Wrap(err, "failed to get current node")
-			}
-			return false, nil // continue polling
-		}
-		return true, nil
-	})
-
-	return node, err
+	return k8s.GetRetry(ctx, clientset.CoreV1().Nodes(), nodeName)
 }

--- a/internal/node/validations_wb_test.go
+++ b/internal/node/validations_wb_test.go
@@ -1,18 +1,12 @@
 package node
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/aws/smithy-go/ptr"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 func Test_isDrained(t *testing.T) {
@@ -58,54 +52,6 @@ func Test_isDrained(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			g.Expect(isDrained(tc.pods)).To(Equal(tc.want))
-		})
-	}
-}
-
-func Test_getNode(t *testing.T) {
-	nodeName := "test"
-	testCases := []struct {
-		name            string
-		node            *corev1.Node
-		setupFakeClient func() kubernetes.Interface
-		err             error
-	}{
-		{
-			name: "success",
-			setupFakeClient: func() kubernetes.Interface {
-				client := fake.NewSimpleClientset()
-				node := &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeName,
-					},
-				}
-				_, _ = client.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
-				return client
-			},
-			err: nil,
-		},
-		{
-			name: "consecutive errors",
-			setupFakeClient: func() kubernetes.Interface {
-				return fake.NewSimpleClientset()
-			},
-			err: errors.NewNotFound(schema.GroupResource{Group: "", Resource: "nodes"}, nodeName),
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewWithT(t)
-			client := tc.setupFakeClient()
-
-			node, err := getNode(context.Background(), nodeName, client, WithValidationInterval(1*time.Millisecond))
-
-			if tc.err != nil {
-				g.Expect(err).To(MatchError(tc.err))
-			} else {
-				g.Expect(err).To(BeNil())
-				g.Expect(node).ToNot(BeNil())
-				g.Expect(node.Name).To(Equal(nodeName))
-			}
 		})
 	}
 }

--- a/internal/ssm/validate.go
+++ b/internal/ssm/validate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/network"
+	"github.com/aws/eks-hybrid/internal/retry"
 	"github.com/aws/eks-hybrid/internal/validation"
 )
 
@@ -24,7 +25,10 @@ func CheckEndpointAccess(ctx context.Context, config aws.Config) error {
 		return fmt.Errorf("resolving ssm endpoint: %w", err)
 	}
 
-	if err := network.CheckConnectionToHost(ctx, endpoint.URI); err != nil {
+	err = retry.NetworkRequest(ctx, func(ctx context.Context) error {
+		return network.CheckConnectionToHost(ctx, endpoint.URI)
+	})
+	if err != nil {
 		return fmt.Errorf("checking connection to ssm endpoint: %w", err)
 	}
 

--- a/internal/ssm/validate_test.go
+++ b/internal/ssm/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/gomega"
@@ -31,7 +32,7 @@ func TestCheckEndpointAccessSuccess(t *testing.T) {
 
 func TestCheckEndpointAccessFailure(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, 10*time.Millisecond)
 
 	config := aws.Config{
 		BaseEndpoint: aws.String("https://localhost:1234"),
@@ -64,7 +65,7 @@ func TestAccessValidatorRunSuccess(t *testing.T) {
 
 func TestAccessValidatorRunFail(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := test.ContextWithTimeout(t, 10*time.Millisecond)
 
 	config := aws.Config{
 		BaseEndpoint: aws.String("https://localhost:1234"),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Seeing issues in the e2e tests where the validations in the debug command fails due to timeouts. Wrapping these operations to retry to fix the flakiness

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


