### PR TITLE
Make e2e-test commands (setup, cleanup, node create, node delete) callable from other packages

### DIFF
--- a/cmd/e2e-test/cleanup/cleanup.go
+++ b/cmd/e2e-test/cleanup/cleanup.go
@@ -34,6 +34,13 @@ func NewCommand() *Command {
 	return &cmd
 }
 
+func NewCommandWithParams(resourcesFilePath string) *Command {
+	cmd := Command{
+		resourcesFilePath: resourcesFilePath,
+	}
+	return &cmd
+}
+
 func (c *Command) Flaggy() *flaggy.Subcommand {
 	return c.flaggy
 }

--- a/cmd/e2e-test/node/create.go
+++ b/cmd/e2e-test/node/create.go
@@ -59,6 +59,20 @@ func NewCreateCommand() cli.Command {
 	return &cmd
 }
 
+func NewCreateCommandWithParams(name, configFile, credsProvider, osType, arch, instanceSize, instanceType string) cli.Command {
+	cmd := create{
+		os:            osType,
+		arch:          arch,
+		instanceSize:  instanceSize,
+		instanceType:  instanceType,
+		credsProvider: credsProvider,
+		instanceName:  name,
+		configFile:    configFile,
+	}
+
+	return &cmd
+}
+
 func (c *create) Flaggy() *flaggy.Subcommand {
 	return c.flaggy
 }

--- a/cmd/e2e-test/node/delete.go
+++ b/cmd/e2e-test/node/delete.go
@@ -43,6 +43,14 @@ func NewDeleteCommand() *Delete {
 	return cmd
 }
 
+func NewDeleteCommandWithParams(instanceName, configFile string) *Delete {
+	cmd := &Delete{
+		instanceName: instanceName,
+		configFile:   configFile,
+	}
+	return cmd
+}
+
 func (d *Delete) Flaggy() *flaggy.Subcommand {
 	return d.flaggy
 }

--- a/cmd/e2e-test/setup/setup.go
+++ b/cmd/e2e-test/setup/setup.go
@@ -32,6 +32,13 @@ func NewCommand() *Command {
 	return &cmd
 }
 
+func NewCommandWithParams(configFilePath string) *Command {
+	cmd := Command{
+		configFilePath: configFilePath,
+	}
+	return &cmd
+}
+
 func (c *Command) Flaggy() *flaggy.Subcommand {
 	return c.flaggy
 }


### PR DESCRIPTION
*Issue #, if available:*
Currently our e2e-test commands are only available from command line. This makes it harder to be called from other packages.

*Description of changes:*
In this PR, I am creating `NewXXXCommandWithParams` method for `setup`, `cleanup`, `node create`, `node delete` commands that other packages can import them to create and delete hybrid nodes.


*Testing (if applicable):*
Tested with aws-k8s-deployer

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

