### PR TITLE
adds support to e2e framework to create nodes requiring proxy

### DIFF
--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -334,6 +334,69 @@ Resources:
                   - "|"
                   - !Ref PortWithDescription
 
+  HybridNodeDefaultSecurityGroupIngressFromProxyOnly:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt HybridNodeVPC.DefaultSecurityGroup
+      IpProtocol: tcp
+      FromPort: 3128
+      ToPort: 3128
+      SourceSecurityGroupId: !Ref HybridNodeProxyOnlySecurityGroup
+
+  HybridNodeProxyOnlySecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for hybrid nodes that only allows traffic through the proxy
+      VpcId: !Ref HybridNodeVPC
+      SecurityGroupIngress:
+        - IpProtocol: -1
+          FromPort: -1
+          ToPort: -1
+          SourceSecurityGroupId: !GetAtt HybridNodeVPC.DefaultSecurityGroup
+      Tags:
+        - Key: Name
+          Value: !Sub ${ClusterName}-hybrid-node-proxy-sg
+        - Key: !Ref TestClusterTagKey
+          Value: !Ref ClusterName
+        - Key: !Ref CreationTimeTagKey
+          Value: !Ref CreationTime
+
+  HybridNodeProxyOnlySecurityGroupIngress10250:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref HybridNodeProxyOnlySecurityGroup
+      IpProtocol: tcp
+      FromPort: 10250
+      ToPort: 10250
+      CidrIp: !Ref ClusterVPCCidr
+
+  HybridNodeProxyOnlySecurityGroupIngress9443:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref HybridNodeProxyOnlySecurityGroup
+      IpProtocol: tcp
+      FromPort: 9443
+      ToPort: 9443
+      CidrIp: !Ref ClusterVPCCidr
+
+  HybridNodeProxyOnlySecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref HybridNodeProxyOnlySecurityGroup
+      IpProtocol: tcp
+      FromPort: 3128
+      ToPort: 3128
+      DestinationSecurityGroupId: !GetAtt HybridNodeVPC.DefaultSecurityGroup
+
+  HybridNodeProxyOnlySecurityGroupEgressToCluster:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref HybridNodeProxyOnlySecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIp: !Ref ClusterVPCCidr
+
   ClusterToHybridTGW:
     Type: AWS::EC2::TransitGateway
     Properties:
@@ -536,8 +599,10 @@ Resources:
         Fn::Base64:
           Fn::Base64: !Sub |
             #cloud-config
+            package_update: true
             packages:
               - rsyslog
+              - squid
             write_files:
               - content: |
                   Host *
@@ -562,6 +627,10 @@ Resources:
                 permissions: "0755"
             runcmd:
               - systemctl enable rsyslog --now
+              - systemctl enable squid
+              - sed -i 's/http_access deny all/http_access allow all/' /etc/squid/squid.conf
+              - echo 'acl allow_my_ip src ${HybridNodeVPCCidr}' | tee -a /etc/squid/squid.conf
+              - systemctl start squid
               - cfn-signal --stack ${AWS::StackName} --resource Jumpbox --region ${AWS::Region}
 
   PodIdentityS3Bucket:
@@ -630,6 +699,10 @@ Outputs:
   ClusterSecurityGroup:
     Description: The ID of the EKS Hybrid Cluster Security Group.
     Value: !GetAtt ClusterVPC.DefaultSecurityGroup
+
+  HybridNodeProxyOnlySecurityGroup:
+    Description: The ID of the security group for hybrid nodes with proxy-only internet access.
+    Value: !Ref HybridNodeProxyOnlySecurityGroup
 
   PodIdentityAssociationRoleARN:
     Description: The role ARN of PodIdentityAssociationRole

--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -50,6 +50,7 @@ type UserDataInput struct {
 	HostName            string
 	ClusterName         string
 	ClusterCert         []byte
+	Proxy               string
 }
 
 type NodeadmURLs struct {

--- a/test/e2e/os/amazonlinux.go
+++ b/test/e2e/os/amazonlinux.go
@@ -13,6 +13,10 @@ import (
 //go:embed testdata/amazonlinux/2023/cloud-init.txt
 var al23CloudInit []byte
 
+const (
+	alSSMAgentProxyPath = "/etc/systemd/system/amazon-ssm-agent.service.d/http-proxy.conf"
+)
+
 type amazonLinuxCloudInitData struct {
 	e2e.UserDataInput
 	NodeadmUrl string
@@ -58,6 +62,10 @@ func (a AmazonLinux2023) BuildUserData(userDataInput e2e.UserDataInput) ([]byte,
 	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
 
 	if err := populateBaseScripts(&userDataInput); err != nil {
+		return nil, err
+	}
+
+	if err := addSystemdProxyConfig(&userDataInput, alSSMAgentProxyPath); err != nil {
 		return nil, err
 	}
 

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -15,7 +15,10 @@ import (
 	"github.com/aws/eks-hybrid/test/e2e"
 )
 
-const rhelAWSAccount = "309956199498"
+const (
+	rhelAWSAccount        = "309956199498"
+	rhelSSMAgentProxyPath = "/etc/systemd/system/amazon-ssm-agent.service.d/http-proxy.conf"
+)
 
 //go:embed testdata/rhel/8/cloud-init.txt
 var rhel8CloudInit []byte
@@ -85,6 +88,10 @@ func (r RedHat8) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) 
 	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
 
 	if err := populateBaseScripts(&userDataInput); err != nil {
+		return nil, err
+	}
+
+	if err := addSystemdProxyConfig(&userDataInput, rhelSSMAgentProxyPath); err != nil {
 		return nil, err
 	}
 
@@ -164,6 +171,10 @@ func (r RedHat9) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, error) 
 	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
 
 	if err := populateBaseScripts(&userDataInput); err != nil {
+		return nil, err
+	}
+
+	if err := addSystemdProxyConfig(&userDataInput, rhelSSMAgentProxyPath); err != nil {
 		return nil, err
 	}
 

--- a/test/e2e/os/testdata/amazonlinux/2023/cloud-init.txt
+++ b/test/e2e/os/testdata/amazonlinux/2023/cloud-init.txt
@@ -14,6 +14,12 @@ write_files:
   - content: |
 {{ .NodeadmConfigYaml | indent 6 }}
     path: nodeadm-config.yaml
+{{- if .Proxy }}
+  - content: |
+        proxy={{ .Proxy }}
+    path: /etc/dnf/dnf.conf
+    append: true
+{{- end }}
 {{ range $file := .Files }}
   - content: |
 {{ $file.Content | indent 6 }}

--- a/test/e2e/os/testdata/bottlerocket/settings.toml
+++ b/test/e2e/os/testdata/bottlerocket/settings.toml
@@ -12,6 +12,9 @@ provider-id = "eks-hybrid:///{{ .Region }}/{{ .ClusterName }}/{{ .HostName }}"
 
 [settings.network]
 hostname = "{{ .HostName }}"
+{{- if .Proxy }}
+https-proxy = "{{ .Proxy }}"
+{{- end }}
 
 [settings.aws]
 region = "{{ .Region }}"

--- a/test/e2e/os/testdata/install-containerd.sh
+++ b/test/e2e/os/testdata/install-containerd.sh
@@ -4,28 +4,49 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source /etc/proxy-vars.sh
+
 if command -v apt-get >/dev/null 2>&1; then
+    # we are installing the key and setting up the docker repo here
+    # instead in the cloud-init template because (i think) cloud-init is using
+    # apt-key which does not seem to be proxy aware and/or the proxy config set
+    # in the cloud-init template is not taking affect before it attempts to
+    # install the key and setup the repo
+    # https://docs.docker.com/engine/install/ubuntu/
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+
+    echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+        $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+        tee /etc/apt/sources.list.d/docker.list > /dev/null
+
     CMD="apt-get -o DPkg::Lock::Timeout=60"
+    UPDATE_SUBCMD="update"
     LOCK_FILE="/var/lib/dpkg/lock-frontend"
     PACKAGE="containerd.io=1.*"
 else
     CMD="yum"
+    UPDATE_SUBCMD="makecache"
     LOCK_FILE="/var/lib/rpm/.rpm.lock"
     PACKAGE="containerd.io-1.*"
 fi
 
-ATTEMPTS=5
-while ! $CMD install -y $PACKAGE ; do
-    echo "$CMD failed to install $PACKAGE"
+for subcmd in $UPDATE_SUBCMD "install -y $PACKAGE"; do
+    ATTEMPTS=5
+    while ! $CMD $subcmd ; do
+        echo "$CMD failed to $subcmd"
     
-    # attempt to wait for any in progress apt-get/yum operations to complete
-    while find /proc/*/fd -ls | grep $LOCK_FILE >/dev/null 2>&1; do
-        echo "waiting for process with lock on $LOCK_FILE to complete"
-        sleep 1
-    done
+        # attempt to wait for any in progress apt-get/yum operations to complete
+        while find /proc/*/fd -ls | grep $LOCK_FILE >/dev/null 2>&1; do
+            echo "waiting for process with lock on $LOCK_FILE to complete"
+            sleep 1
+        done
 
-    ((ATTEMPTS--)) || break
-    sleep 5
+        ((ATTEMPTS--)) || break
+        sleep 5
+    done
 done
 
 if ! command -v ctr >/dev/null 2>&1; then 

--- a/test/e2e/os/testdata/log-collector.sh
+++ b/test/e2e/os/testdata/log-collector.sh
@@ -4,6 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source /etc/proxy-vars.sh
+
 # first arg is the url to upload the logs to
 LOGS_UPLOAD_URL="$1"
 # remaining args are the additional folders/files to add to the bundle

--- a/test/e2e/os/testdata/nodeadm-init.sh
+++ b/test/e2e/os/testdata/nodeadm-init.sh
@@ -10,6 +10,8 @@ PROVDER="$3"
 REGION="$4"
 NODEADM_ADDITIONAL_ARGS="${5-}"
 
+source /etc/proxy-vars.sh
+
 # nodeadmin uninstall does not remove this folder, which contains the cilium/calico config
 # which kubelet uses to determine if a node is "Ready"
 # if we do not remove this folder, the node will flip to ready on re-join immediately

--- a/test/e2e/os/testdata/nodeadm-wrapper.sh
+++ b/test/e2e/os/testdata/nodeadm-wrapper.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+source /etc/proxy-vars.sh
 AWS_ENDPOINT_URL_EKS={{ .EKSEndpoint }} /usr/local/bin/nodeadm "$@"

--- a/test/e2e/os/testdata/proxy/proxy-vars.sh
+++ b/test/e2e/os/testdata/proxy/proxy-vars.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Return early if no proxy is set
+if [ -z "{{ .Proxy }}" ]; then
+    return 0
+fi
+
+# Set proxy environment variables
+export HTTP_PROXY={{ .Proxy }}
+export HTTPS_PROXY={{ .Proxy }}
+export NO_PROXY=localhost 

--- a/test/e2e/os/testdata/proxy/systemd-proxy.conf
+++ b/test/e2e/os/testdata/proxy/systemd-proxy.conf
@@ -1,0 +1,4 @@
+[Service]
+Environment="HTTP_PROXY={{ .Proxy }}"
+Environment="HTTPS_PROXY={{ .Proxy }}"
+Environment="NO_PROXY=localhost" 

--- a/test/e2e/os/testdata/rhel/8/cloud-init.txt
+++ b/test/e2e/os/testdata/rhel/8/cloud-init.txt
@@ -15,6 +15,12 @@ write_files:
   - content: |
 {{ .NodeadmConfigYaml | indent 6 }}
     path: nodeadm-config.yaml
+{{- if .Proxy }}
+  - content: |      
+      proxy={{ .Proxy }}
+    path: /etc/yum.conf
+    append: true
+{{- end }}
 {{ range $file := .Files }}
   - content: |
 {{ $file.Content | indent 6 }}

--- a/test/e2e/os/testdata/rhel/9/cloud-init.txt
+++ b/test/e2e/os/testdata/rhel/9/cloud-init.txt
@@ -23,6 +23,12 @@ write_files:
   - content: |
 {{ .NodeadmConfigYaml | indent 6 }}
     path: nodeadm-config.yaml
+{{- if .Proxy }}
+  - content: |      
+      proxy={{ .Proxy }}
+    path: /etc/yum.conf
+    append: true
+{{- end }}
 {{ range $file := .Files }}
   - content: |
 {{ $file.Content | indent 6 }}

--- a/test/e2e/os/testdata/ubuntu/2004/cloud-init.txt
+++ b/test/e2e/os/testdata/ubuntu/2004/cloud-init.txt
@@ -8,6 +8,15 @@ users:
     hashed_passwd: {{ .RootPasswordHash }}
 {{- end }}
 package_update: true
+{{- if .Proxy }}
+apt:
+  http_proxy: {{ .Proxy }}
+  https_proxy: {{ .Proxy }}
+snap:
+  commands:
+      00: snap set system proxy.http={{ .Proxy }}
+      01: snap set system proxy.https={{ .Proxy }}
+{{- end}}
 write_files:
   - content: |
 {{ .NodeadmConfigYaml | indent 6 }}

--- a/test/e2e/os/testdata/ubuntu/2204/cloud-init.txt
+++ b/test/e2e/os/testdata/ubuntu/2204/cloud-init.txt
@@ -8,6 +8,15 @@ users:
     hashed_passwd: {{ .RootPasswordHash }}
 {{- end }}
 package_update: true
+{{- if .Proxy }}
+apt:
+  http_proxy: {{ .Proxy }}
+  https_proxy: {{ .Proxy }}
+snap:
+  commands:
+      00: snap set system proxy.http={{ .Proxy }}
+      01: snap set system proxy.https={{ .Proxy }}
+{{- end}}
 write_files:
   - content: |
 {{ .NodeadmConfigYaml | indent 6 }}

--- a/test/e2e/os/testdata/ubuntu/2404/cloud-init.txt
+++ b/test/e2e/os/testdata/ubuntu/2404/cloud-init.txt
@@ -7,14 +7,16 @@ users:
 {{- if .RootPasswordHash }}
     hashed_passwd: {{ .RootPasswordHash }}
 {{- end }}
-{{- if .PreinstallContainerd }}
-apt:
-  sources:
-    docker.list:
-      source: deb [arch=amd64] https://download.docker.com/linux/ubuntu $RELEASE stable
-      keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
-{{- end }}
 package_update: true
+{{- if .Proxy }}
+apt:
+  http_proxy: {{ .Proxy }}
+  https_proxy: {{ .Proxy }}
+snap:
+  commands:
+      00: snap set system proxy.http={{ .Proxy }}
+      01: snap set system proxy.https={{ .Proxy }}
+{{- end}}
 write_files:
   - content: |
 {{ .NodeadmConfigYaml | indent 6 }}

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -20,6 +20,10 @@ var ubuntu2204CloudInit []byte
 //go:embed testdata/ubuntu/2404/cloud-init.txt
 var ubuntu2404CloudInit []byte
 
+const (
+	ubuntuSSMAgentProxyPath = "/etc/systemd/system/snap.amazon-ssm-agent.amazon-ssm-agent.service.d/http-proxy.conf"
+)
+
 type ubuntuCloudInitData struct {
 	e2e.UserDataInput
 	NodeadmUrl            string
@@ -95,6 +99,10 @@ func (u Ubuntu2004) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, erro
 		return nil, err
 	}
 
+	if err := addSystemdProxyConfig(&userDataInput, ubuntuSSMAgentProxyPath); err != nil {
+		return nil, err
+	}
+
 	data := ubuntuCloudInitData{
 		UserDataInput: userDataInput,
 		NodeadmUrl:    userDataInput.NodeadmUrls.AMD,
@@ -166,6 +174,10 @@ func (u Ubuntu2204) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, erro
 	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
 
 	if err := populateBaseScripts(&userDataInput); err != nil {
+		return nil, err
+	}
+
+	if err := addSystemdProxyConfig(&userDataInput, ubuntuSSMAgentProxyPath); err != nil {
 		return nil, err
 	}
 
@@ -251,6 +263,10 @@ func (u Ubuntu2404) BuildUserData(userDataInput e2e.UserDataInput) ([]byte, erro
 	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
 
 	if err := populateBaseScripts(&userDataInput); err != nil {
+		return nil, err
+	}
+
+	if err := addSystemdProxyConfig(&userDataInput, ubuntuSSMAgentProxyPath); err != nil {
 		return nil, err
 	}
 

--- a/test/e2e/peered/setup.go
+++ b/test/e2e/peered/setup.go
@@ -13,8 +13,12 @@ import (
 // Infrastructure represents the necessary infrastructure for peered VPCs to be used by nodeadm.
 type Infrastructure struct {
 	Credentials       credentials.Infrastructure
-	JumpboxInstanceId string
+	Jumpbox           Jumpbox
 	NodesPublicSSHKey string
+}
+type Jumpbox struct {
+	Id string
+	IP string
 }
 
 // Setup creates the necessary infrastructure for credentials providers to be used by nodeadm.
@@ -37,8 +41,11 @@ func Setup(ctx context.Context, logger logr.Logger, config aws.Config, clusterNa
 	}
 
 	return &Infrastructure{
-		Credentials:       *credsInfra,
-		JumpboxInstanceId: *jumpbox.InstanceId,
+		Credentials: *credsInfra,
+		Jumpbox: Jumpbox{
+			Id: *jumpbox.InstanceId,
+			IP: *jumpbox.PrivateIpAddress,
+		},
 		NodesPublicSSHKey: *keypair.PublicKey,
 	}, nil
 }

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -16,7 +16,7 @@ type AddonEc2Test struct {
 
 // NewNodeMonitoringAgentTest creates a new NodeMonitoringAgentTest
 func (a *AddonEc2Test) NewNodeMonitoringAgentTest() *addon.NodeMonitoringAgentTest {
-	commandRunner := ssm.NewStandardLinuxSSHOnSSMCommandRunner(a.SSMClient, a.JumpboxInstanceId, a.Logger)
+	commandRunner := ssm.NewStandardLinuxSSHOnSSMCommandRunner(a.SSMClient, a.Jumpbox.Id, a.Logger)
 	return &addon.NodeMonitoringAgentTest{
 		Cluster:       a.Cluster.Name,
 		K8S:           a.k8sClient,
@@ -82,7 +82,7 @@ func (a *AddonEc2Test) NewPrometheusNodeExporterTest() *addon.PrometheusNodeExpo
 
 // NewNvidiaDevicePluginTest creates a new NvidiaDevicePluginTest
 func (a *AddonEc2Test) NewNvidiaDevicePluginTest(nodeName string) *addon.NvidiaDevicePluginTest {
-	commandRunner := ssm.NewStandardLinuxSSHOnSSMCommandRunner(a.SSMClient, a.JumpboxInstanceId, a.Logger)
+	commandRunner := ssm.NewStandardLinuxSSHOnSSMCommandRunner(a.SSMClient, a.Jumpbox.Id, a.Logger)
 	return &addon.NvidiaDevicePluginTest{
 		Cluster:       a.Cluster.Name,
 		K8S:           a.k8sClient,

--- a/test/e2e/suite/nodeadm/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm/nodeadm_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Hybrid Nodes", func() {
 						k8sVersion = test.OverrideNodeK8sVersion
 					}
 
-					remoteCommandRunner := ssm.NewBottlerocketSSHOnSSMCommandRunner(test.SSMClient, test.JumpboxInstanceId, test.Logger)
+					remoteCommandRunner := ssm.NewBottlerocketSSHOnSSMCommandRunner(test.SSMClient, test.Jumpbox.Id, test.Logger)
 					logCollector := os.BottlerocketLogCollector{
 						Runner: remoteCommandRunner,
 					}


### PR DESCRIPTION
## Description of changes

This PR adds support for creating nodes requiring proxy in the E2E framework, implementing the proxy configuration requirements as documented in the [AWS EKS hybrid nodes proxy documentation](https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-proxy.html).

### Key changes
- Implemented proxy configuration for container runtime operations
- Added proxy environment variable handling for:
  - Package manager operations (apt/yum)
  - Container runtime operations
  - System-level proxy settings
- Added proxy support for package manager operations (apt/yum) during node creation
- Added squid to the jumpbox instance to be used as the http_proxy
- Added new ProxyOnly sg for nodes we want to test with limited internet access. The CP cidr is allowed along with the jumpboxinstance.  I intend to update the docs to call out that we strongly recommend that nodes have direct access/routability to the CP private IPs otherwise a number of deployments (ex: cilium) will need the proxy config.  In a public/private cluster, in general kube-proxy running on-prem is going to resolve the kube api endpoint as the public IPs.  It is then going to connect via these public IPs to get the Services to then create the iptable rules.  I want to call this out in the docs as well.  These iptable rules will point to the private IPs of the CP instances and as long as the node has access to these without the need of the proxy, then other deployments do not need the proxy configuration.
- pod identity is a good example of a deployment that will need to proxy config since it is access the AWS api, so would any pods which consume the pod identity metadata endpoint.  pod identity is also unique in that it listens on the metadata like endpoint and expects that not to go thru the proxy, so this needs to be set in the NO_PROXY

### Testing
- Added E2E tests for proxy-enabled node creation scenarios
- Verified package manager operations with proxy settings for both apt and yum-based systems
- Tested container runtime operations through proxy
- Validated on supported operating systems
- 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

