### PR TITLE
adds content-diposition to nodeadm.gz

### DIFF
--- a/buildspecs/test-nodeadm.yml
+++ b/buildspecs/test-nodeadm.yml
@@ -16,8 +16,8 @@ phases:
     commands:
       # Upload binaries to versioned paths
       - echo "Uploading binaries for e2e tests..."
-      - aws s3 cp --no-progress --content-encoding gzip _bin/amd64/nodeadm.gz s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/amd64/nodeadm.gz
-      - aws s3 cp --no-progress --content-encoding gzip _bin/arm64/nodeadm.gz s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/arm64/nodeadm.gz
+      - aws s3 cp --no-progress --content-encoding gzip --content-disposition "attachment; filename=\"nodeadm\"" _bin/amd64/nodeadm.gz s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/amd64/nodeadm.gz
+      - aws s3 cp --no-progress --content-encoding gzip --content-disposition "attachment; filename=\"nodeadm\"" _bin/arm64/nodeadm.gz s3://$ARTIFACTS_BUCKET/test-release/${VERSION}/bin/linux/arm64/nodeadm.gz
       
       # Run the e2e tests with versioned paths
       - SANITIZED_CODEBUILD_BUILD_ID=$(echo $CODEBUILD_BUILD_ID | tr ':' '-')

--- a/hack/release-nodeadm.sh
+++ b/hack/release-nodeadm.sh
@@ -18,7 +18,8 @@ echo "Starting nodeadm release process..."
 # Upload to production
 echo "Uploading artifacts to production..."
 aws s3 sync --no-progress --exclude "*nodeadm.gz" latest/ s3://${PROD_BUCKET}/releases/${VERSION}/ ${PUBLIC_READ_ACL_ARG}
-aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip latest/ s3://${PROD_BUCKET}/releases/${VERSION}/ ${PUBLIC_READ_ACL_ARG}
+# uploading nodeadm.gz files separately to ensure the content-encoding/disposition is applied
+aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip --content-disposition "attachment; filename=\"nodeadm\"" latest/ s3://${PROD_BUCKET}/releases/${VERSION}/ ${PUBLIC_READ_ACL_ARG}
 
 # Update latest symlinks
 echo "Updating latest symlinks for nodeadm..."

--- a/hack/upload-dev-release-artifacts.sh
+++ b/hack/upload-dev-release-artifacts.sh
@@ -17,6 +17,6 @@ cp _bin/{ATTRIBUTION.txt,GIT_VERSION} _bin/latest/
 cp _bin/amd64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/linux/amd64/
 cp _bin/arm64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/linux/arm64/
 
-# uploading nodeadm.gz files separately to ensure the content-encoding is applied
+# uploading nodeadm.gz files separately to ensure the content-encoding/disposition is applied
 aws s3 sync --no-progress --exclude "*nodeadm.gz" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/ ${PUBLIC_READ_ACL_ARG}
-aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/ ${PUBLIC_READ_ACL_ARG}
+aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip --content-disposition "attachment; filename=\"nodeadm\"" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/ ${PUBLIC_READ_ACL_ARG}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding this header, cf will return it when it serves out the file so that if we add this link to our docs and customer clicks the link from their browser, it will download and extract the file and name it `nodeadm` instead of `nodeadm.gz`. In the case of curl usage, which I expect to be the primary use case, they will either need to continue to use the `-o nodeadm` flag, or they could use `-J` which tells curl to respect the disposition header when creating the file with `-O`

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

