### PR TITLE
increases ssm client retries when getting managed instnace info

### DIFF
--- a/internal/flows/uninstall.go
+++ b/internal/flows/uninstall.go
@@ -82,11 +82,14 @@ func (u *Uninstaller) uninstallDaemons(ctx context.Context) error {
 			return err
 		}
 
+		ssmClient := awsSsm.NewFromConfig(awsConfig, func(o *awsSsm.Options) {
+			o.RetryMaxAttempts = 6
+		})
 		if err := ssm.Uninstall(ctx, ssm.UninstallOptions{
 			Logger:          u.Logger,
 			SSMRegistration: ssmRegistration,
 			PkgSource:       u.PackageManager,
-			SSMClient:       awsSsm.NewFromConfig(awsConfig),
+			SSMClient:       ssmClient,
 		}); err != nil {
 			return fmt.Errorf("uninstalling SSM: %w", err)
 		}

--- a/internal/ssm/aws.go
+++ b/internal/ssm/aws.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 )
 
-func isInstanceManaged(client SSMClient, instanceId string) (bool, error) {
-	output, err := client.DescribeInstanceInformation(context.Background(), &awsSsm.DescribeInstanceInformationInput{
+func isInstanceManaged(ctx context.Context, client SSMClient, instanceId string) (bool, error) {
+	output, err := client.DescribeInstanceInformation(ctx, &awsSsm.DescribeInstanceInformationInput{
 		Filters: []types.InstanceInformationStringFilter{
 			{
 				Key:    aws.String("InstanceIds"),
@@ -24,8 +24,8 @@ func isInstanceManaged(client SSMClient, instanceId string) (bool, error) {
 	return len(output.InstanceInformationList) > 0, nil
 }
 
-func deregister(client SSMClient, instanceId string) error {
-	_, err := client.DeregisterManagedInstance(context.Background(), &awsSsm.DeregisterManagedInstanceInput{
+func deregister(ctx context.Context, client SSMClient, instanceId string) error {
+	_, err := client.DeregisterManagedInstance(ctx, &awsSsm.DeregisterManagedInstanceInput{
 		InstanceId: &instanceId,
 	})
 	return err

--- a/internal/ssm/registration.go
+++ b/internal/ssm/registration.go
@@ -53,7 +53,7 @@ func Deregister(ctx context.Context, registration *SSMRegistration, ssmClient SS
 		return errors.Wrapf(err, "reading ssm registration file")
 	}
 
-	managed, err := isInstanceManaged(ssmClient, instanceId)
+	managed, err := isInstanceManaged(ctx, ssmClient, instanceId)
 	if err != nil {
 		return errors.Wrapf(err, "getting managed instance information")
 	}
@@ -61,7 +61,7 @@ func Deregister(ctx context.Context, registration *SSMRegistration, ssmClient SS
 	// Only deregister the instance if init/ssm init was run and
 	// if instances is actively listed as managed
 	if managed {
-		if err := deregister(ssmClient, instanceId); err != nil {
+		if err := deregister(ctx, ssmClient, instanceId); err != nil {
 			return errors.Wrapf(err, "deregistering ssm managed instance")
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We saw:

```
"Command failed","error":"uninstalling SSM: getting managed instance information: operation error SSM: DescribeInstanceInformation, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , request send failed, Post \"https://ssm.eu-central-2.amazonaws.com/\": write tcp 10.1.1.119:48900->16.63.92.84:443: write: connection reset by peer"}
```

This bumps the default retries to 6 from 3 to try and avoid these. 

Another option is we could set it on the aws config as a whole for the uninstall command. The ssm client is currently the only client created from the aws config.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

