### PR TITLE
Set up GPU nodes for nvidia tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GIT_VERSION?=0.0.0
 MANIFEST_HOST?=hybrid-assets.eks.amazonaws.com
 HYBRID_MANIFEST_URL=https://$(MANIFEST_HOST)/manifest.yaml
 
-E2E_SUITES?=./test/e2e/suite/nodeadm ./test/e2e/suite/conformance ./test/e2e/suite/addons
+E2E_SUITES?=./test/e2e/suite/nodeadm ./test/e2e/suite/conformance ./test/e2e/suite/addons ./test/e2e/suite/nvidia
 
 .PHONY: all
 all: crds generate fmt vet build

--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -16,7 +16,7 @@ type NodeadmOS interface {
 	Name() string
 	AMIName(ctx context.Context, awsConfig aws.Config) (string, error)
 	BuildUserData(userDataInput UserDataInput) ([]byte, error)
-	InstanceType(region string, instanceSize InstanceSize) string
+	InstanceType(region string, instanceSize InstanceSize, gpuInstance bool) string
 }
 
 type InstanceSize int

--- a/test/e2e/os/amazonlinux.go
+++ b/test/e2e/os/amazonlinux.go
@@ -41,8 +41,8 @@ func (a AmazonLinux2023) Name() string {
 	return "al23-" + a.architecture.String()
 }
 
-func (a AmazonLinux2023) InstanceType(region string, instanceSize e2e.InstanceSize) string {
-	return getInstanceTypeFromRegionAndArch(region, a.architecture, instanceSize)
+func (a AmazonLinux2023) InstanceType(region string, instanceSize e2e.InstanceSize, gpuInstance bool) string {
+	return getInstanceTypeFromRegionAndArch(region, a.architecture, instanceSize, gpuInstance)
 }
 
 func (a AmazonLinux2023) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {

--- a/test/e2e/os/arch.go
+++ b/test/e2e/os/arch.go
@@ -36,6 +36,17 @@ var instanceSizeToType = map[architecture]map[e2e.InstanceSize]string{
 	},
 }
 
+var gpuInstanceSizeToType = map[architecture]map[e2e.InstanceSize]string{
+	amd64: {
+		e2e.XLarge: "g4dn.2xlarge",
+		e2e.Large:  "g4dn.xlarge",
+	},
+	arm64: {
+		e2e.XLarge: "g5g.2xlarge",
+		e2e.Large:  "g5g.xlarge",
+	},
+}
+
 func (a architecture) String() string {
 	return string(a)
 }
@@ -94,8 +105,16 @@ func getAmiIDFromSSM(ctx context.Context, client *ssm.Client, amiName string) (*
 }
 
 // an unknown size and arch combination is a coding error, so we panic
-func getInstanceTypeFromRegionAndArch(_ string, arch architecture, instanceSize e2e.InstanceSize) string {
-	instanceType, ok := instanceSizeToType[arch][instanceSize]
+func getInstanceTypeFromRegionAndArch(_ string, arch architecture, instanceSize e2e.InstanceSize, gpuInstance bool) string {
+	var instanceType string
+	var ok bool
+
+	if gpuInstance {
+		instanceType, ok = gpuInstanceSizeToType[arch][instanceSize]
+	} else {
+		instanceType, ok = instanceSizeToType[arch][instanceSize]
+	}
+
 	if !ok {
 		panic(fmt.Errorf("unknown instance size %d for architecture %s", instanceSize, arch))
 	}

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -67,8 +67,8 @@ func (r RedHat8) Name() string {
 	return "rhel8-" + r.architecture.String()
 }
 
-func (r RedHat8) InstanceType(region string, instanceSize e2e.InstanceSize) string {
-	return getInstanceTypeFromRegionAndArch(region, r.architecture, instanceSize)
+func (r RedHat8) InstanceType(region string, instanceSize e2e.InstanceSize, gpuInstance bool) string {
+	return getInstanceTypeFromRegionAndArch(region, r.architecture, instanceSize, gpuInstance)
 }
 
 func (r RedHat8) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {
@@ -140,8 +140,8 @@ func (r RedHat9) Name() string {
 	return name
 }
 
-func (r RedHat9) InstanceType(region string, instanceSize e2e.InstanceSize) string {
-	return getInstanceTypeFromRegionAndArch(region, r.architecture, instanceSize)
+func (r RedHat9) InstanceType(region string, instanceSize e2e.InstanceSize, gpuInstance bool) string {
+	return getInstanceTypeFromRegionAndArch(region, r.architecture, instanceSize, gpuInstance)
 }
 
 func (r RedHat9) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -87,8 +87,8 @@ func (u Ubuntu2004) Name() string {
 	return name
 }
 
-func (u Ubuntu2004) InstanceType(region string, instanceSize e2e.InstanceSize) string {
-	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize)
+func (u Ubuntu2004) InstanceType(region string, instanceSize e2e.InstanceSize, gpuInstance bool) string {
+	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize, gpuInstance)
 }
 
 func (u Ubuntu2004) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {
@@ -155,8 +155,8 @@ func (u Ubuntu2204) Name() string {
 	return name
 }
 
-func (u Ubuntu2204) InstanceType(region string, instanceSize e2e.InstanceSize) string {
-	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize)
+func (u Ubuntu2204) InstanceType(region string, instanceSize e2e.InstanceSize, gpuInstance bool) string {
+	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize, gpuInstance)
 }
 
 func (u Ubuntu2204) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {
@@ -234,8 +234,8 @@ func (u Ubuntu2404) Name() string {
 	return name
 }
 
-func (u Ubuntu2404) InstanceType(region string, instanceSize e2e.InstanceSize) string {
-	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize)
+func (u Ubuntu2404) InstanceType(region string, instanceSize e2e.InstanceSize, gpuInstance bool) string {
+	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize, gpuInstance)
 }
 
 func (u Ubuntu2404) AMIName(ctx context.Context, awsConfig aws.Config) (string, error) {

--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -50,6 +50,7 @@ type NodeSpec struct {
 	InstanceProfileARN string
 	NodeK8sVersion     string
 	NodeName           string
+	GpuInstance        bool
 	OS                 e2e.NodeadmOS
 	Provider           e2e.NodeadmCredentialsProvider
 }
@@ -137,7 +138,7 @@ func (c NodeCreate) Create(ctx context.Context, spec *NodeSpec) (PeerdNode, erro
 
 	instanceType := spec.InstanceType
 	if instanceType == "" {
-		instanceType = spec.OS.InstanceType(c.Cluster.Region, spec.InstanceSize)
+		instanceType = spec.OS.InstanceType(c.Cluster.Region, spec.InstanceSize, spec.GpuInstance)
 	}
 
 	ec2Input := ec2.InstanceConfig{

--- a/test/e2e/suite/nodeadm/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm/nodeadm_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Hybrid Nodes", func() {
 						k8sVersion = test.OverrideNodeK8sVersion
 					}
 
-					testNode := test.NewTestNode(ctx, instanceName, nodeName, k8sVersion, nodeOS, provider, e2e.Large)
+					testNode := test.NewTestNode(ctx, instanceName, nodeName, k8sVersion, nodeOS, provider, e2e.Large, false)
 					Expect(testNode.Start(ctx)).To(Succeed(), "node should start successfully")
 					Expect(testNode.Verify(ctx)).To(Succeed(), "node should be fully functional")
 
@@ -155,7 +155,7 @@ var _ = Describe("Hybrid Nodes", func() {
 					nodeKubernetesVersion, err := kubernetes.PreviousVersion(test.Cluster.KubernetesVersion)
 					Expect(err).NotTo(HaveOccurred(), "expected to get previous k8s version")
 
-					testNode := test.NewTestNode(ctx, instanceName, nodeName, nodeKubernetesVersion, nodeOS, provider, e2e.Large)
+					testNode := test.NewTestNode(ctx, instanceName, nodeName, nodeKubernetesVersion, nodeOS, provider, e2e.Large, false)
 					Expect(testNode.Start(ctx)).To(Succeed(), "node should start successfully")
 					Expect(testNode.Verify(ctx)).To(Succeed(), "node should be fully functional")
 

--- a/test/e2e/suite/nvidia/nvidia_test.go
+++ b/test/e2e/suite/nvidia/nvidia_test.go
@@ -1,0 +1,84 @@
+//go:build e2e
+// +build e2e
+
+package nvidia
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+
+	"github.com/aws/eks-hybrid/test/e2e"
+	"github.com/aws/eks-hybrid/test/e2e/suite"
+)
+
+var (
+	filePath    string
+	suiteConfig *suite.SuiteConfiguration
+)
+
+const numberOfNodes = 1
+
+func init() {
+	flag.StringVar(&filePath, "filepath", "", "Path to configuration")
+}
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Nvidia Test Suite")
+}
+
+// This is to test nvidia GPU function in EKS hybrid nodes. We need to use nodes with nvidia GPUs for the test.
+var _ = SynchronizedBeforeSuite(
+	func(ctx context.Context) []byte {
+		suiteConfig := suite.BeforeSuiteCredentialSetup(ctx, filePath)
+		test := suite.BeforeVPCTest(ctx, &suiteConfig)
+		credentialProviders := suite.AddClientsToCredentialProviders(suite.CredentialProviders(), test)
+		osList := suite.OSProviderList(credentialProviders)
+
+		// pick # of random OS/Version/Provider combinations for metricsServer tests worker nodes
+		nodesToCreate := make([]suite.NodeCreate, 0, numberOfNodes)
+
+		rand.Shuffle(len(osList), func(i, j int) {
+			osList[i], osList[j] = osList[j], osList[i]
+		})
+
+		for i := range numberOfNodes {
+			os := osList[i].OS
+			provider := osList[i].Provider
+			nodesToCreate = append(nodesToCreate, suite.NodeCreate{
+				OS:           os,
+				Provider:     provider,
+				InstanceName: test.InstanceName("nvidia-test", os, provider),
+				InstanceSize: e2e.Large,
+				GpuInstance:  true,
+				NodeName:     fmt.Sprintf("nvidia-node-%s-%s", provider.Name(), os.Name()),
+			})
+		}
+		suite.CreateNodes(ctx, test, nodesToCreate)
+
+		suiteJson, err := yaml.Marshal(suiteConfig)
+		Expect(err).NotTo(HaveOccurred(), "suite config should be marshalled successfully")
+		return suiteJson
+	},
+	// This function runs on all processes, and it receives the data from
+	// the first process (a json serialized struct)
+	// The only thing that we want to do here is unmarshal the data into
+	// a struct that we can make accessible from the tests. We leave the rest
+	// for the per tests setup code.
+	func(ctx context.Context, data []byte) {
+		suiteConfig = suite.BeforeSuiteCredentialUnmarshal(ctx, data)
+	},
+)
+
+var _ = Describe("Hybrid Nodes", func() {
+	When("using peered VPC", func() {
+		// TODO: Run nvidia GPU tests below
+	})
+})

--- a/test/e2e/suite/peered_vpc.go
+++ b/test/e2e/suite/peered_vpc.go
@@ -263,7 +263,7 @@ func WithLogging(loggerControl e2e.PausableLogger, serialOutputWriter io.Writer)
 	}
 }
 
-func (t *PeeredVPCTest) NewTestNode(ctx context.Context, instanceName, nodeName, k8sVersion string, os e2e.NodeadmOS, provider e2e.NodeadmCredentialsProvider, instanceSize e2e.InstanceSize, opts ...TestNodeOption) *testNode {
+func (t *PeeredVPCTest) NewTestNode(ctx context.Context, instanceName, nodeName, k8sVersion string, os e2e.NodeadmOS, provider e2e.NodeadmCredentialsProvider, instanceSize e2e.InstanceSize, gpuInstance bool, opts ...TestNodeOption) *testNode {
 	node := &testNode{
 		ArtifactsPath:   t.ArtifactsPath,
 		ClusterName:     t.Cluster.Name,
@@ -282,6 +282,7 @@ func (t *PeeredVPCTest) NewTestNode(ctx context.Context, instanceName, nodeName,
 		OS:              os,
 		Provider:        provider,
 		Region:          t.Cluster.Region,
+		GpuInstance: 	 gpuInstance,
 	}
 
 	for _, opt := range opts {
@@ -458,6 +459,7 @@ type NodeCreate struct {
 	NodeName     string
 	OS           e2e.NodeadmOS
 	Provider     e2e.NodeadmCredentialsProvider
+	GpuInstance    bool
 }
 
 func CreateNodes(ctx context.Context, test *PeeredVPCTest, nodesToCreate []NodeCreate) {
@@ -480,7 +482,7 @@ func CreateNodes(ctx context.Context, test *PeeredVPCTest, nodesToCreate []NodeC
 
 			// Create a new logger that uses our SwitchWriter
 			controlledLogger := e2e.NewPausableLogger(e2e.WithWriter(outputControl))
-			testNode := test.NewTestNode(ctx, entry.InstanceName, entry.NodeName, test.Cluster.KubernetesVersion, entry.OS, entry.Provider, entry.InstanceSize,
+			testNode := test.NewTestNode(ctx, entry.InstanceName, entry.NodeName, test.Cluster.KubernetesVersion, entry.OS, entry.Provider, entry.InstanceSize, entry.GpuInstance,
 				WithLogging(controlledLogger, outputControl))
 
 			Expect(testNode.Start(ctx)).To(Succeed(), "node should start successfully")

--- a/test/e2e/suite/test_node.go
+++ b/test/e2e/suite/test_node.go
@@ -38,6 +38,7 @@ type testNode struct {
 	LoggerControl      e2e.PausableLogger
 	Logger             logr.Logger
 	NodeName           string
+	GpuInstance        bool
 	OS                 e2e.NodeadmOS
 	PeeredNode         *peered.Node
 	Provider           e2e.NodeadmCredentialsProvider
@@ -69,6 +70,7 @@ func (n *testNode) Start(ctx context.Context) error {
 			NodeName:       n.NodeName,
 			OS:             n.OS,
 			Provider:       n.Provider,
+			GpuInstance: 	n.GpuInstance,
 		})
 		Expect(err).NotTo(HaveOccurred(), "EC2 Instance should have been created successfully")
 		flakeRun.DeferCleanup(func(ctx context.Context) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In this PR, I am setting up hybrid nodes for nvidia test. It doesn't belong to add-on test as the nodes require specialized hardware. I modified `InstanceType` func in `NodeadmOS` interface to accept `gpuInstance` flag. When this flag is set to true, it choose instance type among `g4dn.xlarge`, `g4dn.2xlarge`, `g5g.xlarge`, `g5g.2xlarge`, based on architecture and instance size.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

