### PR TITLE
Add helpers for most common retry usecases

### DIFF
--- a/internal/kubernetes/retry.go
+++ b/internal/kubernetes/retry.go
@@ -1,0 +1,72 @@
+package kubernetes
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/aws/eks-hybrid/internal/retry"
+)
+
+// Getter retrieves an object of type O from the Kubernetes API.
+// It matches the Get signature of client-go clients.
+type Getter[O runtime.Object] interface {
+	Get(ctx context.Context, name string, options metav1.GetOptions) (O, error)
+}
+
+// GetOptions configures a Get request.
+type GetOptions struct {
+	metav1.GetOptions
+}
+
+// GetOption is an option for the Get request.
+type GetOption func(*GetOptions)
+
+// GetRetry retries the get request until it succeeds or the retry limit is reached.
+func GetRetry[O runtime.Object](ctx context.Context, getter Getter[O], name string, opts ...GetOption) (O, error) {
+	getOpt := &GetOptions{}
+	for _, opt := range opts {
+		opt(getOpt)
+	}
+
+	var obj O
+	err := retry.NetworkRequest(ctx, func(ctx context.Context) error {
+		var err error
+		obj, err = getter.Get(ctx, name, getOpt.GetOptions)
+		return err
+	})
+
+	return obj, err
+}
+
+// List retrieves a list of objects from the Kubernetes API.
+// It matches the List signature of client-go clients.
+type Lister[O runtime.Object] interface {
+	List(context.Context, metav1.ListOptions) (O, error)
+}
+
+// ListOptions configures a List request.
+type ListOptions struct {
+	metav1.ListOptions
+}
+
+// ListOption is an option for the List request.
+type ListOption func(*ListOptions)
+
+// ListRetry retries the list request until it succeeds or the retry limit is reached.
+func ListRetry[O runtime.Object](ctx context.Context, lister Lister[O], opts ...ListOption) (O, error) {
+	listOpt := &ListOptions{}
+	for _, opt := range opts {
+		opt(listOpt)
+	}
+
+	var obj O
+	err := retry.NetworkRequest(ctx, func(ctx context.Context) error {
+		var err error
+		obj, err = lister.List(ctx, listOpt.ListOptions)
+		return err
+	})
+
+	return obj, err
+}

--- a/internal/kubernetes/retry_test.go
+++ b/internal/kubernetes/retry_test.go
@@ -1,0 +1,206 @@
+package kubernetes_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/aws/eks-hybrid/internal/kubernetes"
+)
+
+var (
+	errInternalGetter = errors.New("internal getter error")
+	errInternalLister = errors.New("internal lister error")
+)
+
+func TestGetRetry(t *testing.T) {
+	// Define a concrete type for O in tests, e.g., *corev1.Pod
+	// This makes it easier to work with the mock and expected values.
+	type PodGetter = mockGetter[*corev1.Pod]
+
+	tests := []struct {
+		name        string
+		podName     string
+		setupGetter func(g Gomega, mg *PodGetter) // Function to configure the mock getter
+		ctxTimeout  time.Duration                 // 0 for no explicit test-level timeout on context
+		expectedPod *corev1.Pod                   // The pod expected to be returned
+		expectedErr string                        // Substring of the expected error, empty if no error
+	}{
+		{
+			name:    "success with non-nil object",
+			podName: "my-pod",
+			setupGetter: func(g Gomega, mg *PodGetter) {
+				mg.getFunc = func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+					g.Expect(name).To(Equal("my-pod"))
+					return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "my-pod"}}, nil
+				}
+			},
+			expectedPod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "my-pod"}},
+		},
+		{
+			name:    "success with nil object and nil error from getter",
+			podName: "nil-pod",
+			setupGetter: func(g Gomega, mg *PodGetter) {
+				mg.getFunc = func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+					g.Expect(name).To(Equal("nil-pod"))
+					return nil, nil // Getter returns nil object, nil error
+				}
+			},
+			expectedPod: nil, // Expecting a nil pod back
+		},
+		{
+			name:    "error case with short context timeout",
+			podName: "error-pod",
+			setupGetter: func(g Gomega, mg *PodGetter) {
+				mg.getFunc = func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+					return nil, errInternalGetter
+				}
+			},
+			ctxTimeout:  10 * time.Millisecond, // Short timeout for the test context
+			expectedPod: nil,
+			// NetworkRequest wraps the last error with the context error when its derived context is interrupted.
+			expectedErr: errInternalGetter.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			getter := &PodGetter{}
+			tt.setupGetter(g, getter)
+
+			ctx := context.Background()
+			if tt.ctxTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tt.ctxTimeout)
+				defer cancel()
+			}
+
+			pod, err := kubernetes.GetRetry(ctx, getter, tt.podName)
+
+			if tt.expectedErr == "" {
+				g.Expect(err).ToNot(HaveOccurred())
+				if tt.expectedPod == nil {
+					g.Expect(pod).To(BeNil())
+				} else {
+					g.Expect(pod).ToNot(BeNil())
+					g.Expect(pod).To(BeComparableTo(tt.expectedPod))
+				}
+			} else {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring(tt.expectedErr)))
+				g.Expect(pod).To(BeNil())
+			}
+		})
+	}
+}
+
+func TestListRetry(t *testing.T) {
+	type PodListLister = mockLister[*corev1.PodList]
+
+	tests := []struct {
+		name         string
+		setupLister  func(g Gomega, ml *PodListLister)
+		ctxTimeout   time.Duration
+		expectedList *corev1.PodList
+		expectedErr  string
+	}{
+		{
+			name: "success with non-nil list",
+			setupLister: func(g Gomega, ml *PodListLister) {
+				ml.listFunc = func(ctx context.Context, options metav1.ListOptions) (*corev1.PodList, error) {
+					return &corev1.PodList{Items: []corev1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}}}, nil
+				}
+			},
+			expectedList: &corev1.PodList{Items: []corev1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}}},
+		},
+		{
+			name: "success with nil list and nil error from lister",
+			setupLister: func(g Gomega, ml *PodListLister) {
+				ml.listFunc = func(ctx context.Context, options metav1.ListOptions) (*corev1.PodList, error) {
+					return nil, nil
+				}
+			},
+			expectedList: nil,
+		},
+		{
+			name: "error case with short context timeout",
+			setupLister: func(g Gomega, ml *PodListLister) {
+				ml.listFunc = func(ctx context.Context, options metav1.ListOptions) (*corev1.PodList, error) {
+					return nil, errInternalLister
+				}
+			},
+			ctxTimeout:   10 * time.Millisecond,
+			expectedList: nil,
+			expectedErr:  errInternalLister.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			lister := &PodListLister{}
+			tt.setupLister(g, lister)
+
+			ctx := context.Background()
+			if tt.ctxTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tt.ctxTimeout)
+				defer cancel()
+			}
+
+			list, err := kubernetes.ListRetry(ctx, lister)
+
+			if tt.expectedErr == "" {
+				g.Expect(err).ToNot(HaveOccurred())
+				if tt.expectedList == nil {
+					g.Expect(list).To(BeNil())
+				} else {
+					g.Expect(list).ToNot(BeNil())
+					g.Expect(list).To(BeComparableTo(tt.expectedList))
+				}
+			} else {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring(tt.expectedErr)))
+				g.Expect(list).To(BeNil())
+			}
+		})
+	}
+}
+
+// mockGetter is a mock implementation of the Getter interface.
+type mockGetter[O runtime.Object] struct {
+	getFunc   func(ctx context.Context, name string, options metav1.GetOptions) (O, error)
+	callCount int
+}
+
+func (m *mockGetter[O]) Get(ctx context.Context, name string, options metav1.GetOptions) (O, error) {
+	m.callCount++
+	if m.getFunc != nil {
+		return m.getFunc(ctx, name, options)
+	}
+	var zero O
+	// This default error helps identify if a test case forgot to set up getFunc.
+	return zero, errors.New("mockGetter.Get not implemented or called unexpectedly")
+}
+
+// mockLister is a mock implementation of the Lister interface.
+type mockLister[O runtime.Object] struct {
+	listFunc  func(ctx context.Context, options metav1.ListOptions) (O, error)
+	callCount int
+}
+
+func (m *mockLister[O]) List(ctx context.Context, options metav1.ListOptions) (O, error) {
+	m.callCount++
+	if m.listFunc != nil {
+		return m.listFunc(ctx, options)
+	}
+	var zero O
+	return zero, errors.New("mockLister.List not implemented or called unexpectedly")
+}

--- a/internal/kubernetes/wait.go
+++ b/internal/kubernetes/wait.go
@@ -1,0 +1,64 @@
+package kubernetes
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/aws/eks-hybrid/internal/retry"
+)
+
+const minWait = time.Duration(200 * time.Millisecond)
+
+type Read[O runtime.Object] func(context.Context) (O, error)
+
+// WaitFor waits for an object/s to meet a condition.
+// It will retry until the timeout is reached or the condition is met.
+// To allow for longer wait times while avoiding to retry non-transient errors,
+// we only retry up to 3 consecutive errors coming from the API server.
+func WaitFor[O runtime.Object](ctx context.Context, timeout time.Duration, read Read[O], ready func(O) bool) (O, error) {
+	// Rule of thum dynamic wait time calculation, we try 10ish times.
+	// Don't allow for wait times that are too small to avoid throttling.
+	wait := max(timeout/10, minWait)
+	var obj O
+	retrier := retry.Retrier{
+		HandleError: retry.NewMaxConsecutiveErrorHandler(3),
+		Timeout:     timeout,
+		Backoff: retry.Backoff{
+			Duration: wait,
+		},
+	}
+	err := retrier.Do(ctx, func(ctx context.Context) (bool, error) {
+		var err error
+		obj, err = read(ctx)
+		if err != nil {
+			return false, err
+		}
+
+		return ready(obj), nil
+	})
+
+	return obj, err
+}
+
+// GetAndWait waits for an object to meet a condition.
+// It will retry until the timeout is reached or the condition is met.
+// To allow for longer wait times while avoiding to retry non-transient errors,
+// we only retry up to 3 consecutive errors coming from the API server.
+func GetAndWait[O runtime.Object](ctx context.Context, timeout time.Duration, get Getter[O], name string, ready func(O) bool) (O, error) {
+	return WaitFor(ctx, timeout, func(ctx context.Context) (O, error) {
+		return get.Get(ctx, name, metav1.GetOptions{})
+	}, ready)
+}
+
+// ListAndWait waits for a list of objects to meet a condition.
+// It will retry until the timeout is reached or the condition is met.
+// To allow for longer wait times while avoiding to retry non-transient errors,
+// we only retry up to 3 consecutive errors coming from the API server.
+func ListAndWait[O runtime.Object](ctx context.Context, timeout time.Duration, list Lister[O], ready func(O) bool) (O, error) {
+	return WaitFor(ctx, timeout, func(ctx context.Context) (O, error) {
+		return list.List(ctx, metav1.ListOptions{})
+	}, ready)
+}

--- a/internal/kubernetes/wait_test.go
+++ b/internal/kubernetes/wait_test.go
@@ -1,0 +1,252 @@
+package kubernetes_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-hybrid/internal/kubernetes"
+)
+
+func TestWaitFor(t *testing.T) {
+	type PodGetter = mockGetter[*corev1.Pod] // Assuming mockGetter is accessible or redefined
+
+	readyPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}, Status: corev1.PodStatus{Phase: corev1.PodRunning}}
+	notReadyPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}, Status: corev1.PodStatus{Phase: corev1.PodPending}}
+
+	isPodReady := func(pod *corev1.Pod) bool {
+		if pod == nil {
+			return false
+		}
+		return pod.Status.Phase == corev1.PodRunning
+	}
+
+	tests := []struct {
+		name                 string
+		podName              string
+		waitForTimeout       time.Duration
+		ctxTimeout           time.Duration // For external context cancellation
+		ctxCanceler          func(context.CancelFunc)
+		setupGetter          func(g Gomega, mg *PodGetter)
+		readyFunc            func(*corev1.Pod) bool
+		expectedPod          *corev1.Pod
+		expectedErrSubstring string
+	}{
+		{
+			name:           "success on first try",
+			podName:        "pod1",
+			waitForTimeout: 2 * time.Second, // Sufficiently long for one attempt
+			setupGetter: func(g Gomega, mg *PodGetter) {
+				mg.getFunc = func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+					return readyPod, nil
+				}
+			},
+			readyFunc:   isPodReady,
+			expectedPod: readyPod,
+		},
+		{
+			name:           "success after a few retries",
+			podName:        "pod2",
+			waitForTimeout: 2 * time.Second,
+			setupGetter: func(g Gomega, mg *PodGetter) {
+				mg.getFunc = func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+					mg.callCount++
+					if mg.callCount < 3 {
+						return notReadyPod, nil
+					}
+					return readyPod, nil
+				}
+			},
+			readyFunc:   isPodReady,
+			expectedPod: readyPod,
+		},
+		{
+			name:           "failure due to WaitFor timeout",
+			podName:        "pod3",
+			waitForTimeout: 10 * time.Millisecond, // Short WaitFor timeout
+			setupGetter: func(g Gomega, mg *PodGetter) {
+				mg.getFunc = func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+					return notReadyPod, nil // Always not ready
+				}
+			},
+			readyFunc:            isPodReady,
+			expectedErrSubstring: context.DeadlineExceeded.Error(), // Error from retrier.Do's internal context
+		},
+		{
+			name:           "failure due to getter error max 3 consecutive",
+			podName:        "pod4",
+			waitForTimeout: 1 * time.Second,
+			setupGetter: func(g Gomega, mg *PodGetter) {
+				mg.getFunc = func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+					// Fail 4 times consecutively
+					return nil, errInternalGetter
+				}
+			},
+			readyFunc:            isPodReady,
+			expectedErrSubstring: fmt.Sprintf("max attempts 3 reached: %s", errInternalGetter),
+		},
+		{
+			name:           "success despite intermittent getter errors",
+			podName:        "pod5",
+			waitForTimeout: 2 * time.Second,
+			setupGetter: func(g Gomega, mg *PodGetter) {
+				mg.getFunc = func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+					mg.callCount++
+					switch mg.callCount {
+					case 1: // Error
+						return nil, errInternalGetter
+					case 2: // Not ready
+						return notReadyPod, nil
+					case 3: // Error again
+						return nil, errInternalGetter
+					default: // Ready
+						return readyPod, nil
+					}
+				}
+			},
+			readyFunc:   isPodReady,
+			expectedPod: readyPod,
+		},
+		{
+			name:           "external context cancellation",
+			podName:        "pod6",
+			waitForTimeout: 2 * time.Second,        // Long enough WaitFor timeout
+			ctxTimeout:     100 * time.Millisecond, // Short external context timeout
+			ctxCanceler: func(cancel context.CancelFunc) {
+				go func() {
+					time.Sleep(2 * time.Millisecond)
+					cancel()
+				}()
+			},
+			setupGetter: func(g Gomega, mg *PodGetter) {
+				mg.getFunc = func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+					return notReadyPod, nil
+				}
+			},
+			readyFunc:            isPodReady,
+			expectedErrSubstring: context.Canceled.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			getter := &PodGetter{}
+			tt.setupGetter(g, getter)
+
+			ctx := context.Background()
+			var cancel context.CancelFunc
+			if tt.ctxTimeout > 0 {
+				ctx, cancel = context.WithTimeout(ctx, tt.ctxTimeout)
+				defer cancel()
+			} else {
+				ctx, cancel = context.WithCancel(ctx)
+				defer cancel()
+			}
+			if tt.ctxCanceler != nil {
+				tt.ctxCanceler(cancel)
+			}
+
+			read := func(ctx context.Context) (*corev1.Pod, error) {
+				return getter.Get(ctx, tt.podName, metav1.GetOptions{})
+			}
+
+			pod, err := kubernetes.WaitFor(ctx, tt.waitForTimeout, read, tt.readyFunc)
+
+			if tt.expectedErrSubstring == "" {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(pod).ToNot(BeNil())
+				g.Expect(pod).To(BeComparableTo(tt.expectedPod)) // For non-nil expectedPod
+			} else {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectedErrSubstring))
+			}
+		})
+	}
+}
+
+func TestGetAndWait(t *testing.T) {
+	podName := "test-get-and-wait"
+	readyPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName}, Status: corev1.PodStatus{Phase: corev1.PodRunning}}
+
+	isPodReady := func(pod *corev1.Pod) bool {
+		return pod != nil && pod.Status.Phase == corev1.PodRunning
+	}
+
+	t.Run("positive case - get succeeds and object is ready", func(t *testing.T) {
+		g := NewWithT(t)
+		getter := &mockGetter[*corev1.Pod]{}
+		getter.getFunc = func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+			g.Expect(name).To(Equal(podName))
+			return readyPod, nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		pod, err := kubernetes.GetAndWait(ctx, 500*time.Millisecond, getter, podName, isPodReady)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(pod).To(Equal(readyPod))
+		g.Expect(getter.callCount).To(Equal(1))
+	})
+
+	t.Run("negative case - get fails leading to timeout", func(t *testing.T) {
+		g := NewWithT(t)
+		getter := &mockGetter[*corev1.Pod]{}
+		getter.getFunc = func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+			return nil, errInternalGetter // Always fail
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond) // Outer context for the whole test
+		defer cancel()
+
+		_, err := kubernetes.GetAndWait(ctx, 50*time.Millisecond, getter, podName, isPodReady)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring(errInternalGetter.Error()))
+	})
+}
+
+func TestListAndWait(t *testing.T) {
+	readyPodList := &corev1.PodList{Items: []corev1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}, Status: corev1.PodStatus{Phase: corev1.PodRunning}}}}
+
+	isPodListReady := func(podList *corev1.PodList) bool {
+		return podList != nil && len(podList.Items) > 0 && podList.Items[0].Status.Phase == corev1.PodRunning
+	}
+
+	t.Run("positive case - list succeeds and object is ready", func(t *testing.T) {
+		g := NewWithT(t)
+		lister := &mockLister[*corev1.PodList]{}
+		lister.listFunc = func(ctx context.Context, options metav1.ListOptions) (*corev1.PodList, error) {
+			return readyPodList, nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		list, err := kubernetes.ListAndWait(ctx, 500*time.Millisecond, lister, isPodListReady)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(list).To(Equal(readyPodList))
+		g.Expect(lister.callCount).To(Equal(1))
+	})
+
+	t.Run("negative case - list fails leading to timeout", func(t *testing.T) {
+		g := NewWithT(t)
+		lister := &mockLister[*corev1.PodList]{}
+		lister.listFunc = func(ctx context.Context, options metav1.ListOptions) (*corev1.PodList, error) {
+			return nil, errInternalLister // Always fail
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		_, err := kubernetes.ListAndWait(ctx, 50*time.Millisecond, lister, isPodListReady)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring(errInternalLister.Error()))
+	})
+}

--- a/internal/retry/maxerrors.go
+++ b/internal/retry/maxerrors.go
@@ -1,0 +1,19 @@
+package retry
+
+import "fmt"
+
+func NewMaxConsecutiveErrorHandler(maxAttempts int) HandleError {
+	attempts := 0
+	return func(err error) error {
+		if err == nil {
+			attempts = 0
+		} else {
+			attempts++
+		}
+
+		if attempts <= maxAttempts {
+			return nil
+		}
+		return fmt.Errorf("max attempts %d reached: %w", maxAttempts, err)
+	}
+}

--- a/internal/retry/maxerrors_test.go
+++ b/internal/retry/maxerrors_test.go
@@ -1,0 +1,91 @@
+package retry_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-hybrid/internal/retry"
+)
+
+// errorHandlerTestStep defines a single step in a NewMaxConsecutiveErrorHandler test sequence.
+type errorHandlerTestStep struct {
+	inputError    error
+	expectedError string // empty if nil, otherwise substring to match
+}
+
+func TestNewMaxConsecutiveErrorHandler(t *testing.T) {
+	testErrBase := errors.New("test error for handler")
+
+	tests := []struct {
+		name        string
+		maxAttempts int
+		sequence    []errorHandlerTestStep
+	}{
+		{
+			name:        "maxAttempts = 0, first error exceeds",
+			maxAttempts: 0,
+			sequence: []errorHandlerTestStep{
+				{inputError: testErrBase, expectedError: fmt.Sprintf("max attempts 0 reached: %s", testErrBase.Error())},
+				{inputError: nil, expectedError: ""},
+				{inputError: testErrBase, expectedError: fmt.Sprintf("max attempts 0 reached: %s", testErrBase.Error())}, // Counter resets, but still 0 attempts allowed
+			},
+		},
+		{
+			name:        "maxAttempts = 1",
+			maxAttempts: 1,
+			sequence: []errorHandlerTestStep{
+				{inputError: testErrBase, expectedError: ""},                                                             // 1st error, attempts = 1, <= maxAttempts
+				{inputError: testErrBase, expectedError: fmt.Sprintf("max attempts 1 reached: %s", testErrBase.Error())}, // 2nd error, attempts = 2, > maxAttempts
+				{inputError: nil, expectedError: ""},                                                                     // Reset attempts
+				{inputError: testErrBase, expectedError: ""},                                                             // 1st error again
+				{inputError: errors.New("another error"), expectedError: "max attempts 1 reached: another error"},        // 2nd error
+			},
+		},
+		{
+			name:        "maxAttempts = 2",
+			maxAttempts: 2,
+			sequence: []errorHandlerTestStep{
+				{inputError: testErrBase, expectedError: ""},                                                             // 1st error
+				{inputError: testErrBase, expectedError: ""},                                                             // 2nd error
+				{inputError: testErrBase, expectedError: fmt.Sprintf("max attempts 2 reached: %s", testErrBase.Error())}, // 3rd error
+				{inputError: nil, expectedError: ""},                                                                     // Reset
+				{inputError: testErrBase, expectedError: ""},                                                             // 1st again
+				{inputError: testErrBase, expectedError: ""},                                                             // 2nd again
+				{inputError: testErrBase, expectedError: fmt.Sprintf("max attempts 2 reached: %s", testErrBase.Error())}, // 3rd again
+			},
+		},
+		{
+			name:        "nil inputs do not increment attempts and reset count",
+			maxAttempts: 1,
+			sequence: []errorHandlerTestStep{
+				{inputError: nil, expectedError: ""},
+				{inputError: testErrBase, expectedError: ""}, // 1st error
+				{inputError: nil, expectedError: ""},         // Reset
+				{inputError: nil, expectedError: ""},
+				{inputError: testErrBase, expectedError: ""}, // 1st error again
+				{inputError: testErrBase, expectedError: fmt.Sprintf("max attempts 1 reached: %s", testErrBase.Error())}, // 2nd error
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			handler := retry.NewMaxConsecutiveErrorHandler(tt.maxAttempts)
+			for i, step := range tt.sequence {
+				returnedErr := handler(step.inputError)
+				if step.expectedError == "" {
+					g.Expect(returnedErr).ToNot(HaveOccurred(), "Test: %s, Step: %d", tt.name, i+1)
+				} else {
+					g.Expect(returnedErr).To(MatchError(ContainSubstring(step.expectedError)), "Test: %s, Step: %d", tt.name, i+1)
+					if step.inputError != nil {
+						g.Expect(errors.Is(returnedErr, step.inputError)).To(BeTrue(), "Test: %s, Step: %d, error should wrap input error", tt.name, i+1)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/retry/network.go
+++ b/internal/retry/network.go
@@ -1,0 +1,41 @@
+package retry
+
+import (
+	"context"
+	"time"
+)
+
+// NetworkRequest retries an operation with exponential backoff until it succeeds,
+// max timeout is reached or context is cancelled. Default sensible values are used
+// for total timeout, max consecutive errors and backoff.
+// This is intended for "lightweight" network requests, like relatively fast HTTP API
+// requests, and assumes a relatively fast network connection: response time sub 500ms.
+// It's meant to be used for the majority of API requests we make in nodeadm, where this
+// assumptions hold.
+// If you are making heavy network requests, like downloading files or long polling for
+// async operations, you should consider using a custom retrier.
+func NetworkRequest(ctx context.Context, request func(context.Context) error, opts ...RetrierOption) error {
+	// Default sensible values for network requests.
+	r := Retrier{
+		// Rule of thumb: if we don't succeed in 10s, this is not transient
+		Timeout: 10 * time.Second,
+		Backoff: Backoff{
+			// Classic exponential backoff with 10% jitter
+			// to avoid syncronized requests.
+			Duration: 1 * time.Second,
+			Factor:   2,
+			Jitter:   0.1,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(&r)
+	}
+
+	return r.Do(ctx, func(ctx context.Context) (bool, error) {
+		if err := request(ctx); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}

--- a/internal/retry/network_test.go
+++ b/internal/retry/network_test.go
@@ -1,0 +1,95 @@
+package retry_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-hybrid/internal/retry"
+)
+
+func TestNetworkRequest(t *testing.T) {
+	tests := []struct {
+		name          string
+		requestFunc   func(ctx context.Context) error
+		ctxTimeout    time.Duration // 0 means no timeout on the context itself
+		expectedError string
+	}{
+		{
+			name: "succeeds on first try",
+			requestFunc: func(ctx context.Context) error {
+				return nil
+			},
+		},
+		{
+			name: "succeeds after a few retries",
+			requestFunc: func() func(ctx context.Context) error {
+				attempts := 0
+				return func(ctx context.Context) error {
+					attempts++
+					if attempts < 3 {
+						return errors.New("test error")
+					}
+					return nil
+				}
+			}(),
+		},
+		{
+			name: "fails due to timeout",
+			requestFunc: func(ctx context.Context) error {
+				return errors.New("test error")
+			},
+			expectedError: "test error", // The last error should be this
+		},
+		{
+			name: "fails due to context cancellation",
+			requestFunc: func(ctx context.Context) error {
+				// Simulate a long-running task that will be interrupted
+				select {
+				case <-time.After(15 * time.Second): // longer than NetworkRequest timeout
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			},
+			ctxTimeout:    10 * time.Millisecond, // Cancel context quickly
+			expectedError: "context deadline exceeded",
+		},
+		{
+			name: "propagates last error on timeout",
+			requestFunc: func() func(ctx context.Context) error {
+				customErr := errors.New("custom persistent error")
+				return func(ctx context.Context) error {
+					return customErr
+				}
+			}(),
+			expectedError: "custom persistent error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+			if tt.ctxTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tt.ctxTimeout)
+				defer cancel()
+			}
+
+			err := retry.NetworkRequest(ctx, tt.requestFunc,
+				retry.WithTimeout(100*time.Millisecond),
+				retry.WithBackoffDuration(1*time.Millisecond),
+			)
+
+			if tt.expectedError == "" {
+				g.Expect(err).ToNot(HaveOccurred())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.expectedError)))
+			}
+		})
+	}
+}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,101 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// Retrier configures retries for an operation.
+type Retrier struct {
+	// HandleError is called after each operation retry.
+	// If it returns an error, the operation is not retried
+	// and that error is returned. This is useful for special
+	// error handling, for example, for non retryable errors.
+	// If HandleError is nil, the operation is always retried.
+	HandleError HandleError
+	// Timeout is the maximum time for the complete retry loop.
+	// If zero, the operation is retried indefinitely until either
+	// the backoff reaches its limit (if configured to do so) or
+	// the context is cancelled.
+	Timeout time.Duration
+	// Backoff is the backoff configuration for the retry loop.
+	Backoff Backoff
+}
+
+type (
+	Backoff     wait.Backoff
+	HandleError func(error) error
+	// Operation is a process that can be retried.
+	// It returns a boolean indicating if the operation is done.
+	// Errors might be retried.
+	Operation func(context.Context) (done bool, err error)
+)
+
+// Do retries an operation until it succeeds, max timeout is reached or context is cancelled.
+func (r *Retrier) Do(ctx context.Context, op Operation) error {
+	if r.Timeout != 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, r.Timeout)
+		defer cancel()
+	}
+
+	backoff := wait.Backoff(r.Backoff)
+	if r.Backoff.Steps == 0 {
+		// If the number of steps is zero, we set it to the maximum possible value
+		// to effectively remove the limit.
+		// This is simply sane behavior for zero values, we should not make the caller
+		// configure the limit unless they want to limit the number of steps. And a zero
+		// steps limit doesn't make sense.
+		// Unfortunately, wait.ExponentialBackoffWithContext does expect this field to be set
+		// so we need to handle the "non-limit" case here.
+		backoff.Steps = math.MaxInt
+	}
+
+	var lastErr error
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		done, err := op(ctx)
+		if err != nil {
+			lastErr = err
+		}
+		if r.HandleError != nil {
+			if err = r.HandleError(err); err != nil {
+				return false, err
+			}
+		}
+
+		// If for some reason the operation returns true and an error, and the HandleError
+		// wanted to retry, we want to return false to retry the operation.
+		return done && err == nil, nil
+	})
+
+	// If the retry loop exited for any other reason but a non-retryable error
+	// (context cancelled, timeout, backoff limit reached) then we wrap the last
+	// error to give a better indication of what happened to the caller.
+	if wait.Interrupted(err) && lastErr != nil {
+		return fmt.Errorf("%s while retrying: %w", err, lastErr)
+	}
+
+	return err
+}
+
+// RetrierOption is a function that modifies a Retrier.
+// Generally only for tests.
+type RetrierOption func(*Retrier)
+
+// WithTimeout sets the timeout for the retrier.
+func WithTimeout(timeout time.Duration) RetrierOption {
+	return func(r *Retrier) {
+		r.Timeout = timeout
+	}
+}
+
+// WithBackoffDuration sets the backoff duration for the retrier.
+func WithBackoffDuration(duration time.Duration) RetrierOption {
+	return func(r *Retrier) {
+		r.Backoff.Duration = duration
+	}
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,264 @@
+package retry_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-hybrid/internal/retry"
+)
+
+var (
+	errTest         = errors.New("test error")
+	errNonRetryable = errors.New("non-retryable error")
+)
+
+type mockOperation struct {
+	currentAttempt int
+	errToReturn    error
+	sequence       []struct {
+		done bool
+		err  error
+	}
+	succeedAt int // attempt number to return (true, nil)
+}
+
+func (m *mockOperation) run(ctx context.Context) (bool, error) {
+	m.currentAttempt++
+
+	if m.currentAttempt <= len(m.sequence) {
+		seq := m.sequence[m.currentAttempt-1]
+		return seq.done, seq.err
+	}
+
+	if m.succeedAt > 0 && m.currentAttempt == m.succeedAt {
+		return true, nil
+	}
+
+	if m.errToReturn != nil { // persistent error
+		return false, m.errToReturn
+	}
+
+	return true, nil // Default success if not configured otherwise
+}
+
+func TestRetrier_Do(t *testing.T) {
+	tests := []struct {
+		name        string
+		retrier     retry.Retrier
+		op          func(ctx context.Context) (bool, error)
+		ctxTimeout  time.Duration // For external context timeout
+		expectedErr string        // Substring to match in error
+	}{
+		{
+			name: "succeeds on first try",
+			retrier: retry.Retrier{
+				Timeout: 100 * time.Millisecond,
+				Backoff: retry.Backoff{Duration: 1 * time.Millisecond, Steps: 5, Factor: 1.0, Jitter: 0.0},
+			},
+			op:          (&mockOperation{succeedAt: 1}).run,
+			expectedErr: "",
+		},
+		{
+			name: "succeeds after a few retries",
+			retrier: retry.Retrier{
+				Timeout: 100 * time.Millisecond,
+				Backoff: retry.Backoff{Duration: 1 * time.Millisecond, Steps: 5, Factor: 1.0, Jitter: 0.0},
+			},
+			op:          (&mockOperation{errToReturn: errTest, succeedAt: 3}).run,
+			expectedErr: "",
+		},
+		{
+			name: "fails due to retrier timeout",
+			retrier: retry.Retrier{
+				Timeout: 20 * time.Millisecond, // Short timeout
+				Backoff: retry.Backoff{Duration: 5 * time.Millisecond, Steps: 10, Factor: 1.0, Jitter: 0.0},
+			},
+			op:          (&mockOperation{errToReturn: errTest}).run, // Always errors
+			expectedErr: fmt.Sprintf("%s while retrying: %s", context.DeadlineExceeded, errTest),
+		},
+		{
+			name: "fails due to external context expiration",
+			retrier: retry.Retrier{
+				Timeout: 200 * time.Millisecond, // Long enough retrier timeout
+				Backoff: retry.Backoff{Duration: 5 * time.Millisecond, Steps: 20, Factor: 1.0, Jitter: 0.0},
+			},
+			op: func(ctx context.Context) (bool, error) { // Operation that respects context
+				time.Sleep(1 * time.Millisecond) // Simulate work
+				return false, errTest            // This error will be the 'lastErr'
+			},
+			ctxTimeout:  10 * time.Millisecond, // External context times out sooner
+			expectedErr: fmt.Sprintf("%s while retrying: %s", context.DeadlineExceeded, errTest),
+		},
+		{
+			name: "stops after Backoff.Steps reached",
+			retrier: retry.Retrier{
+				Timeout: 100 * time.Millisecond,
+				Backoff: retry.Backoff{Duration: 1 * time.Millisecond, Steps: 2, Factor: 1.0, Jitter: 0.0},
+			},
+			op:          (&mockOperation{errToReturn: errTest}).run, // Always errors
+			expectedErr: fmt.Sprintf("while retrying: %s", errTest),
+		},
+		{
+			name: "Backoff.Steps = 0 means effectively infinite (limited by timeout)",
+			retrier: retry.Retrier{
+				Timeout: 20 * time.Millisecond, // Short timeout
+				Backoff: retry.Backoff{Duration: 1 * time.Millisecond, Steps: 0, Factor: 1.0, Jitter: 0.0},
+			},
+			op:          (&mockOperation{errToReturn: errTest}).run, // Always errors
+			expectedErr: fmt.Sprintf("%s while retrying: %s", context.DeadlineExceeded, errTest),
+		},
+		{
+			name: "HandleError returns non-retryable error",
+			retrier: retry.Retrier{
+				Timeout: 100 * time.Millisecond,
+				Backoff: retry.Backoff{Duration: 1 * time.Millisecond, Steps: 5, Factor: 1.0, Jitter: 0.0},
+				HandleError: func(err error) error {
+					if errors.Is(err, errTest) {
+						return errNonRetryable
+					}
+					return nil
+				},
+			},
+			op:          (&mockOperation{errToReturn: errTest, succeedAt: 0}).run, // Returns errTest on first try
+			expectedErr: errNonRetryable.Error(),
+		},
+		{
+			name: "HandleError allows retry if it returns nil, leading to success",
+			retrier: retry.Retrier{
+				Timeout: 100 * time.Millisecond,
+				Backoff: retry.Backoff{Duration: 1 * time.Millisecond, Steps: 5, Factor: 1.0, Jitter: 0.0},
+				HandleError: func() func(error) error {
+					count := 0
+					return func(err error) error {
+						if errors.Is(err, errTest) {
+							count++
+							if count == 1 { // Allow first error
+								return nil
+							}
+							return errNonRetryable // Stop on subsequent
+						}
+						return nil
+					}
+				}(),
+			},
+			op:          (&mockOperation{errToReturn: errTest, succeedAt: 2}).run, // op will error once, then succeed
+			expectedErr: "",
+		},
+		{
+			name: "Operation returns done=true with an error",
+			retrier: retry.Retrier{
+				Timeout: 100 * time.Millisecond,
+				Backoff: retry.Backoff{Duration: 1 * time.Millisecond, Steps: 5, Factor: 1.0, Jitter: 0.0},
+			},
+			op:          func(ctx context.Context) (bool, error) { return true, errTest },
+			expectedErr: errTest.Error(),
+		},
+		{
+			name: "Operation returns done=false, nil error, then succeeds",
+			retrier: retry.Retrier{
+				Timeout: 100 * time.Millisecond,
+				Backoff: retry.Backoff{Duration: 1 * time.Millisecond, Steps: 5, Factor: 1.0, Jitter: 0.0},
+			},
+			op: (&mockOperation{
+				sequence: []struct {
+					done bool
+					err  error
+				}{
+					{done: false, err: nil},
+					{done: true, err: nil},
+				},
+			}).run,
+		},
+		{
+			name: "Operation never done, nil error, times out (retrier timeout)",
+			retrier: retry.Retrier{
+				Timeout: 20 * time.Millisecond,
+				Backoff: retry.Backoff{Duration: 5 * time.Millisecond, Steps: 10, Factor: 1.0, Jitter: 0.0},
+			},
+			op:          func(ctx context.Context) (bool, error) { return false, nil },
+			expectedErr: context.DeadlineExceeded.Error(), // lastErr is nil, so original context.DeadlineExceeded
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+			var cancel context.CancelFunc
+
+			if tt.ctxTimeout > 0 {
+				ctx, cancel = context.WithTimeout(ctx, tt.ctxTimeout)
+				defer cancel()
+			}
+
+			err := tt.retrier.Do(ctx, tt.op)
+
+			if tt.expectedErr == "" {
+				g.Expect(err).ToNot(HaveOccurred())
+			} else {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring(tt.expectedErr)))
+			}
+		})
+	}
+}
+
+func TestRetrier_Do_ContextAlreadyCancelled(t *testing.T) {
+	g := NewWithT(t)
+	op := (&mockOperation{errToReturn: errTest}).run
+
+	r := retry.Retrier{
+		Timeout: 100 * time.Millisecond,
+		Backoff: retry.Backoff{Duration: 1 * time.Millisecond, Steps: 5},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	err := r.Do(ctx, op)
+
+	g.Expect(err).To(HaveOccurred())
+	// wait.ExponentialBackoffWithContext will check ctx.Done() first.
+	// It will return ctx.Err() (which is context.Canceled).
+	// lastErr in Do will be nil as op is not called.
+	// So Do returns context.Canceled directly.
+	g.Expect(errors.Is(err, context.Canceled)).To(BeTrue())
+	g.Expect(err.Error()).To(ContainSubstring(context.Canceled.Error()))
+}
+
+func TestRetrier_Do_HandleError_ErrorIsNil(t *testing.T) {
+	g := NewWithT(t)
+	var handleErrorCalledWith error
+	var opCalledCount int
+
+	r := retry.Retrier{
+		Timeout: 100 * time.Millisecond,
+		Backoff: retry.Backoff{Duration: 1 * time.Millisecond, Steps: 3},
+		HandleError: func(e error) error {
+			handleErrorCalledWith = e
+			if opCalledCount == 1 { // On first call (where op returns nil error)
+				return errNonRetryable // Stop retries
+			}
+			return nil
+		},
+	}
+
+	op := func(ctx context.Context) (bool, error) {
+		opCalledCount++
+		if opCalledCount == 1 {
+			return false, nil // First time, no error, not done
+		}
+		return true, nil // Subsequent time, done
+	}
+
+	err := r.Do(context.Background(), op)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(errors.Is(err, errNonRetryable)).To(BeTrue())
+	g.Expect(opCalledCount).To(Equal(1))        // Should call op once
+	g.Expect(handleErrorCalledWith).To(BeNil()) // HandleError called with nil
+}


### PR DESCRIPTION
## Description of changes
This introduces a generic retrier. I don't expect us to use this retrier directly most of the time, it's just a building block to construct higher level retry helpers, depending on the usecase.

I wrote a few of these higher level retry helpers, like a few for Kubernetes API operations (`Get` and `List` and "wait for condition") and one for general network requests. They are all backed by the generic retrier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

