### PR TITLE
Add regex to filter version output for comparison in validate-release.sh

### DIFF
--- a/hack/validate-release.sh
+++ b/hack/validate-release.sh
@@ -33,7 +33,10 @@ echo "CloudFront invalidation completed successfully"
 echo "Validating released version..."
 curl -L -o released_nodeadm https://hybrid-assets.eks.amazonaws.com/releases/latest/bin/linux/amd64/nodeadm
 chmod +x released_nodeadm
-RELEASED_VERSION=$(./released_nodeadm version)
+
+# Extract just the semantic version using regex i.e. 'Version: v1.0.5' -> 'v1.0.5'
+NODEADM_VERSION_OUTPUT=$(./released_nodeadm version)
+RELEASED_VERSION=$(echo "${NODEADM_VERSION_OUTPUT}" | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+\(-[0-9a-zA-Z.-]\+\)\?' || echo "VERSION_NOT_FOUND")
 EXPECTED_VERSION=$(cat "${VERSION_FILE}")
 
 if [ "${RELEASED_VERSION}" != "${EXPECTED_VERSION}" ]; then
@@ -43,4 +46,4 @@ fi
 echo "Version validation successful"
 
 echo "Production release completed successfully"
-echo "Version: ${VERSION_FILE}"
+echo "Version: $(cat ${VERSION_FILE})"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a regex to filter out the version when comparing versions. Fixes error where we saw `Version mismatch! Released version (Version: v1.0.5) does not match expected version (v1.0.5)`


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

