### PR TITLE
adds gz build of nodeadm through release process/e2e

### DIFF
--- a/buildspecs/build-nodeadm.yml
+++ b/buildspecs/build-nodeadm.yml
@@ -4,6 +4,8 @@ phases:
   build:
     commands:
     - make build-cross-platform build-cross-e2e-tests-binary build-cross-e2e-test install-cross-ginkgo
+    - gzip --best < _bin/amd64/nodeadm > _bin/amd64/nodeadm.gz
+    - gzip --best < _bin/arm64/nodeadm > _bin/arm64/nodeadm.gz
     - echo $GIT_VERSION >> _bin/GIT_VERSION
 
 cache:

--- a/buildspecs/dev-release-nodeadm.yml
+++ b/buildspecs/dev-release-nodeadm.yml
@@ -3,6 +3,6 @@ version: 0.2
 phases:
   build:
     commands:
-    - aws s3 sync --no-progress _bin/amd64/ s3://$ARTIFACTS_BUCKET/latest/linux/amd64/ --acl public-read
-    - aws s3 sync --no-progress _bin/arm64/ s3://$ARTIFACTS_BUCKET/latest/linux/arm64/ --acl public-read
+    - aws s3 sync --no-progress --exclude "*nodeadm.gz" _bin/ s3://$ARTIFACTS_BUCKET/latest/linux/ --acl public-read
+    - aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip _bin/ s3://$ARTIFACTS_BUCKET/latest/linux/ --acl public-read
     - aws s3 cp _bin/GIT_VERSION s3://$ARTIFACTS_BUCKET/latest/GIT_VERSION --acl public-read

--- a/buildspecs/test-nodeadm.yml
+++ b/buildspecs/test-nodeadm.yml
@@ -16,12 +16,12 @@ phases:
     commands:
       # Upload binaries to versioned paths
       - echo "Uploading binaries for e2e tests..."
-      - aws s3 cp --no-progress _bin/amd64/nodeadm s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/amd64/nodeadm
-      - aws s3 cp --no-progress _bin/arm64/nodeadm s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/arm64/nodeadm
+      - aws s3 cp --no-progress --content-encoding gzip _bin/amd64/nodeadm.gz s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/amd64/nodeadm.gz
+      - aws s3 cp --no-progress --content-encoding gzip _bin/arm64/nodeadm.gz s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/arm64/nodeadm.gz
       
       # Run the e2e tests with versioned paths
       - SANITIZED_CODEBUILD_BUILD_ID=$(echo $CODEBUILD_BUILD_ID | tr ':' '-')
-      - ./hack/run-e2e.sh $SANITIZED_CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/amd64/nodeadm s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/arm64/nodeadm $LOGS_BUCKET e2e-artifacts
+      - ./hack/run-e2e.sh $SANITIZED_CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/amd64/nodeadm.gz s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/arm64/nodeadm.gz $LOGS_BUCKET e2e-artifacts
 
 reports:
   e2e-reports:

--- a/test/e2e/os/testdata/nodeadm-init.sh
+++ b/test/e2e/os/testdata/nodeadm-init.sh
@@ -17,12 +17,12 @@ NODEADM_ADDITIONAL_ARGS="${5-}"
 # so deletion succeeds and is not replaced by the running container
 rm -rf /etc/cni/net.d
 
-echo "Downloading nodeadm binary"
-for i in {1..5}; do curl --fail -s --retry 5 -L "$NODEADM_URL" -o /tmp/nodeadm-bin && break || sleep 5; done
-
-chmod +x /tmp/nodeadm-bin
+if [ ! -f /usr/local/bin/nodeadm ]; then
+    echo "Downloading nodeadm binary"
+    for i in {1..5}; do curl --compressed --fail -s --retry 5 -L "$NODEADM_URL" -o /usr/local/bin/nodeadm && break || sleep 5; done
+    chmod +x /usr/local/bin/nodeadm
+fi
 mv /tmp/nodeadm-wrapper.sh /tmp/nodeadm
-
 
 echo "Installing kubernetes components"
 # the test will wait up to 10 minutes for the node to become ready

--- a/test/e2e/os/testdata/nodeadm-wrapper.sh
+++ b/test/e2e/os/testdata/nodeadm-wrapper.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-AWS_ENDPOINT_URL_EKS={{ .EKSEndpoint }} /tmp/nodeadm-bin "$@"
+AWS_ENDPOINT_URL_EKS={{ .EKSEndpoint }} /usr/local/bin/nodeadm "$@"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds a gz "build" of the nodeadm bins during the build/test/release process so our customers (and canaries) can download the gz version (~90MB vs 20MB).

When uploading the .gz version to s3, we explicitly add the content-encoding override.  This allows for curl to be able to automatically decompress for us during download and avoiding needing to add an additional url config to the test resource config.  the `--compress` flag on curl will only decompress if the url returns with the proper content-encoding, if it does not, itll just write it out as is.  This allows for us to make this change without worrying about breaking existing usage/canaries where we config the nodeadm url to be a non-gzip version.

Also change the cloud-init download to save nodeadm in /usr/local/bin so that on reboot we do not need to redownload it.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

