### PR TITLE
adds support for gzipped uri in artifacts manifest

### DIFF
--- a/internal/artifact/source_test.go
+++ b/internal/artifact/source_test.go
@@ -2,10 +2,13 @@ package artifact_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"crypto/sha256"
 	"io"
 	"strings"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	"github.com/aws/eks-hybrid/internal/artifact"
 )
@@ -74,5 +77,47 @@ func TestWithNopChecksum(t *testing.T) {
 		if !src.VerifyChecksum() {
 			t.Fatalf("Expected true; expect = %x; actual = %x", src.ExpectedChecksum(), src.ActualChecksum())
 		}
+	})
+}
+
+func TestGzippedWithChecksum(t *testing.T) {
+	g := NewWithT(t)
+	data := "hello world"
+	expect := []byte("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  -")
+	mismatchExpect := []byte("2fe4d4a5963f28b77737c091c436096beee0b74fabb9fcdcd2a4d8859d2099a3  -")
+
+	// Create gzipped data
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write([]byte(data))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(gw.Close()).To(Succeed())
+	gzippedData := buf.Bytes()
+
+	t.Run("GoodChecksum", func(t *testing.T) {
+		g := NewWithT(t)
+		src, err := artifact.GzippedWithChecksum(io.NopCloser(bytes.NewBuffer(gzippedData)), sha256.New(), expect)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		_, err = io.Copy(io.Discard, src)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(src.VerifyChecksum()).To(BeTrue(), "checksum verification should succeed")
+	})
+
+	t.Run("BadChecksum", func(t *testing.T) {
+		g := NewWithT(t)
+		src, err := artifact.GzippedWithChecksum(io.NopCloser(bytes.NewBuffer(gzippedData)), sha256.New(), mismatchExpect)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		_, err = io.Copy(io.Discard, src)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(src.VerifyChecksum()).To(BeFalse(), "checksum verification should fail")
+	})
+
+	t.Run("InvalidGzip", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := artifact.GzippedWithChecksum(io.NopCloser(bytes.NewBufferString("not gzipped")), sha256.New(), expect)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("getting gzip reader"))
 	})
 }

--- a/internal/aws/manifest.go
+++ b/internal/aws/manifest.go
@@ -47,6 +47,7 @@ type Artifact struct {
 	OS          string `json:"os"`
 	URI         string `json:"uri"`
 	ChecksumURI string `json:"checksum_uri"`
+	GzipURI     string `json:"gzip_uri"`
 }
 
 // Read from the manifest file on s3 and parse into Manifest struct


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We are going to start publish .gz files for the individual binaries we download via nodeadm install.  This adds support for these in the manifest, which does not currently exist today, but will after the next platform release.  Currently during install we download ~200MB from the cloudfront distro, once these are all available as gz versions this will drop down to ~50MB.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

