### PR TITLE
Only retrieve tgw attachments that are in available state for given tgw

### DIFF
--- a/test/e2e/peered/cluster.go
+++ b/test/e2e/peered/cluster.go
@@ -102,6 +102,10 @@ func findHybridVPC(ctx context.Context, client *ec2.Client, clusterVpcID string)
 				Name:   aws.String("transit-gateway-id"),
 				Values: []string{tgwID},
 			},
+			{
+				Name:   aws.String("state"),
+				Values: []string{"available"},
+			},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

We see the following tgw issue occasionally.

```
Expected should build peered VPC test config
		Unexpected error:
		    <*fmt.wrapError | 0xc0009aca60>: 
		    getting peered VPC for the given cluster nodeadm-canary-1-30-vuDGmFQ8J6-1747907576: expected 2 TGW attachments for TGW tgw-0a5b45657366b7cd6, got 3
		    {
		        msg: "getting peered VPC for the given cluster nodeadm-canary-1-30-vuDGmFQ8J6-1747907576: expected 2 TGW attachments for TGW tgw-0a5b45657366b7cd6, got 3",
		        err: <*errors.errorString | 0xc0009af9a0>{
		            s: "expected 2 TGW attachments for TGW tgw-0a5b45657366b7cd6, got 3",
		        },
		    }
		occurred
```

*Description of changes:*
Similar to #552 , we now only retrieve tgw attachments that are in available state for given tgw.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

