### PR TITLE
update ec2-role name to be unique

### DIFF
--- a/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
+++ b/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
@@ -19,7 +19,9 @@ Parameters:
   IRARolePrefix:
     Type: String
     Default: 'ira'
- 
+  EC2RolePrefix:
+    Type: String
+    Default: 'ec2'
     
 Resources:
   SSMRole:
@@ -158,20 +160,11 @@ Resources:
     Properties:
       # use a predictable prefix for EC2 role while maintaining uniqueness requirement for EC2 role name
       RoleName:
-        Fn::Join:
-        - '-'
-        - - 'ec2-role'
-          - !Ref AWS::AccountId
-          - !Ref AWS::Region
-          - Fn::Select:
-            - 0
-            - Fn::Split:
-              - '-'
-              - Fn::Select:
-                - 2
-                - Fn::Split:
-                  - /
-                  - !Ref AWS::StackId
+        !Sub
+          - '${RolePrefix}-${TrimmedRegion}${UUID}'
+          - RolePrefix: !Ref EC2RolePrefix
+            TrimmedRegion: !Join ['', !Split ['-', !Ref AWS::Region]]
+            UUID: !Join ['', !Split ['-', !Select [2, !Split [/, !Ref AWS::StackId]]]]
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
Modified the IAM role naming pattern to use the full UUID instead of first segment similar to ssm and ira role names 

