### PR TITLE
Use kernel 6.12 instead of 6.1 for AL23 in E2E tests

### DIFF
--- a/test/e2e/os/amazonlinux.go
+++ b/test/e2e/os/amazonlinux.go
@@ -46,7 +46,7 @@ func (a AmazonLinux2023) InstanceType(region string, instanceSize e2e.InstanceSi
 }
 
 func (a AmazonLinux2023) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {
-	amiId, err := getAmiIDFromSSM(ctx, ssm.NewFromConfig(awsConfig), "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-"+a.amiArchitecture)
+	amiId, err := getAmiIDFromSSM(ctx, ssm.NewFromConfig(awsConfig), "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.12-"+a.amiArchitecture)
 	return *amiId, err
 }
 


### PR DESCRIPTION
*Issue #, if available:*
When using `default` to get `AMI` ID from `SSM`, it gets `6.1` instead of latest `6.12`. This works fine for all our existing tests. 

However when installing nvidia drivers for our GPU EC2 instance with instructions from [official website](https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/index.html#amazon-installation), the installation fails due to the following error.

```
dkms: running auto installation service for kernel 6.12.25-32.101.amzn2023.x86_64
Error! Your kernel headers for kernel 6.12.25-32.101.amzn2023.x86_64 cannot be found at /lib/modules/6.12.25-32.101.amzn2023.x86_64/build or /lib/modules/6.12.25-32.101.amzn2023.x86_64/source.
Please install the linux-headers-6.12.25-32.101.amzn2023.x86_64 package or use the --kernelsourcedir option to tell DKMS where it's located.
```

The instance is running with kernel `6.1.134`. However nvidia tries to use a higher version `6.12.25` for some reason. I guess it might be related to the fact that both version exist in the `/lib/modules` path.

```
[root@ip-10-1-1-19 modules]# ls
6.1.134-152.225.amzn2023.x86_64  6.12.25-32.101.amzn2023.x86_64
``` 

If we start with kernel `6.12`, then the installation succeeds.

*Description of changes:*

In this PR, I am upgrading kernel version for AL23 to `6.12`. SSM returns `6.1` back when `default` is used. This behavior could change in the future but for now we want to explicitly use kernel version `6.12`.

*Testing (if applicable):*
Manual test

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

