### PR TITLE
fixes iam-ra update service when used with proxies

### DIFF
--- a/internal/iamrolesanywhere/aws_config.go
+++ b/internal/iamrolesanywhere/aws_config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path"
 	"text/template"
+
+	"golang.org/x/net/http/httpproxy"
 )
 
 const (
@@ -64,7 +66,8 @@ func WriteAWSConfig(cfg AWSConfig) error {
 		cfg.ConfigPath = DefaultAWSConfigPath
 	}
 
-	if httpProxy, httpsProxy := os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"); httpProxy != "" || httpsProxy != "" {
+	proxyEnv := httpproxy.FromEnvironment()
+	if proxyEnv.HTTPProxy != "" || proxyEnv.HTTPSProxy != "" {
 		cfg.ProxyEnabled = true
 	}
 

--- a/internal/iamrolesanywhere/aws_signing_helper_update_service.tpl
+++ b/internal/iamrolesanywhere/aws_signing_helper_update_service.tpl
@@ -11,7 +11,7 @@ ExecStart={{ .SigningHelperBinPath }} update \
         --profile-arn {{ .ProfileARN }} \
         --role-arn {{ .RoleARN }} \
         --role-session-name {{ .NodeName }} \
-        --region {{ .Region }}
+        --region {{ .Region }}{{ if .ProxyEnabled }} --with-proxy{{end}}
 StandardOutput=journal
 StandardError=journal
 Restart=always

--- a/internal/iamrolesanywhere/testdata/expected-systemd-service-unit-with-proxy
+++ b/internal/iamrolesanywhere/testdata/expected-systemd-service-unit-with-proxy
@@ -1,0 +1,23 @@
+[Unit]
+Description=Service that runs aws_signing_helper update to keep the AWS credentials refreshed in /eks-hybrid/.aws/credentials.
+
+[Service]
+User=root
+Environment=AWS_SHARED_CREDENTIALS_FILE=/eks-hybrid/.aws/credentials
+ExecStart=/usr/local/bin/aws_signing_helper update \
+        --certificate /etc/certificates/iam/pki/my-server.crt \
+        --private-key /etc/certificates/iam/pki/my-server.key \
+        --trust-anchor-arn arn:aws:acm-pca:us-west-2:123456789010:certificate-authority/fc32b514-4aca-4a4b-91a5-602294a6f4b7 \
+        --profile-arn arn:aws:iam::123456789010:instance-profile/mockHybridNodeRole \
+        --role-arn arn:aws:iam::123456789010:role/mockHybridNodeRole \
+        --role-session-name mock-hybrid-node \
+        --region us-west-2 --with-proxy
+StandardOutput=journal
+StandardError=journal
+Restart=always
+RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We previously fixed the iam-ra generated aws config to pass the --with-proxy flag when appropriate, but missed the update service.  This applies similiar logic to the service generation to ensure the --with-proxy flag is passed to the aws_signing_helper cmd.

Note, I will update the [docs](https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-proxy.html) page to include the need to add a similar service env file for the iam-ra update service.  As a future improvement, this service file along with most of the others listed on that docs page *could* be created by nodeadm.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

