### PR TITLE
limit e2e tests sweeper to nodeadm-e2e-tests clusters

### DIFF
--- a/buildspecs/cleanup-nodeadm.yml
+++ b/buildspecs/cleanup-nodeadm.yml
@@ -4,4 +4,4 @@ phases:
   build:
     commands:
     - ARCH="$([ "x86_64" = "$(uname -m)" ] && echo amd64 || echo arm64)"
-    - ./_bin/$ARCH/e2e-test sweeper --all --eks-endpoint "${EKS_ENDPOINT:-}"
+    - ./_bin/$ARCH/e2e-test sweeper --cluster-prefix "nodeadm-e2e-tests" --eks-endpoint "${EKS_ENDPOINT:-}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This should not affect CI since we only create clusters with this prefix in CI, but I occasionally create canary clusters in my account which use a different cluster prefix.  This ends up triggering a failure in my devstack runs because our cdk limits the role for cleanup to only clusters with the `nodeadm-e2e-tests` prefix.  This will ensure it wont even look at the canary clusters.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

