### PR TITLE
Disable CGO for nodeadm build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ lint: golangci-lint ## Run golangci-lint.
 .PHONY: build
 build: LINKER_FLAGS :=-X github.com/aws/eks-hybrid/cmd/nodeadm/version.GitVersion=$(GIT_VERSION) -X github.com/aws/eks-hybrid/internal/aws.manifestUrl=$(HYBRID_MANIFEST_URL) -s -w -buildid='' -extldflags -static
 build: ## Build nodeadm binary.
-	$(GO) build -ldflags "$(LINKER_FLAGS)" -trimpath -o $(LOCALBIN)/nodeadm cmd/nodeadm/main.go
+	CGO_ENABLED=0 $(GO) build -ldflags "$(LINKER_FLAGS)" -trimpath -o $(LOCALBIN)/nodeadm cmd/nodeadm/main.go
 
 .PHONY: build-cross-platform
 build-cross-platform: LINKER_FLAGS :=-X github.com/aws/eks-hybrid/cmd/nodeadm/version.GitVersion=$(GIT_VERSION) -X github.com/aws/eks-hybrid/internal/aws.manifestUrl=$(HYBRID_MANIFEST_URL) -s -w -buildid='' -extldflags -static

--- a/internal/packagemanager/packagemanager.go
+++ b/internal/packagemanager/packagemanager.go
@@ -47,9 +47,6 @@ const (
 	ssmPkgName      = "amazon-ssm-agent"
 )
 
-var aptDockerRepoConfig = fmt.Sprintf("deb [arch=%s signed-by=%s] %s %s stable\n", runtime.GOARCH, ubuntuDockerGpgKeyPath,
-	ubuntuDockerRepo, system.GetVersionCodeName())
-
 // DistroPackageManager defines a new package manager using apt or yum
 type DistroPackageManager struct {
 	manager             string
@@ -147,6 +144,7 @@ func (pm *DistroPackageManager) configureAptPackageManagerWithDockerRepo(ctx con
 		return err
 	}
 
+	aptDockerRepoConfig := fmt.Sprintf("deb [arch=%s signed-by=%s] %s %s stable\n", runtime.GOARCH, ubuntuDockerGpgKeyPath, ubuntuDockerRepo, system.GetVersionCodeName())
 	// Add docker repo config for ubuntu-apt to apt sources
 	if err := util.WriteFileWithDir(aptDockerRepoSourceFilePath, []byte(aptDockerRepoConfig), ubuntuDockerGpgKeyFilePerms); err != nil {
 		return err


### PR DESCRIPTION
* Disable CGO for nodeadm build target. Without this, the `make build` target throws a linker error:
```
/opt/homebrew/bin/go build -ldflags "-X github.com/aws/eks-hybrid/cmd/nodeadm/version.GitVersion=0.0.0 -X github.com/aws/eks-hybrid/internal/aws.manifestUrl=https://hybrid-assets.eks.amazonaws.com/manifest.yaml -s -w -buildid='' -extldflags -static" -trimpath -o /Users/arnchlm/eks-hybrid/_bin/nodeadm cmd/nodeadm/main.go
# command-line-arguments
/opt/homebrew/Cellar/go/1.24.3/libexec/pkg/tool/darwin_arm64/link: running cc failed: exit status 1
/usr/bin/cc -arch arm64 -Wl,-S -Wl,-x -o $WORK/b001/exe/a.out -Qunused-arguments /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/go.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000000.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000001.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000002.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000003.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000004.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000005.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000006.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000007.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000008.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000009.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000010.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000011.o /var/folders/sv/cpy5yzy57mj8xj8q35l9l_8h0000gq/T/go-link-518237138/000012.o -lresolv -framework CoreFoundation -framework Security -O2 -g -O2 -g -framework CoreFoundation -static
ld: library 'crt0.o' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)

make: *** [build] Error 1
```
* Move apt Docker repo config inside function so that Darwin build of nodeadm binary can run. Without this, it just panics looking for the `/etc/os-release` file.
```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x1 pc=0x1057f968c]

goroutine 1 [running]:
github.com/go-ini/ini.(*File).SectionsByName(0x0, {0x0?, 0x1400064eae0?})
        /Users/arnchlm/go/pkg/mod/github.com/go-ini/ini@v1.67.0/file.go:156 +0x4c
github.com/go-ini/ini.(*File).GetSection(...)
        /Users/arnchlm/go/pkg/mod/github.com/go-ini/ini@v1.67.0/file.go:137
github.com/go-ini/ini.(*File).Section(0x0, {0x0, 0x0})
        /Users/arnchlm/go/pkg/mod/github.com/go-ini/ini@v1.67.0/file.go:175 +0x28
github.com/aws/eks-hybrid/internal/system.GetVersionCodeName()
        /Users/arnchlm/eks-hybrid/internal/system/os.go:21 +0x68
github.com/aws/eks-hybrid/internal/packagemanager.init()
        /Users/arnchlm/eks-hybrid/internal/packagemanager/packagemanager.go:51 +0x1c
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

