### PR TITLE
Update IAM role names to be unique to avoid collisions

### DIFF
--- a/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
+++ b/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
@@ -13,6 +13,13 @@ Parameters:
   rolePathPrefix:
     Type: String
     Description: The path prefix for the IAM roles.
+  SSMRolePrefix:
+    Type: String
+    Default: 'ssm'
+  IRARolePrefix:
+    Type: String
+    Default: 'ira'
+ 
     
 Resources:
   SSMRole:
@@ -20,20 +27,11 @@ Resources:
     Properties: 
       # use a predictable prefix for SSM role while maintaining uniqueness requirement for SSM role name
       RoleName:
-        Fn::Join:
-        - '-'
-        - - 'ssm-role'
-          - !Ref AWS::AccountId
-          - !Ref AWS::Region
-          - Fn::Select:
-            - 0
-            - Fn::Split:
-              - '-'
-              - Fn::Select:
-                - 2
-                - Fn::Split:
-                  - /
-                  - !Ref AWS::StackId
+        !Sub
+          - '${RolePrefix}-${TrimmedRegion}${UUID}'
+          - RolePrefix: !Ref SSMRolePrefix
+            TrimmedRegion: !Join ['', !Split ['-', !Ref AWS::Region]]
+            UUID: !Join ['', !Split ['-', !Select [2, !Split [/, !Ref AWS::StackId]]]]
       AssumeRolePolicyDocument: 
         Version: '2012-10-17'
         Statement: 
@@ -106,20 +104,11 @@ Resources:
     Properties:
       # use a predictable prefix for IRA role while maintaining uniqueness requirement for IRA role name
       RoleName:
-        Fn::Join:
-        - '-'
-        - - 'ira-role'
-          - !Ref AWS::AccountId
-          - !Ref AWS::Region
-          - Fn::Select:
-            - 0
-            - Fn::Split:
-              - '-'
-              - Fn::Select:
-                - 2
-                - Fn::Split:
-                  - /
-                  - !Ref AWS::StackId
+        !Sub
+          - '${RolePrefix}-${TrimmedRegion}${UUID}'
+          - RolePrefix: !Ref IRARolePrefix
+            TrimmedRegion: !Join ['', !Split ['-', !Ref AWS::Region]]
+            UUID: !Join ['', !Split ['-', !Select [2, !Split [/, !Ref AWS::StackId]]]]
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly
         - arn:aws:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy


### PR DESCRIPTION

Description of changes:

IAM role name collisions were occurring between stacks when their UUIDs started with the same segment. Modified the IAM role naming pattern to use the full UUID instead of first segment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


