### PR TITLE
changes gpgkey http get to use existing retryable http

### DIFF
--- a/internal/packagemanager/packagemanager.go
+++ b/internal/packagemanager/packagemanager.go
@@ -3,7 +3,6 @@ package packagemanager
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
@@ -134,13 +133,12 @@ func (pm *DistroPackageManager) configureAptPackageManagerWithDockerRepo(ctx con
 	}
 
 	// Download docker gpg key and write it to file
-	resp, err := http.Get(ubuntuDockerGpgKey)
+	data, err := util.GetHttpFile(ctx, ubuntuDockerGpgKey)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "downloading docker gpg key")
 	}
-	defer resp.Body.Close()
 
-	if err := util.WriteFileWithDirFromReader(ubuntuDockerGpgKeyPath, resp.Body, ubuntuDockerGpgKeyFilePerms); err != nil {
+	if err := util.WriteFileWithDir(ubuntuDockerGpgKeyPath, data, ubuntuDockerGpgKeyFilePerms); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When downloading the gpg key, this change uses the existing helper for downloading files with retries.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

