### PR TITLE
adds e2e test to validate containerd-source none

### DIFF
--- a/test/e2e/os/testdata/rhel/9/cloud-init.txt
+++ b/test/e2e/os/testdata/rhel/9/cloud-init.txt
@@ -10,6 +10,16 @@ users:
 rh_subscription:
   username: {{ .RhelUsername }}
   password: {{ .RhelPassword }}
+{{- if eq .ContainerdSource "none" }}
+yum_repos:
+  docker-ce-stable:
+    name: docker-ce-stable
+    baseurl: https://download.docker.com/linux/rhel/$releasever/$basearch/stable
+    gpgcheck: true
+    gpgkey: https://download.docker.com/linux/rhel/gpg
+packages:
+  - containerd.io
+{{- end }}
 package_update: true
 write_files:
   - content: |
@@ -25,6 +35,6 @@ write_files:
 {{- end }}
 
 runcmd:
-  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}" "--containerd-source docker"
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}" "--containerd-source {{ .ContainerdSource }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/os/testdata/ubuntu/2404/cloud-init.txt
+++ b/test/e2e/os/testdata/ubuntu/2404/cloud-init.txt
@@ -7,7 +7,16 @@ users:
 {{- if .RootPasswordHash }}
     hashed_passwd: {{ .RootPasswordHash }}
 {{- end }}
+{{- if .PreinstallContainerd }}
+apt:
+  sources:
+    docker.list:
+      source: deb [arch=amd64] https://download.docker.com/linux/ubuntu $RELEASE stable
+      keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 package_update: true
+packages:
+  - containerd.io
+{{- end }}
 write_files:
   - content: |
 {{ .NodeadmConfigYaml | indent 6 }}

--- a/test/e2e/suite/peered_vpc.go
+++ b/test/e2e/suite/peered_vpc.go
@@ -405,12 +405,14 @@ func OSProviderList(credentialProviders []e2e.NodeadmCredentialsProvider) []OSPr
 		osystem.NewUbuntu2404AMD(),
 		osystem.NewUbuntu2404ARM(),
 		osystem.NewUbuntu2404DockerSource(),
+		osystem.NewUbuntu2404NoDockerSource(),
 		osystem.NewAmazonLinux2023AMD(),
 		osystem.NewAmazonLinux2023ARM(),
 		osystem.NewRedHat8AMD(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
 		osystem.NewRedHat8ARM(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
 		osystem.NewRedHat9AMD(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
 		osystem.NewRedHat9ARM(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
+		osystem.NewRedHat9NoDockerSource(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
 	}
 	osProviderList := []OSProvider{}
 	for _, nodeOS := range osList {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds a new rhel9-amd64-no-source and ubuntu2404-amd64-no-source test to validate the upgrade/uninstall flow when using containerd-source:none.  The integration test already covers al23 and I dont think this test is need across all OS/Versions since the behavior is similar enough between them.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

