### PR TITLE
Init the git repository for making the attribution

### DIFF
--- a/buildspecs/prod-release-nodeadm.yml
+++ b/buildspecs/prod-release-nodeadm.yml
@@ -25,6 +25,15 @@ phases:
 
   build:
     commands:
+      - echo "Setting up Git repository for attribution generation"
+      - git init
+      - git config --global user.email "ci@eks-hybrid.local"
+      - git config --global user.name "Release CodePipeline"
+      - git remote add origin https://github.com/aws/eks-hybrid.git
+      - git add .
+      - git commit -m "Initialize repository for attribution"
+      - echo "Git repository initialized successfully"
+
       - ./hack/release-nodeadm.sh "${PROD_BUCKET}" "artifacts-production" "${VERSION}"
 
   post_build:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Initialize the git repo in the container that runs `release-nodeadm.sh` so it doesn't run into "not a git repository" errors. Long term this can be resolved by using AWS Codestar connections which has a Full Clone option.

https://docs.aws.amazon.com/codepipeline/latest/userguide/update-github-action-connections.html

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

