### PR TITLE
fixes upgrade and uninstall when using containerd-source:none

### DIFF
--- a/cmd/nodeadm/install/install.go
+++ b/cmd/nodeadm/install/install.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/eks-hybrid/internal/logger"
 	"github.com/aws/eks-hybrid/internal/packagemanager"
 	"github.com/aws/eks-hybrid/internal/ssm"
+	"github.com/aws/eks-hybrid/internal/tracker"
 )
 
 const installHelpText = `Examples:
@@ -29,7 +30,8 @@ Documentation:
 
 func NewCommand() cli.Command {
 	cmd := command{
-		timeout: 20 * time.Minute,
+		timeout:          20 * time.Minute,
+		containerdSource: string(tracker.ContainerdSourceDistro),
 	}
 	cmd.region = ssm.DefaultSsmInstallerRegion
 
@@ -79,11 +81,10 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return err
 	}
 
-	// Default containerd source to distro
-	if c.containerdSource == "" {
-		c.containerdSource = string(containerd.ContainerdSourceDistro)
+	containerdSource, err := tracker.ContainerdSource(c.containerdSource)
+	if err != nil {
+		return err
 	}
-	containerdSource := containerd.GetContainerdSource(c.containerdSource)
 	if err := containerd.ValidateContainerdSource(containerdSource); err != nil {
 		return err
 	}

--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/eks-hybrid/internal/cleanup"
 	"github.com/aws/eks-hybrid/internal/cli"
 	"github.com/aws/eks-hybrid/internal/cni"
-	"github.com/aws/eks-hybrid/internal/containerd"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/flows"
 	"github.com/aws/eks-hybrid/internal/kubelet"
@@ -113,7 +112,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 
 	log.Info("Creating package manager...")
-	containerdSource := containerd.GetContainerdSource(installed.Artifacts.Containerd)
+	containerdSource := installed.Artifacts.Containerd
 	log.Info("Configuring package manager with", zap.Reflect("containerd source", string(containerdSource)))
 	packageManager, err := packagemanager.New(containerdSource, log)
 	if err != nil {

--- a/cmd/nodeadm/upgrade/upgrade.go
+++ b/cmd/nodeadm/upgrade/upgrade.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/aws/eks-hybrid/internal/aws"
 	"github.com/aws/eks-hybrid/internal/cli"
-	"github.com/aws/eks-hybrid/internal/containerd"
 	"github.com/aws/eks-hybrid/internal/creds"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/flows"
@@ -169,7 +168,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 
 	log.Info("Creating package manager...")
-	containerdSource := containerd.GetContainerdSource(installed.Artifacts.Containerd)
+	containerdSource := installed.Artifacts.Containerd
 	log.Info("Configuring package manager with", zap.Reflect("containerd source", string(containerdSource)))
 	packageManager, err := packagemanager.New(containerdSource, log)
 	if err != nil {

--- a/internal/flows/install.go
+++ b/internal/flows/install.go
@@ -23,7 +23,7 @@ import (
 
 type Installer struct {
 	AwsSource          aws.Source
-	ContainerdSource   containerd.SourceName
+	ContainerdSource   tracker.ContainerdSourceName
 	PackageManager     *packagemanager.DistroPackageManager
 	CredentialProvider creds.CredentialProvider
 	SsmRegion          string

--- a/internal/flows/uninstall.go
+++ b/internal/flows/uninstall.go
@@ -100,7 +100,7 @@ func (u *Uninstaller) uninstallDaemons(ctx context.Context) error {
 			}
 		}
 	}
-	if containerd.GetContainerdSource(u.Artifacts.Containerd) != containerd.ContainerdSourceNone {
+	if u.Artifacts.Containerd != tracker.ContainerdSourceNone {
 		u.Logger.Info("Uninstalling containerd...")
 		if err := u.DaemonManager.StopDaemon(containerd.ContainerdDaemonName); err != nil {
 			return err

--- a/internal/flows/uninstall.go
+++ b/internal/flows/uninstall.go
@@ -100,7 +100,7 @@ func (u *Uninstaller) uninstallDaemons(ctx context.Context) error {
 			}
 		}
 	}
-	if u.Artifacts.Containerd != string(containerd.ContainerdSourceNone) {
+	if containerd.GetContainerdSource(u.Artifacts.Containerd) != containerd.ContainerdSourceNone {
 		u.Logger.Info("Uninstalling containerd...")
 		if err := u.DaemonManager.StopDaemon(containerd.ContainerdDaemonName); err != nil {
 			return err

--- a/internal/flows/upgrade.go
+++ b/internal/flows/upgrade.go
@@ -66,7 +66,7 @@ func (u *Upgrader) upgradeDistroPackages(ctx context.Context) error {
 	if err := u.PackageManager.RefreshMetadataCache(ctx); err != nil {
 		return err
 	}
-	if u.Artifacts.Containerd != string(containerd.ContainerdSourceNone) {
+	if containerd.GetContainerdSource(u.Artifacts.Containerd) != containerd.ContainerdSourceNone {
 		u.Logger.Info("Upgrading containerd...")
 		if err := containerd.Upgrade(ctx, u.PackageManager); err != nil {
 			return err

--- a/internal/flows/upgrade.go
+++ b/internal/flows/upgrade.go
@@ -66,7 +66,7 @@ func (u *Upgrader) upgradeDistroPackages(ctx context.Context) error {
 	if err := u.PackageManager.RefreshMetadataCache(ctx); err != nil {
 		return err
 	}
-	if containerd.GetContainerdSource(u.Artifacts.Containerd) != containerd.ContainerdSourceNone {
+	if u.Artifacts.Containerd != tracker.ContainerdSourceNone {
 		u.Logger.Info("Upgrading containerd...")
 		if err := containerd.Upgrade(ctx, u.PackageManager); err != nil {
 			return err

--- a/internal/packagemanager/packagemanager.go
+++ b/internal/packagemanager/packagemanager.go
@@ -13,8 +13,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/aws/eks-hybrid/internal/artifact"
-	"github.com/aws/eks-hybrid/internal/containerd"
 	"github.com/aws/eks-hybrid/internal/system"
+	"github.com/aws/eks-hybrid/internal/tracker"
 	"github.com/aws/eks-hybrid/internal/util"
 	"github.com/aws/eks-hybrid/internal/util/cmd"
 )
@@ -61,7 +61,7 @@ type DistroPackageManager struct {
 	logger              *zap.Logger
 }
 
-func New(containerdSource containerd.SourceName, logger *zap.Logger) (*DistroPackageManager, error) {
+func New(containerdSource tracker.ContainerdSourceName, logger *zap.Logger) (*DistroPackageManager, error) {
 	manager, err := getOsPackageManager()
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func New(containerdSource containerd.SourceName, logger *zap.Logger) (*DistroPac
 		deleteVerb:          packageManagerDeleteCmd[manager],
 		refreshMetadataVerb: packageManagerMetadataRefreshCmd[manager],
 	}
-	if containerdSource == containerd.ContainerdSourceDocker {
+	if containerdSource == tracker.ContainerdSourceDocker {
 		pm.dockerRepo = managerToDockerRepoMap[manager]
 	}
 	return pm, nil

--- a/test/integration/cases/install-containerd-source-none/expected-nodeadm-tracker
+++ b/test/integration/cases/install-containerd-source-none/expected-nodeadm-tracker
@@ -1,6 +1,6 @@
 Artifacts:
   CniPlugins: true
-  Containerd: ""
+  Containerd: none
   IamAuthenticator: true
   IamRolesAnywhere: true
   ImageCredentialProvider: true

--- a/test/integration/cases/uninstall-with-source-none/config.yaml
+++ b/test/integration/cases/uninstall-with-source-none/config.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+    region: us-west-2
+  hybrid:
+    enableCredentialsFile: true
+    iamRolesAnywhere:
+      nodeName: mock-hybrid-node
+      awsConfigPath: /.aws/config
+      roleArn: arn:aws:iam::123456789010:role/mockHybridNodeRole
+      profileArn: arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole
+      trustAnchorArn: arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7

--- a/test/integration/cases/uninstall-with-source-none/expected-nodeadm-tracker
+++ b/test/integration/cases/uninstall-with-source-none/expected-nodeadm-tracker
@@ -1,0 +1,10 @@
+Artifacts:
+  CniPlugins: true
+  Containerd: none
+  IamAuthenticator: true
+  IamRolesAnywhere: true
+  ImageCredentialProvider: true
+  Iptables: true
+  Kubectl: true
+  Kubelet: true
+  Ssm: false

--- a/test/integration/cases/uninstall-with-source-none/run.sh
+++ b/test/integration/cases/uninstall-with-source-none/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+wait::dbus-ready
+
+mkdir -p /etc/iam/pki
+touch /etc/iam/pki/server.pem
+touch /etc/iam/pki/server.key
+
+nodeadm install 1.30 --credential-provider iam-ra --containerd-source none
+assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
+
+# mock iam-ra update service credentials file
+mock::iamra_aws_credentials
+nodeadm init --skip run,node-ip-validation --config-source file://config.yaml
+
+nodeadm uninstall --skip run,node-validation,pod-validation
+
+assert::path-exists /usr/bin/containerd
+
+# run a second test that removes the containerd from the tracker file to
+# simulate older installations which would not have included none in the source
+# to ensure during unmarshal it defaults to none
+nodeadm install 1.30 --credential-provider iam-ra --containerd-source none
+yq -i '.Artifacts.Containerd = ""' /opt/nodeadm/tracker
+
+# mock iam-ra update service credentials file
+mock::iamra_aws_credentials
+nodeadm init --skip run,node-ip-validation --config-source file://config.yaml
+
+nodeadm uninstall --skip run,node-validation,pod-validation
+
+assert::path-exists /usr/bin/containerd

--- a/test/integration/cases/upgrade-with-source-none/config.yaml
+++ b/test/integration/cases/upgrade-with-source-none/config.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+    region: us-west-2
+  hybrid:
+    enableCredentialsFile: true
+    iamRolesAnywhere:
+      nodeName: mock-hybrid-node
+      awsConfigPath: /.aws/config
+      roleArn: arn:aws:iam::123456789010:role/mockHybridNodeRole
+      profileArn: arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole
+      trustAnchorArn: arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7

--- a/test/integration/cases/upgrade-with-source-none/expected-nodeadm-tracker
+++ b/test/integration/cases/upgrade-with-source-none/expected-nodeadm-tracker
@@ -1,0 +1,10 @@
+Artifacts:
+  CniPlugins: true
+  Containerd: none
+  IamAuthenticator: true
+  IamRolesAnywhere: true
+  ImageCredentialProvider: true
+  Iptables: true
+  Kubectl: true
+  Kubelet: true
+  Ssm: false

--- a/test/integration/cases/upgrade-with-source-none/mock-containerd.sh
+++ b/test/integration/cases/upgrade-with-source-none/mock-containerd.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+true

--- a/test/integration/cases/upgrade-with-source-none/run.sh
+++ b/test/integration/cases/upgrade-with-source-none/run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+wait::dbus-ready
+
+declare INITIAL_VERSION=1.26
+declare TARGET_VERSION=1.32
+
+mkdir -p /etc/iam/pki
+touch /etc/iam/pki/server.pem
+touch /etc/iam/pki/server.key
+
+# remove previously installed containerd 
+dnf remove -y containerd
+
+# before running install/upgrade, install a non-latest version of containerd
+# so we can ensure install nor upgrade trigger a yum upgrade of the packages
+install-previous-containerd-version
+generate::birth-file /usr/bin/containerd
+
+# Test nodeadm upgrade with iam as credential provider
+# initial: version 1.26
+# target: version 1.32
+nodeadm install $INITIAL_VERSION --credential-provider iam-ra --containerd-source none
+assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
+assert::birth-match /usr/bin/containerd
+
+# mock iam-ra update service credentials file
+mock::iamra_aws_credentials
+nodeadm init --skip run,node-ip-validation --config-source file://config.yaml
+
+# In integration test environment, the aws_signing_helper_update will run
+# but stuck in a loop of failure which prevents the next nodeadm init call
+# from starting it, we manually stop and reset the service to work around it.
+systemctl stop aws_signing_helper_update.service
+systemctl disable aws_signing_helper_update.service
+systemctl daemon-reload
+systemctl reset-failed
+
+nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation,init-validation,node-ip-validation --config-source file://config.yaml
+
+assert::birth-match /usr/bin/containerd

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -392,3 +392,15 @@ function mock::aws() {
   # ensure that our instance exists in the API
   aws ec2 run-instances
 }
+
+function install-previous-containerd-version() {
+  # example output:
+  # Last metadata expiration check: 0:09:53 ago on Fri May  9 14:32:14 2025.
+  # Available Packages
+  # containerd.x86_64      1.6.8-2.amzn2023.0.3 amazonlinux
+  # containerd.x86_64      1.6.8-2.amzn2023.0.4 amazonlinux
+  # skip first 2 header lines, grab second column, pick second to last line
+  containerd_version=$(yum --showduplicates list --available containerd | tail -n +3  | awk '{print $2}' | tail -n 2 | head -1)
+  yum install -y containerd-${containerd_version}  
+}
+

--- a/test/integration/infra/Dockerfile
+++ b/test/integration/infra/Dockerfile
@@ -1,9 +1,4 @@
-FROM public.ecr.aws/eks-distro-build-tooling/golang:1.23 AS imds-mock-build
-ARG TARGETARCH
-RUN curl -Lo /imds-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v1.12.0/ec2-metadata-mock-linux-${TARGETARCH}
-RUN chmod +x /imds-mock
-
-FROM public.ecr.aws/eks-distro-build-tooling/golang:1.23 AS nodeadm-build
+FROM public.ecr.aws/eks-distro-build-tooling/golang:1.24 AS nodeadm-build
 WORKDIR /go/src/github.com/aws/eks-hybrid
 ARG GOPROXY
 RUN go env -w GOPROXY=${GOPROXY}
@@ -14,24 +9,34 @@ RUN make build
 RUN mv _bin/nodeadm /nodeadm
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+ARG TARGETARCH
+
 RUN dnf -y update && \
     dnf -y install systemd containerd jq git-core python3 tar procps zip && \
     dnf clean all
+
+RUN curl -OL https://github.com/mikefarah/yq/releases/download/v4.45.3/yq_linux_${TARGETARCH}.tar.gz && \
+    tar -C /usr/bin -xzf yq_linux_${TARGETARCH}.tar.gz && \
+    mv /usr/bin/yq_linux_${TARGETARCH} /usr/bin/yq
+
+RUN curl -Lo /imds-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v1.13.0/ec2-metadata-mock-linux-${TARGETARCH} && \
+    chmod +x /imds-mock && \
+    cp /imds-mock /usr/local/bin/imds-mock
+
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
-    rm -rf aws awscliv2.zip    
+    rm -rf aws awscliv2.zip
+
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
     rm get-pip.py
-# install moto from main to fix eks timestamp issue
-# remove when there is a new moto release with this commit included
-RUN pip install --user 'moto[server] @ git+https://github.com/getmoto/moto.git@5edb0c50b88db96d3a90b3f69096317ba2daf04c'
+
+RUN pip install --user 'moto[server]'
 
 
 # I know how this looks, but it lets us use moto with our mocked IMDS and for now the simplicity is worth the hack
 RUN sed -i 's/= random_instance_id()/= "i-1234567890abcdef0"/g' $HOME/.local/lib/python*/site-packages/moto/ec2/models/instances.py
-COPY --from=imds-mock-build /imds-mock /usr/local/bin/imds-mock
 # The content of ec2 userdata in the 'aemm-default-config.json'
 # file is the base64 encoding of a minimally viable NodeConfig.
 # At the time of this change, it is equal to the following:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
see #534 for background

Fixes handling of containerd-source:none during upgrade and install.  Previously during upgrade nodeadm was yum/apt updating and during uninstall it would have removed containerd even if the user had ran install with source:none.

This PR is broken into 3 commits:
- the first commit adds an integration test to prove the failure, replicating the error on al23 requires a bit of yum magic since containerd is provided in the yum repo, whereas on rhel yum gets confused easier since there is no containerd package in the default repos
- the second commit is the bare minimum fix for this issue where because we were not properly handling the empty value of the Containerd "enum" in the tracker struct/file, we were comparing "" against None, which was false and therefore dropping into the upgrade/uninstall flow
- the third commit improves the handling of this default value by ensuring we always write and read empty string as `none`, thus avoiding this class of error in the future.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

