### PR TITLE
adds cloudwatch log group cleanup for e2e clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15 // indirect
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.26.3 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
 	github.com/cloudflare/circl v1.6.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 h1:dM9/92u2
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15/go.mod h1:SwFBy2vjtA0vZbjjaFtfN045boopadnoVPhu4Fv66vY=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15 h1:moLQUoVq91LiqT1nbvzDukyqAlCv89ZmwaHw/ZFlFZg=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15/go.mod h1:ZH34PJUc8ApjBIfgQCFvkWcUDBtl/WTD+uiYHjd8igA=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.26.3 h1:P87jejqS8WvQvRWyXlHUylt99VXt0y/WUIFuU6gBU7A=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.26.3/go.mod h1:cgPfPTC/V3JqwCKed7Q6d0FrgarV7ltz4Bz6S4Q+Dqk=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.2 h1:0LBxtAX2bHcfPr6VSzQSvJlR1nzlna7xp031gEjbWGU=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.2/go.mod h1:NW+LcIadUUlDgM3gb8+97lr6zSKExHR58NRRWSWkXl8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3 h1:BRXS0U76Z8wfF+bnkilA2QwpIch6URlm++yPUt9QPmQ=

--- a/hybrid-nodes-cdk/lib/nodeadm/policies.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm/policies.ts
@@ -356,6 +356,17 @@ export function createNodeadmTestsCreationCleanupPolicy(
         actions: ['logs:DescribeLogGroups'],
         resources: ['*'],
       }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['logs:DeleteLogGroup'],
+        resources: [`arn:aws:logs:${stack.region}:${stack.account}:log-group:/aws/eks/*`],
+        conditions: resourceTagCondition,
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['tag:GetResources'],
+        resources: ['*'],
+      }),
     ],
   });
 }

--- a/test/e2e/cleanup/cloudwatchlogs.go
+++ b/test/e2e/cleanup/cloudwatchlogs.go
@@ -1,0 +1,113 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/go-logr/logr"
+)
+
+const (
+	// 14 days is the retention period for log groups
+	// on the 15th day, the log group will be deleted
+	clusterLogGroupRetentionDays = 15
+	clusterLogGroupPrefix        = "/aws/eks"
+	clusterLogGroupSuffix        = "/cluster"
+)
+
+type CloudWatchLogsCleaner struct {
+	client        *cloudwatchlogs.Client
+	logger        logr.Logger
+	taggingClient *ResourceTaggingClient
+}
+
+func NewCloudWatchLogsCleaner(client *cloudwatchlogs.Client, taggingClient *ResourceTaggingClient, logger logr.Logger) *CloudWatchLogsCleaner {
+	return &CloudWatchLogsCleaner{
+		client:        client,
+		logger:        logger,
+		taggingClient: taggingClient,
+	}
+}
+
+// ListLogGroups lists all log groups that match the filter input
+// the instance age threshold is not used for log groups, instead we use 15 days as the threshold
+func (c *CloudWatchLogsCleaner) ListLogGroups(ctx context.Context, filterInput FilterInput) ([]string, error) {
+	// describe-logs-groups does not return the tags and since we expect there to be a number of log groups (~400)
+	// for a specific sweeper run, we use the resource tagging api to get the tags for all log groups based on the filter input
+	// instead of making seperate tagging api calls for each log group
+	groups, err := c.allGroupsWithTags(ctx, filterInput)
+	if err != nil {
+		return nil, fmt.Errorf("listing log groups: %w", err)
+	}
+
+	groupNamePattern := fmt.Sprintf("%s/", clusterLogGroupPrefix)
+	if filterInput.ClusterName != "" {
+		groupNamePattern = groupNamePattern + filterInput.ClusterName
+	} else if filterInput.ClusterNamePrefix != "" {
+		groupNamePattern = groupNamePattern + filterInput.ClusterNamePrefix
+	}
+	paginator := cloudwatchlogs.NewDescribeLogGroupsPaginator(c.client, &cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String(groupNamePattern),
+	})
+
+	var logGroupNames []string
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("describing log groups: %w", err)
+		}
+
+		for _, logGroup := range output.LogGroups {
+			tags, ok := groups[*logGroup.LogGroupName]
+			if ok && shouldDeleteLogGroup(logGroup, tags, filterInput) {
+				logGroupNames = append(logGroupNames, *logGroup.LogGroupName)
+			}
+		}
+	}
+
+	return logGroupNames, nil
+}
+
+// ex: arn:aws:logs:us-west-2:<account-id>:log-group:/aws/eks/nodeadm-e2e-tests-74c4e460-3af4-4a6e-abcd-62713cba1c52/cluster
+func parseLogGroupNameFromARN(arn string) string {
+	lastSlashIndex := strings.Index(arn, "/")
+	return arn[lastSlashIndex:]
+}
+
+func (c *CloudWatchLogsCleaner) allGroupsWithTags(ctx context.Context, filterInput FilterInput) (map[string][]Tag, error) {
+	resourceARNs, err := c.taggingClient.GetResourcesWithClusterTag(ctx, "logs:log-group", filterInput)
+	if err != nil {
+		return nil, fmt.Errorf("listing roles anywhere profiles: %w", err)
+	}
+
+	groups := map[string][]Tag{}
+	for resourceARN, tags := range resourceARNs {
+		groups[parseLogGroupNameFromARN(resourceARN)] = tags
+	}
+	return groups, nil
+}
+
+func (c *CloudWatchLogsCleaner) DeleteLogGroup(ctx context.Context, logGroupName string) error {
+	_, err := c.client.DeleteLogGroup(ctx, &cloudwatchlogs.DeleteLogGroupInput{
+		LogGroupName: &logGroupName,
+	})
+	if err != nil {
+		return fmt.Errorf("deleting log group %s: %w", logGroupName, err)
+	}
+	c.logger.Info("Deleted log group", "logGroupName", logGroupName)
+	return nil
+}
+
+func shouldDeleteLogGroup(logGroup types.LogGroup, tags []Tag, filterInput FilterInput) bool {
+	filterInput.InstanceAgeThreshold = clusterLogGroupRetentionDays * 24 * time.Hour
+	return shouldDeleteResource(ResourceWithTags{
+		ID:           *logGroup.LogGroupName,
+		CreationTime: time.UnixMilli(aws.ToInt64(logGroup.CreationTime)),
+		Tags:         tags,
+	}, filterInput)
+}

--- a/test/e2e/cleanup/resource_tagging.go
+++ b/test/e2e/cleanup/resource_tagging.go
@@ -1,0 +1,68 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	resourcegroupstaggingTypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+
+	"github.com/aws/eks-hybrid/test/e2e/constants"
+)
+
+type ResourceTaggingClient struct {
+	client *resourcegroupstaggingapi.Client
+}
+
+func NewResourceTaggingClient(client *resourcegroupstaggingapi.Client) *ResourceTaggingClient {
+	return &ResourceTaggingClient{
+		client: client,
+	}
+}
+
+// GetResourcesWithClusterTag returns a array of resourceARNs for the resourceType with the given cluster tag
+// this is useful for getting resources which do not allow filtering by tag in their native api
+// and (usually) an additional api call per resource to get the tags
+// which we need to determine if we want to delete the resource
+func (c *ResourceTaggingClient) GetResourcesWithClusterTag(ctx context.Context, resourceType string, filterInput FilterInput) (map[string][]Tag, error) {
+	input := &resourcegroupstaggingapi.GetResourcesInput{
+		ResourceTypeFilters: []string{resourceType},
+	}
+	if filterInput.ClusterName != "" {
+		input.TagFilters = []resourcegroupstaggingTypes.TagFilter{
+			{
+				Key:    aws.String(constants.TestClusterTagKey),
+				Values: []string{filterInput.ClusterName},
+			},
+		}
+	} else {
+		input.TagFilters = []resourcegroupstaggingTypes.TagFilter{
+			{
+				Key: aws.String(constants.TestClusterTagKey),
+			},
+		}
+	}
+
+	resourceARNs := map[string][]Tag{}
+	paginator := resourcegroupstaggingapi.NewGetResourcesPaginator(c.client, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("listing resources: %w", err)
+		}
+
+		for _, resource := range page.ResourceTagMappingList {
+			var customTags []Tag
+			for _, tag := range resource.Tags {
+				customTags = append(customTags, Tag{
+					Key:   *tag.Key,
+					Value: *tag.Value,
+				})
+			}
+			resourceARNs[aws.ToString(resource.ResourceARN)] = customTags
+		}
+	}
+
+	return resourceARNs, nil
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

During e2e test setup we enable eks cluster logs to cloudwatch.  We set the retention period to 14 days.  This PR adds cleanup to remove the log groups after 15 days, to keep from filling up the account with old/empty log groups.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

