### PR TITLE
Remove retrier from AWS STS call

### DIFF
--- a/internal/aws/sts/validate.go
+++ b/internal/aws/sts/validate.go
@@ -64,11 +64,7 @@ func (a AuthenticationValidator) Run(ctx context.Context, informer validation.In
 
 	client := sts_sdk.NewFromConfig(a.aws)
 
-	err = retry.NetworkRequest(ctx, func(ctx context.Context) error {
-		_, err := client.GetCallerIdentity(ctx, &sts_sdk.GetCallerIdentityInput{})
-		return err
-	})
-	if err != nil {
+	if _, err = client.GetCallerIdentity(ctx, &sts_sdk.GetCallerIdentityInput{}); err != nil {
 		err = validation.WithRemediation(err, "Check your AWS configuration and make sure you can obtain valid AWS credentials.")
 		return err
 	}


### PR DESCRIPTION
## Description of changes
The AWS SDK already handles retries reasonable well and adapting better to the different API responses than our generic retrier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

