### PR TITLE
Add retries for ssm agent registration

### DIFF
--- a/internal/containerd/daemon.go
+++ b/internal/containerd/daemon.go
@@ -35,7 +35,7 @@ func NewContainerdDaemon(daemonManager daemon.DaemonManager, cfg *api.NodeConfig
 	}
 }
 
-func (cd *containerd) Configure() error {
+func (cd *containerd) Configure(ctx context.Context) error {
 	if err := writeContainerdConfig(cd.nodeConfig); err != nil {
 		return err
 	}

--- a/internal/daemon/interface.go
+++ b/internal/daemon/interface.go
@@ -4,7 +4,7 @@ import "context"
 
 type Daemon interface {
 	// Configure configures the daemon.
-	Configure() error
+	Configure(ctx context.Context) error
 
 	// EnsureRunning ensures that the daemon is running.
 	// If the daemon is not running, it will be started.

--- a/internal/flows/init.go
+++ b/internal/flows/init.go
@@ -77,7 +77,7 @@ func initDaemons(ctx context.Context, nodeProvider nodeprovider.NodeProvider, sk
 			nameField := zap.String("name", daemon.Name())
 
 			logger.Info("Configuring daemon...", nameField)
-			if err := daemon.Configure(); err != nil {
+			if err := daemon.Configure(ctx); err != nil {
 				return err
 			}
 			logger.Info("Configured daemon", nameField)

--- a/internal/iamrolesanywhere/daemon.go
+++ b/internal/iamrolesanywhere/daemon.go
@@ -43,7 +43,7 @@ func NewSigningHelperDaemon(daemonManager daemon.DaemonManager, node *api.NodeCo
 	}
 }
 
-func (s *SigningHelperDaemon) Configure() error {
+func (s *SigningHelperDaemon) Configure(ctx context.Context) error {
 	service, err := GenerateUpdateSystemdService(s.node)
 	if err != nil {
 		return err

--- a/internal/kubelet/daemon.go
+++ b/internal/kubelet/daemon.go
@@ -40,7 +40,7 @@ func NewKubeletDaemon(daemonManager daemon.DaemonManager, cfg *api.NodeConfig, a
 	}
 }
 
-func (k *kubelet) Configure() error {
+func (k *kubelet) Configure(ctx context.Context) error {
 	if err := k.writeKubeletConfig(); err != nil {
 		return err
 	}

--- a/internal/node/hybrid/aws.go
+++ b/internal/node/hybrid/aws.go
@@ -68,7 +68,7 @@ type SSMAWSConfigurator struct {
 
 func (c SSMAWSConfigurator) Configure(ctx context.Context, nodeConfig *api.NodeConfig) error {
 	ssmDaemon := ssm.NewSsmDaemon(c.Manager, nodeConfig, c.Logger)
-	if err := ssmDaemon.Configure(); err != nil {
+	if err := ssmDaemon.Configure(ctx); err != nil {
 		return err
 	}
 	if err := ssmDaemon.EnsureRunning(ctx); err != nil {
@@ -107,7 +107,7 @@ func (c RolesAnywhereAWSConfigurator) Configure(ctx context.Context, nodeConfig 
 
 	c.Logger.Info("Configuring aws_signing_helper_update daemon")
 	signingHelper := iamrolesanywhere.NewSigningHelperDaemon(c.Manager, nodeConfig, c.Logger)
-	if err := signingHelper.Configure(); err != nil {
+	if err := signingHelper.Configure(ctx); err != nil {
 		return err
 	}
 	if err := signingHelper.EnsureRunning(ctx); err != nil {

--- a/internal/ssm/daemon.go
+++ b/internal/ssm/daemon.go
@@ -44,8 +44,11 @@ func NewSsmDaemon(daemonManager daemon.DaemonManager, cfg *api.NodeConfig, logge
 	}
 }
 
-func (s *ssm) Configure() error {
-	if err := s.registerMachine(s.nodeConfig); err != nil {
+func (s *ssm) Configure(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, SSMRegistrationTimeout)
+	defer cancel()
+
+	if err := s.registerMachine(ctx, s.nodeConfig); err != nil {
 		if match := activationExpiredRegex.MatchString(err.Error()); match {
 			return fmt.Errorf("SSM activation expired. Please use a valid activation")
 		} else if match := invalidActivationRegex.MatchString(err.Error()); match {


### PR DESCRIPTION

Adding retries with backoff for SSM agent registration to handle network connectivity issues (connection reset errors). Uses cmd.Retry with a 10seconds backoff and 60seconds timeout allowing 6 retry attempts before failure

