### PR TITLE
uses proxy environment for connection to host test

### DIFF
--- a/internal/kubernetes/unauthenticated.go
+++ b/internal/kubernetes/unauthenticated.go
@@ -24,12 +24,13 @@ func MakeUnauthenticatedRequest(ctx context.Context, endpoint string, caCertific
 		)
 	}
 
+	// ensure proxy configuration is inherited from the default transport
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = &tls.Config{
+		RootCAs: caCertPool,
+	}
 	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: caCertPool,
-			},
-		},
+		Transport: tr,
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)

--- a/internal/network/connection.go
+++ b/internal/network/connection.go
@@ -1,30 +1,105 @@
 package network
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"time"
+
+	"golang.org/x/net/http/httpproxy"
 )
 
 const dialTimeout = 5 * time.Second
 
+type ConnectionOptions struct {
+	// ProxyFunc determines which proxy to use for a given request.
+	// If nil, uses httpproxy.FromEnvironment().ProxyFunc()
+	ProxyFunc func(*url.URL) (*url.URL, error)
+}
+
+type ConnectionOption func(*ConnectionOptions)
+
+// this is overridable mainly for testing purposes to avoid using environment variables
+// to manipulate the proxy environment and because the default ProxyFunc always skips the proxy
+// for localhost/loopback addresses, it does not require that they be listed in the NO_PROXY
+// environment variable. This makes testing difficult since we would need to manipulate the dns resolution
+// on the test machine (ex: modify /etc/hosts).
+func WithProxyFunc(f func(*url.URL) (*url.URL, error)) ConnectionOption {
+	return func(o *ConnectionOptions) {
+		o.ProxyFunc = f
+	}
+}
+
 // CheckConnectionToHost checks if a connection can be established to the host
 // specified in the URL.
-func CheckConnectionToHost(ctx context.Context, url url.URL) error {
-	port := url.Port()
-	if port == "" && url.Scheme == "https" {
+func CheckConnectionToHost(ctx context.Context, targetURL url.URL, opts ...ConnectionOption) error {
+	// Use default proxy function if none provided
+	options := &ConnectionOptions{
+		ProxyFunc: httpproxy.FromEnvironment().ProxyFunc(),
+	}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	port := targetURL.Port()
+	if port == "" && targetURL.Scheme == "https" {
 		port = "443"
 	}
 
-	host := fmt.Sprintf("%s:%s", url.Hostname(), port)
+	target := fmt.Sprintf("%s:%s", targetURL.Hostname(), port)
+
+	proxyURL, err := options.ProxyFunc(&targetURL)
+	if err != nil {
+		return fmt.Errorf("getting proxy URL: %w", err)
+	}
+
+	host := target
+	if proxyURL != nil {
+		host = proxyURL.Host
+	}
 
 	conn, err := net.DialTimeout("tcp", host, dialTimeout)
 	if err != nil {
 		return fmt.Errorf("dialing %s: %w", host, err)
 	}
 	defer conn.Close()
+
+	if proxyURL == nil {
+		return nil
+	}
+
+	// The CONNECT method requests that the recipient establish a tunnel to
+	// the destination origin server identified by the request-target and,
+	// if successful, thereafter restrict its behavior to blind forwarding
+	// of packets, in both directions, until the tunnel is closed.
+	//
+	// https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.6
+	req := &http.Request{
+		Method: "CONNECT",
+		URL:    &url.URL{Host: target},
+		Host:   target,
+		Header: make(http.Header),
+	}
+
+	if err := req.Write(conn); err != nil {
+		return fmt.Errorf("proxy: writing CONNECT request: %w", err)
+	}
+
+	// this will not be a typical HTTP response/body, but a tunnel response
+	// this is before any tls negotiation, only the tunnel to the target is established
+	// ex: HTTP/1.1 200 Connection Established
+	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+	if err != nil {
+		return fmt.Errorf("proxy: reading CONNECT response: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("proxy: returned status: %d", resp.StatusCode)
+	}
 
 	return nil
 }

--- a/internal/network/connection_test.go
+++ b/internal/network/connection_test.go
@@ -1,0 +1,223 @@
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-hybrid/internal/network"
+	"github.com/aws/eks-hybrid/internal/test"
+)
+
+type serverFunc func(*testing.T) (net.Listener, string)
+
+type proxyBehavior int
+
+const (
+	proxyBehaviorSuccess proxyBehavior = iota
+	proxyBehaviorBadGateway
+	proxyBehaviorNoResponse
+	proxyBehaviorBadStatus
+)
+
+// mockProxyServer creates a test proxy server that handles CONNECT requests and forwards to target
+func mockProxyServer(t *testing.T, targetHost string, behavior proxyBehavior) (net.Listener, string) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	proxy := test.NewHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.Method).To(Equal(http.MethodConnect), "expected CONNECT request")
+
+		// Hijack the connection to establish the tunnel
+		hijacker, ok := w.(http.Hijacker)
+		g.Expect(ok).To(BeTrue(), "webserver doesn't support hijacking")
+
+		clientConn, _, err := hijacker.Hijack()
+		g.Expect(err).NotTo(HaveOccurred(), "hijacking failed")
+		defer clientConn.Close()
+
+		switch behavior {
+		case proxyBehaviorBadStatus:
+			// Return a non-200 status
+			_, err := clientConn.Write([]byte("HTTP/1.1 403 Forbidden\r\n\r\n"))
+			g.Expect(err).NotTo(HaveOccurred(), "writing response failed")
+			return
+		case proxyBehaviorNoResponse:
+			// Don't write any response, just close
+			return
+		case proxyBehaviorBadGateway:
+			// Return 502 to simulate proxy returning a bad gateway error
+			_, err := clientConn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
+			g.Expect(err).NotTo(HaveOccurred(), "writing response failed")
+			return
+		}
+
+		// Forward the connection to the target
+		targetConn, err := net.Dial("tcp", targetHost)
+		if err != nil {
+			_, err := clientConn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
+			g.Expect(err).NotTo(HaveOccurred(), "writing response failed")
+			return
+		}
+		defer targetConn.Close()
+
+		// Send 200 Connection Established
+		_, err = clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+		g.Expect(err).NotTo(HaveOccurred(), "writing response failed")
+	})
+
+	proxyURL, err := url.Parse(proxy.URL)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to parse proxy URL")
+
+	return proxy.Listener, proxyURL.Host
+}
+
+// mockTargetServer creates a test server that accepts and immediately closes connections
+func mockTargetServer(t *testing.T) (net.Listener, string) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create listener")
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// Accept and immediately close the connection
+			conn.Close()
+		}
+	}()
+
+	return listener, listener.Addr().String()
+}
+
+// mockMisbehavingTargetServer creates a test server that does not respond to the connection
+func mockMisbehavingTargetServer(t *testing.T) (net.Listener, string) {
+	t.Helper()
+	g := NewGomegaWithT(t)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create listener")
+	// immediately close the listener to simulate a misbehaving target server
+	listener.Close()
+
+	return listener, listener.Addr().String()
+}
+
+func TestCheckConnectionToHost(t *testing.T) {
+	tests := []struct {
+		name           string
+		useProxy       bool
+		targetServer   serverFunc
+		proxyBehavior  proxyBehavior
+		proxyShouldErr bool
+		wantErr        string
+	}{
+		{
+			name:         "successful direct connection",
+			useProxy:     false,
+			targetServer: mockTargetServer,
+		},
+		{
+			name:          "successful proxy connection",
+			useProxy:      true,
+			targetServer:  mockTargetServer,
+			proxyBehavior: proxyBehaviorSuccess,
+		},
+		{
+			name:           "proxy connection failure - invalid URL",
+			useProxy:       true,
+			targetServer:   mockTargetServer,
+			proxyShouldErr: true,
+			wantErr:        "dialing invalid-proxy:8080",
+		},
+		{
+			name:          "proxy connection failure - bad gateway",
+			useProxy:      true,
+			targetServer:  mockMisbehavingTargetServer,
+			proxyBehavior: proxyBehaviorBadGateway,
+			wantErr:       "proxy: returned status: 502",
+		},
+		{
+			name:          "proxy connection failure - forbidden",
+			useProxy:      true,
+			targetServer:  mockTargetServer,
+			proxyBehavior: proxyBehaviorBadStatus,
+			wantErr:       "proxy: returned status: 403",
+		},
+		{
+			name:          "proxy connection failure - no response",
+			useProxy:      true,
+			targetServer:  mockTargetServer,
+			proxyBehavior: proxyBehaviorNoResponse,
+			wantErr:       "proxy: reading CONNECT response",
+		},
+		{
+			name:         "target connection failure direct",
+			useProxy:     false,
+			targetServer: mockMisbehavingTargetServer,
+			wantErr:      "dialing",
+		},
+		{
+			name:           "proxy function error",
+			useProxy:       true,
+			targetServer:   mockTargetServer,
+			proxyShouldErr: true,
+			wantErr:        "getting proxy URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			// Always set up the target server
+			targetServer, targetHost := tt.targetServer(t)
+			defer targetServer.Close()
+
+			// Set up proxy if needed
+			var opts []network.ConnectionOption
+			if tt.useProxy {
+				proxyServer, proxyHost := mockProxyServer(t, targetHost, tt.proxyBehavior)
+				defer proxyServer.Close()
+				if tt.proxyShouldErr {
+					// Return an invalid proxy URL or error
+					opts = append(opts, network.WithProxyFunc(func(*url.URL) (*url.URL, error) {
+						if tt.wantErr == "getting proxy URL" {
+							return nil, fmt.Errorf("proxy function error")
+						}
+						return &url.URL{Host: "invalid-proxy:8080"}, nil
+					}))
+				} else {
+					// Return our test proxy URL
+					opts = append(opts, network.WithProxyFunc(func(*url.URL) (*url.URL, error) {
+						return &url.URL{
+							Scheme: "http",
+							Host:   proxyHost,
+						}, nil
+					}))
+				}
+			}
+
+			targetURL := url.URL{
+				Scheme: "https",
+				Host:   targetHost,
+			}
+
+			err := network.CheckConnectionToHost(context.Background(), targetURL, opts...)
+			if tt.wantErr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently during the debug flow, and soon during init, the code which attempts to verify if a host is reachable/connectable is not proxy aware.  We use the `net.Dialer` to try and open a tcp connection then immediately close it.  In the case that the environment requires a proxy for internet access, ex: ssm/iam-ra endpoints, this will fail.

This modifies this check to be proxy aware.  If the url is configured, by the user, to require a proxy, a CONNECT request is made to the proxy with the host as the target url. This will initiate the tunnel thru the proxy to the target. If this succeeds, we immediately close the tunnel and mark the check as success. If this fails, it is assumed the target url is not reachable.

I am working on changes to the e2e stack to support running tests/creating nodes which require a proxy. This will come in a future PR, but that is what I am using to confirm the current and new behavior.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

