### PR TITLE
improves containerd install for the source-none tests

### DIFF
--- a/test/e2e/os/arch.go
+++ b/test/e2e/os/arch.go
@@ -58,6 +58,7 @@ func populateBaseScripts(userDataInput *e2e.UserDataInput) error {
 		e2e.File{Content: string(nodeAdmInitScript), Path: "/tmp/nodeadm-init.sh", Permissions: "0755"},
 		e2e.File{Content: string(logCollector), Path: "/tmp/log-collector.sh", Permissions: "0755"},
 		e2e.File{Content: string(nodeadmWrapper), Path: "/tmp/nodeadm-wrapper.sh", Permissions: "0755"},
+		e2e.File{Content: string(installContainerdScript), Path: "/tmp/install-containerd.sh", Permissions: "0755"},
 	)
 
 	return nil

--- a/test/e2e/os/testdata/install-containerd.sh
+++ b/test/e2e/os/testdata/install-containerd.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if command -v apt-get >/dev/null 2>&1; then
+    CMD="apt-get -o DPkg::Lock::Timeout=60"
+    LOCK_FILE="/var/lib/dpkg/lock-frontend"
+    PACKAGE="containerd.io=1.*"
+else
+    CMD="yum"
+    LOCK_FILE="/var/lib/rpm/.rpm.lock"
+    PACKAGE="containerd.io-1.*"
+fi
+
+ATTEMPTS=5
+while ! $CMD install -y $PACKAGE ; do
+    echo "$CMD failed to install $PACKAGE"
+    
+    # attempt to wait for any in progress apt-get/yum operations to complete
+    while find /proc/*/fd -ls | grep $LOCK_FILE >/dev/null 2>&1; do
+        echo "waiting for process with lock on $LOCK_FILE to complete"
+        sleep 1
+    done
+
+    ((ATTEMPTS--)) || break
+    sleep 5
+done
+
+if ! command -v ctr >/dev/null 2>&1; then 
+    echo "containerd failed to installed"
+    exit 1
+fi

--- a/test/e2e/os/testdata/rhel/9/cloud-init.txt
+++ b/test/e2e/os/testdata/rhel/9/cloud-init.txt
@@ -17,8 +17,6 @@ yum_repos:
     baseurl: https://download.docker.com/linux/rhel/$releasever/$basearch/stable
     gpgcheck: true
     gpgkey: https://download.docker.com/linux/rhel/gpg
-packages:
-  - containerd.io
 {{- end }}
 package_update: true
 write_files:
@@ -35,6 +33,9 @@ write_files:
 {{- end }}
 
 runcmd:
+{{- if eq .ContainerdSource "none" }}
+  - /tmp/install-containerd.sh
+{{- end }}
   - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}" "--containerd-source {{ .ContainerdSource }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/os/testdata/ubuntu/2404/cloud-init.txt
+++ b/test/e2e/os/testdata/ubuntu/2404/cloud-init.txt
@@ -13,10 +13,8 @@ apt:
     docker.list:
       source: deb [arch=amd64] https://download.docker.com/linux/ubuntu $RELEASE stable
       keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
-package_update: true
-packages:
-  - containerd.io
 {{- end }}
+package_update: true
 write_files:
   - content: |
 {{ .NodeadmConfigYaml | indent 6 }}
@@ -31,6 +29,9 @@ write_files:
 {{- end }}
 
 runcmd:
+{{- if .PreinstallContainerd }}
+  - /tmp/install-containerd.sh
+{{- end }}
   - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}" "{{ .NodeadmAdditionalArgs }}"
 
 final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -29,6 +29,9 @@ var logCollectorScript []byte
 //go:embed testdata/nodeadm-wrapper.sh
 var nodeadmWrapperScript []byte
 
+//go:embed testdata/install-containerd.sh
+var installContainerdScript []byte
+
 type ubuntuCloudInitData struct {
 	e2e.UserDataInput
 	NodeadmUrl            string


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I would occasionally get an rpm.lock error when running the source-none, which were using cloud-init to install containerd, in my devstack.

This introduces a basic script which attempts to wait for existing yum/apt operations and then also retries up to 5 times on failure to help ensure containerd is installed before we run `nodeadm install` for the containerd-source:none tests.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

