### PR TITLE
adds random sleep prior to kicking off ci run

### DIFF
--- a/buildspecs/test-nodeadm.yml
+++ b/buildspecs/test-nodeadm.yml
@@ -21,6 +21,7 @@ phases:
       
       # Run the e2e tests with versioned paths
       - SANITIZED_CODEBUILD_BUILD_ID=$(echo $CODEBUILD_BUILD_ID | tr ':' '-')
+      - sleep $((RANDOM % 30)); # random sleep to introduce some jitter in concurrent test runs
       - ./hack/run-e2e.sh $SANITIZED_CODEBUILD_BUILD_ID $AWS_REGION $KUBERNETES_VERSION $CNI s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/amd64/nodeadm.gz s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/arm64/nodeadm.gz $LOGS_BUCKET e2e-artifacts
 
 reports:

--- a/test/e2e/suite/nodeadm/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm/nodeadm_test.go
@@ -7,8 +7,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
+	smithyTime "github.com/aws/smithy-go/time"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
@@ -50,6 +53,10 @@ var _ = SynchronizedBeforeSuite(
 	// a struct that we can make accessible from the tests. We leave the rest
 	// for the per tests setup code.
 	func(ctx context.Context, data []byte) {
+		// add a small sleep to add jitter to the start of each test
+		randomSleep := rand.Intn(10)
+		err := smithyTime.SleepWithContext(ctx, time.Duration(randomSleep)*time.Second)
+		Expect(err).NotTo(HaveOccurred(), "failed to sleep")
 		suiteConfig = suite.BeforeSuiteCredentialUnmarshal(ctx, data)
 	},
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently we run across all kube versions/cni combos concurrently in CI.  We see issues due to this from time to time because the test end up hitting points across the various builders around the same time, which can trigger large amount of concurrent api requests.

This adds a random wait between 0-30 seconds before starting each test to try and give a bit more variance.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

