### PR TITLE
Incorporate cluster name into role names to ensure uniqueness

### DIFF
--- a/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
+++ b/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
@@ -30,8 +30,9 @@ Resources:
       # use a predictable prefix for SSM role while maintaining uniqueness requirement for SSM role name
       RoleName:
         !Sub
-          - '${RolePrefix}-${TrimmedRegion}${UUID}'
+          - '${RolePrefix}-${ClusterName}-${TrimmedRegion}${UUID}'
           - RolePrefix: !Ref SSMRolePrefix
+            ClusterName: !Ref clusterName
             TrimmedRegion: !Join ['', !Split ['-', !Ref AWS::Region]]
             UUID: !Join ['', !Split ['-', !Select [2, !Split [/, !Ref AWS::StackId]]]]
       AssumeRolePolicyDocument: 
@@ -107,8 +108,9 @@ Resources:
       # use a predictable prefix for IRA role while maintaining uniqueness requirement for IRA role name
       RoleName:
         !Sub
-          - '${RolePrefix}-${TrimmedRegion}${UUID}'
+          - '${RolePrefix}-${ClusterName}-${TrimmedRegion}${UUID}'
           - RolePrefix: !Ref IRARolePrefix
+            ClusterName: !Ref clusterName
             TrimmedRegion: !Join ['', !Split ['-', !Ref AWS::Region]]
             UUID: !Join ['', !Split ['-', !Select [2, !Split [/, !Ref AWS::StackId]]]]
       ManagedPolicyArns:
@@ -161,8 +163,9 @@ Resources:
       # use a predictable prefix for EC2 role while maintaining uniqueness requirement for EC2 role name
       RoleName:
         !Sub
-          - '${RolePrefix}-${TrimmedRegion}${UUID}'
+          - '${RolePrefix}-${ClusterName}-${TrimmedRegion}${UUID}'
           - RolePrefix: !Ref EC2RolePrefix
+            ClusterName: !Ref clusterName
             TrimmedRegion: !Join ['', !Split ['-', !Ref AWS::Region]]
             UUID: !Join ['', !Split ['-', !Select [2, !Split [/, !Ref AWS::StackId]]]]
       AssumeRolePolicyDocument:


### PR DESCRIPTION
*Description of changes:*
While running multiple e2e tests at the same time, there are certain time although fairly minimal, where stacks for 2 different cluster versions get deployed at the exact same time. This ends up resulting in the both stacks with the same UUID. This ends up in a race where one stack's roles fail to create as the exact role name exists on another stack. The cluster name here houses the EKS/k8s version which will ensure uniqueness to the role name generation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

