### PR TITLE
rework release/build scripts to limit prod release work

### DIFF
--- a/buildspecs/build-nodeadm.yml
+++ b/buildspecs/build-nodeadm.yml
@@ -3,10 +3,7 @@ version: 0.2
 phases:
   build:
     commands:
-    - make build-cross-platform build-cross-e2e-tests-binary build-cross-e2e-test install-cross-ginkgo
-    - gzip --best < _bin/amd64/nodeadm > _bin/amd64/nodeadm.gz
-    - gzip --best < _bin/arm64/nodeadm > _bin/arm64/nodeadm.gz
-    - echo $GIT_VERSION >> _bin/GIT_VERSION
+    - ./hack/build-nodeadm.sh $GIT_VERSION
 
 cache:
   paths:

--- a/buildspecs/dev-release-nodeadm.yml
+++ b/buildspecs/dev-release-nodeadm.yml
@@ -3,6 +3,8 @@ version: 0.2
 phases:
   build:
     commands:
-    - aws s3 sync --no-progress --exclude "*nodeadm.gz" _bin/ s3://$ARTIFACTS_BUCKET/latest/linux/ --acl public-read
-    - aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip _bin/ s3://$ARTIFACTS_BUCKET/latest/linux/ --acl public-read
-    - aws s3 cp _bin/GIT_VERSION s3://$ARTIFACTS_BUCKET/latest/GIT_VERSION --acl public-read
+    - ./hack/upload-dev-release-artifacts.sh $ARTIFACTS_BUCKET
+
+  post_build:
+    commands:
+    - ./hack/validate-release-artifacts.sh $ARTIFACTS_BUCKET latest

--- a/buildspecs/prod-release-nodeadm.yml
+++ b/buildspecs/prod-release-nodeadm.yml
@@ -3,14 +3,13 @@ version: 0.2
 phases:
   pre_build:
     commands:
+      # ensure staging release artifacts are valid before starting prod release
+      - ./hack/validate-release-artifacts.sh $STAGING_BUCKET latest
       - echo "Downloading artifacts from staging bucket..."
-      - aws s3 sync --no-progress s3://${STAGING_BUCKET}/latest/linux/amd64/ _bin/amd64/
-      - aws s3 sync --no-progress s3://${STAGING_BUCKET}/latest/linux/arm64/ _bin/arm64/
-      - aws s3 cp --no-progress s3://${STAGING_BUCKET}/latest/GIT_VERSION _bin/GIT_VERSION
-
-      - export VERSION=$(cat _bin/GIT_VERSION)
+      - aws s3 sync --no-progress s3://${STAGING_BUCKET}/latest/ ./latest
+      - export VERSION=$(cat latest/GIT_VERSION)
       - echo "Using version:"
-      - cat _bin/GIT_VERSION
+      - cat latest/GIT_VERSION
 
       - echo "Setting up AWS config for role assumption..."
       - |
@@ -25,8 +24,10 @@ phases:
 
   build:
     commands:
-      - ./hack/release-nodeadm.sh "${PROD_BUCKET}" "artifacts-production" "${VERSION}"
+      - AWS_PROFILE=artifacts-production ./hack/release-nodeadm.sh "${PROD_BUCKET}" "${VERSION}"
 
   post_build:
     commands:
-      - ./hack/validate-release.sh "${CLOUDFRONT_DISTRIBUTION_ID}" "artifacts-production" "_bin/GIT_VERSION"
+      - AWS_PROFILE=artifacts-production ./hack/validate-release-artifacts.sh $PROD_BUCKET releases/${VERSION}
+      - AWS_PROFILE=artifacts-production ./hack/validate-release-artifacts.sh $PROD_BUCKET releases/latest
+      - AWS_PROFILE=artifacts-production ./hack/validate-release.sh "${CLOUDFRONT_DISTRIBUTION_ID}" "latest/GIT_VERSION"

--- a/hack/build-nodeadm.sh
+++ b/hack/build-nodeadm.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GIT_VERSION="$1"
+
+# Generate attribution
+echo "Generating attribution..."
+make generate-attribution
+
+echo "Building nodeadm and tests binaries..."
+make build-cross-platform build-cross-e2e-tests-binary build-cross-e2e-test install-cross-ginkgo
+
+echo "Compressing nodeadm binaries..."
+for ARCH in amd64 arm64; do
+    gzip --best < _bin/${ARCH}/nodeadm > _bin/${ARCH}/nodeadm.gz
+done
+
+# Generate and upload checksums
+echo "Generating and uploading nodeadm checksums..."
+for ARCH in amd64 arm64; do
+  for FILE in nodeadm nodeadm.gz; do
+    for CHECKSUM in sha256 sha512; do
+      (cd _bin/${ARCH} && ${CHECKSUM}sum ${FILE} > ${FILE}.${CHECKSUM})
+    done
+  done
+done
+
+mv ATTRIBUTION.txt _bin/ATTRIBUTION.txt
+echo $GIT_VERSION >> _bin/GIT_VERSION

--- a/hack/release-nodeadm.sh
+++ b/hack/release-nodeadm.sh
@@ -5,37 +5,23 @@ set -o pipefail
 
 # Required arguments
 PROD_BUCKET=$1
-PROFILE=$2
-VERSION=$3
+VERSION=$2
+PUBLIC_READ_ACL="${3:-true}"
+
+PUBLIC_READ_ACL_ARG=""  
+if [ "$PUBLIC_READ_ACL" = "true" ]; then
+  PUBLIC_READ_ACL_ARG="--acl public-read"
+fi
 
 echo "Starting nodeadm release process..."
 
 # Upload to production
-echo "Uploading nodeadm to production..."
-for ARCH in amd64 arm64; do
-  aws s3 cp --no-progress _bin/${ARCH}/nodeadm "s3://${PROD_BUCKET}/releases/${VERSION}/bin/linux/${ARCH}/nodeadm" --profile "${PROFILE}"
-  aws s3 cp --no-progress _bin/${ARCH}/nodeadm.gz "s3://${PROD_BUCKET}/releases/${VERSION}/bin/linux/${ARCH}/nodeadm.gz" --profile "${PROFILE}" --content-encoding gzip
-done
-
-# Generate and upload checksums
-echo "Generating and uploading nodeadm checksums..."
-for ARCH in amd64 arm64; do
-  for FILE in nodeadm nodeadm.gz; do
-    for CHECKSUM in sha256 sha512; do
-      ${CHECKSUM}sum _bin/${ARCH}/${FILE} > _bin/${ARCH}/${FILE}.${CHECKSUM}
-      aws s3 cp --no-progress _bin/${ARCH}/${FILE}.${CHECKSUM} "s3://${PROD_BUCKET}/releases/${VERSION}/bin/linux/${ARCH}/${FILE}.${CHECKSUM}" --profile "${PROFILE}"
-    done
-  done
-done
+echo "Uploading artifacts to production..."
+aws s3 sync --no-progress --exclude "*nodeadm.gz" latest/ s3://${PROD_BUCKET}/releases/${VERSION}/ ${PUBLIC_READ_ACL_ARG}
+aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip latest/ s3://${PROD_BUCKET}/releases/${VERSION}/ ${PUBLIC_READ_ACL_ARG}
 
 # Update latest symlinks
 echo "Updating latest symlinks for nodeadm..."
-aws s3 sync --no-progress s3://${PROD_BUCKET}/releases/${VERSION}/bin/linux/ s3://${PROD_BUCKET}/releases/latest/bin/linux/ --profile "${PROFILE}"
-
-# Generate and upload attribution
-echo "Generating and uploading attribution..."
-make generate-attribution
-aws s3 cp --no-progress ATTRIBUTION.txt "s3://${PROD_BUCKET}/releases/${VERSION}/ATTRIBUTION.txt" --profile "${PROFILE}"
-aws s3 cp --no-progress ATTRIBUTION.txt "s3://${PROD_BUCKET}/releases/latest/ATTRIBUTION.txt" --profile "${PROFILE}"
+aws s3 sync --no-progress s3://${PROD_BUCKET}/releases/${VERSION}/ s3://${PROD_BUCKET}/releases/latest/
 
 echo "Release process completed successfully"

--- a/hack/upload-dev-release-artifacts.sh
+++ b/hack/upload-dev-release-artifacts.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ARTIFACTS_BUCKET="$1"
+PUBLIC_READ_ACL="${2:-true}"
+
+PUBLIC_READ_ACL_ARG=""  
+if [ "$PUBLIC_READ_ACL" = "true" ]; then
+  PUBLIC_READ_ACL_ARG="--acl public-read"
+fi
+
+# only uploading nodeadm, ATTRIBUTION.txt, and GIT_VERSION, skipping ginkgo/e2e-test/nodeadm.test
+mkdir -p _bin/latest/linux/{amd64,arm64}
+cp _bin/{ATTRIBUTION.txt,GIT_VERSION} _bin/latest/
+cp _bin/amd64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/linux/amd64/
+cp _bin/arm64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/linux/arm64/
+
+# uploading nodeadm.gz files separately to ensure the content-encoding is applied
+aws s3 sync --no-progress --exclude "*nodeadm.gz" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/ ${PUBLIC_READ_ACL_ARG}
+aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/ ${PUBLIC_READ_ACL_ARG}

--- a/hack/validate-release-artifacts.sh
+++ b/hack/validate-release-artifacts.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ARTIFACTS_BUCKET="$1"
+BUCKET_PREFIX="$2"
+
+# *********************************************************************
+# DO NOT EDIT this list unless you are sure you know what you are doing
+# *********************************************************************
+
+# expected list of files is intentional hardcoded and not generated
+# to ensure we do not accidentally upload new files or remove files from the list  
+# this will run after staging and prod releases
+EXPECTED_FILES_FILE=$(mktemp)
+cat <<EOF > ${EXPECTED_FILES_FILE}
+ATTRIBUTION.txt
+GIT_VERSION
+linux/amd64/nodeadm
+linux/amd64/nodeadm.gz
+linux/amd64/nodeadm.gz.sha256
+linux/amd64/nodeadm.gz.sha512
+linux/amd64/nodeadm.sha256
+linux/amd64/nodeadm.sha512
+linux/arm64/nodeadm
+linux/arm64/nodeadm.gz
+linux/arm64/nodeadm.gz.sha256
+linux/arm64/nodeadm.gz.sha512
+linux/arm64/nodeadm.sha256
+linux/arm64/nodeadm.sha512
+EOF
+# *********************************************************************
+
+echo "Validating release artifacts..."
+
+# get a list of files via s3 cli
+if ! S3_FILES=$(aws s3 ls s3://${ARTIFACTS_BUCKET}/${BUCKET_PREFIX}/ --recursive | awk '{print $4}' | sed -e "s#^${BUCKET_PREFIX}/##"); then
+    echo "Failed to get list of files from S3"
+    exit 1
+fi
+
+S3_FILES_FILE=$(mktemp)
+sort <(echo "${S3_FILES[@]}") > ${S3_FILES_FILE}
+
+if ! diff -q ${EXPECTED_FILES_FILE} ${S3_FILES_FILE} &>/dev/null; then
+    echo "Artifacts directory on S3 does not matched expected!"
+    diff -y ${EXPECTED_FILES_FILE} ${S3_FILES_FILE}
+    exit 1
+fi
+
+echo "Release artifacts validated successfully"

--- a/hack/validate-release.sh
+++ b/hack/validate-release.sh
@@ -5,19 +5,18 @@ set -o pipefail
 
 # Required arguments
 CLOUDFRONT_ID=$1
-PROFILE=$2
-VERSION_FILE=$3
+VERSION_FILE=$2
 
 echo "Starting release validation..."
 
 # Create and wait for CloudFront invalidation
 echo "Invalidating CloudFront cache..."
-INVALIDATION_ID=$(aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_ID}" --paths "/releases/latest/bin/*" --profile "${PROFILE}" --query 'Invalidation.Id' --output text)
+INVALIDATION_ID=$(aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_ID}" --paths "/releases/latest/bin/*" --query 'Invalidation.Id' --output text)
 echo "Created invalidation with ID: ${INVALIDATION_ID}"
 
 echo "Waiting for CloudFront invalidation to complete..."
 while true; do
-    STATUS=$(aws cloudfront get-invalidation --distribution-id "${CLOUDFRONT_ID}" --id "${INVALIDATION_ID}" --profile "${PROFILE}" --query 'Invalidation.Status' --output text)
+    STATUS=$(aws cloudfront get-invalidation --distribution-id "${CLOUDFRONT_ID}" --id "${INVALIDATION_ID}" --query 'Invalidation.Status' --output text)
     echo "Current invalidation status: ${STATUS}"
     if [ "${STATUS}" = "Completed" ]; then
         break

--- a/scripts/make_attribution.sh
+++ b/scripts/make_attribution.sh
@@ -24,7 +24,7 @@ if [ "$CI" = "true" ]; then
     # Prow clone process does not add remote so we have to explicitly add
     # it. Setting it to HTTPS URL for go-licenses 
     git remote add origin https://github.com/$REPO_OWNER/eks-hybrid.git
-else
+elif [ "$CODEBUILD_CI" = false ]; then
     # go-licenses supports only HTTPS URLs so if the CLI repo is cloned locally 
     # with SSH URL, we need to temporarily override the remote URL for go-licenses
     # to work as expected
@@ -44,7 +44,11 @@ source "$REPO_ROOT/scripts/attribution_helpers.sh"
 function build::attribution::generate(){
     cd $REPO_ROOT
     $(get_go_path "$GOLANG_VERSION")/go mod vendor
-    build::create_git_tag
+    if [ -n "$GIT_VERSION" ]; then
+        echo $GIT_VERSION > GIT_TAG
+    else
+        build::create_git_tag
+    fi    
     gather_licenses "$GOLANG_VERSION" _output "./cmd/nodeadm"
     build::exclude_own
     build::generate_attribution $GOLANG_VERSION


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This reworks the build and release scripts to better support testing throughout the process. As much as can be as been pushed to the build + staging build nows.  The prod release is a pretty simple s3 sync and then validation.

Added a validation script to ensure we are publishing the expected artifacts throughout the various points in the process.

Fixed the checksum generation to remove the `_bin/linux` path in the final files, which makes validating for the user complicated. The new format will be 

`e2e18a56947384781ae61b9d58d57d9ddf0fe9dad1cbfe0e0323c7ea497d93aa  nodeadm.gz`

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

