### PR TITLE
Only retrieve tgw attachments that are in available state

### DIFF
--- a/test/e2e/peered/cluster.go
+++ b/test/e2e/peered/cluster.go
@@ -76,6 +76,10 @@ func findHybridVPC(ctx context.Context, client *ec2.Client, clusterVpcID string)
 				Name:   aws.String("resource-type"),
 				Values: []string{"vpc"},
 			},
+			{
+				Name:   aws.String("state"),
+				Values: []string{"available"},
+			},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*
We are seeing the following errors infrequently in E2E canary tests.
```
Expected should build peered VPC test config
        Unexpected error:
            <*fmt.wrapError | 0xc00076a680>: 
            getting peered VPC for the given cluster nodeadm-canary-1-30-mnUen4pniS-1747546871: more than one TGW attachment found for VPC vpc-0cc30be47789226f6
            {
                msg: "getting peered VPC for the given cluster nodeadm-canary-1-30-mnUen4pniS-1747546871: more than one TGW attachment found for VPC vpc-0cc30be47789226f6",
                err: <*errors.errorString | 0xc000dab4b0>{
                    s: "more than one TGW attachment found for VPC vpc-0cc30be47789226f6",
                },
            }
        occurred
```


*Description of changes:*
The root cause is likely aws api returns both `available` and other non-available states tgw attachments back some times. With this PR, we only want to get tgw that is in `available` state.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

