### PR TITLE
Consolidate policies to reduce size of role

### DIFF
--- a/hybrid-nodes-cdk/lib/nodeadm/policies.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm/policies.ts
@@ -21,10 +21,10 @@ export function createNodeadmTestsCreationCleanupPolicy(
   return new iam.Policy(stack, 'nodeadm-e2e-tests-runner-policy', {
     statements: [
       new iam.PolicyStatement({
-         effect: iam.Effect.ALLOW,
-         actions: ['cloudformation:CreateChangeSet', 'cloudformation:ExecuteChangeSet'],
-         resources: ['arn:aws:cloudformation:*:aws:transform/LanguageExtensions'],
-       }),
+        effect: iam.Effect.ALLOW,
+        actions: ['cloudformation:CreateChangeSet', 'cloudformation:ExecuteChangeSet'],
+        resources: ['arn:aws:cloudformation:*:aws:transform/LanguageExtensions'],
+      }),
       new iam.PolicyStatement({
         actions: [
           'iam:AttachRolePolicy',
@@ -42,6 +42,8 @@ export function createNodeadmTestsCreationCleanupPolicy(
       }),
       new iam.PolicyStatement({
         actions: [
+          'iam:CreateRole',
+          'iam:DeleteRole',
           'iam:DeleteRolePolicy',
           'iam:ListAttachedRolePolicies',
           'iam:ListInstanceProfilesForRole',
@@ -55,18 +57,6 @@ export function createNodeadmTestsCreationCleanupPolicy(
         actions: ['iam:CreateServiceLinkedRole'],
         resources: [`arn:aws:iam::${stack.account}:role/aws-service-role/*`],
         effect: iam.Effect.ALLOW,
-      }),
-      new iam.PolicyStatement({
-        actions: ['iam:CreateRole'],
-        resources: [`arn:aws:iam::${stack.account}:role/*`],
-        effect: iam.Effect.ALLOW,
-        conditions: requestTagCondition,
-      }),
-      new iam.PolicyStatement({
-        actions: ['iam:DeleteRole'],
-        resources: [`arn:aws:iam::${stack.account}:role/*`],
-        effect: iam.Effect.ALLOW,
-        conditions: resourceTagCondition,
       }),
       new iam.PolicyStatement({
         actions: [
@@ -88,6 +78,8 @@ export function createNodeadmTestsCreationCleanupPolicy(
       }),
       new iam.PolicyStatement({
         actions: [
+          'cloudformation:ListStacks',
+          'cloudformation:DescribeStacks',
           'ec2:AcceptVpcPeeringConnection',
           'ec2:AssociateRouteTable',
           'ec2:AssociateTransitGatewayRouteTable',
@@ -133,18 +125,30 @@ export function createNodeadmTestsCreationCleanupPolicy(
           'ec2:RevokeSecurityGroupIngress',
           'ec2:RunInstances',
           'ec2:SearchTransitGatewayRoutes',
+          'logs:DescribeLogGroups',
+          'rolesanywhere:ListTrustAnchors',
+          'rolesanywhere:ListProfiles',
+          'ssm:DeleteActivation',
+          'ssm:DeleteParameter',
+          'ssm:DescribeActivations',
+          'ssm:DescribeInstanceInformation',
+          'ssm:DescribeInstanceInformation',
+          'ssm:DescribeParameters',
+          'ssm:GetParameters',
+          'ssm:ListTagsForResource',
+          'ssm:PutParameter',
+          's3:ListAllMyBuckets',
+          'tag:GetResources',
         ],
         resources: ['*'],
         effect: iam.Effect.ALLOW,
       }),
       new iam.PolicyStatement({
-        actions: ['ec2:CreateInternetGateway', 'ec2:CreateKeyPair', 'ec2:CreateTags', 'ec2:CreateVpc'],
-        resources: ['*'],
-        effect: iam.Effect.ALLOW,
-        conditions: requestTagCondition,
-      }),
-      new iam.PolicyStatement({
         actions: [
+          'ec2:CreateInternetGateway', 
+          'ec2:CreateKeyPair',
+          'ec2:CreateTags',
+          'ec2:CreateVpc',
           'ec2:DeleteInternetGateway',
           'ec2:DeleteRoute',
           'ec2:DeleteSubnet',
@@ -156,6 +160,10 @@ export function createNodeadmTestsCreationCleanupPolicy(
           'ec2:StopInstances',
           'ec2:TerminateInstances',
           'ec2-instance-connect:SendSerialConsoleSSHPublicKey',
+          'rolesanywhere:CreateTrustAnchor',
+          'rolesanywhere:CreateProfile',
+          'ssm:CreateActivation',
+          'ssm:AddTagsToResource',
         ],
         resources: ['*'],
         effect: iam.Effect.ALLOW,
@@ -173,31 +181,6 @@ export function createNodeadmTestsCreationCleanupPolicy(
       new iam.PolicyStatement({
         actions: ['ssm:GetCommandInvocation'],
         resources: [`arn:aws:ssm:*:${stack.account}:*`],
-        effect: iam.Effect.ALLOW,
-      }),
-      new iam.PolicyStatement({
-        actions: [
-          'ssm:DeleteParameter',
-          'ssm:DescribeActivations',
-          'ssm:DescribeInstanceInformation',
-          'ssm:DescribeInstanceInformation',
-          'ssm:DescribeParameters',
-          'ssm:GetParameters',
-          'ssm:ListTagsForResource',
-          'ssm:PutParameter',
-        ],
-        resources: ['*'],
-        effect: iam.Effect.ALLOW,
-      }),
-      new iam.PolicyStatement({
-        actions: ['ssm:CreateActivation', 'ssm:AddTagsToResource'],
-        resources: ['*'],
-        effect: iam.Effect.ALLOW,
-        conditions: requestTagCondition,
-      }),
-      new iam.PolicyStatement({
-        actions: ['ssm:DeleteActivation'],
-        resources: ['*'],
         effect: iam.Effect.ALLOW,
       }),
       new iam.PolicyStatement({
@@ -238,11 +221,6 @@ export function createNodeadmTestsCreationCleanupPolicy(
       }),
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ['s3:ListAllMyBuckets'],
-        resources: ['*'],
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
         actions: ['eks:CreateAccessEntry', 'eks:DescribeCluster', 'eks:ListClusters', 'eks:TagResource'],
         resources: [
           `arn:aws:eks:${stack.region}:${stack.account}:cluster/*`,
@@ -251,15 +229,9 @@ export function createNodeadmTestsCreationCleanupPolicy(
       }),
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ['eks:CreateCluster'],
+        actions: ['eks:CreateCluster', 'eks:DeleteCluster', 'eks:ListUpdates', 'eks:DescribeUpdate'],
         resources: [`arn:aws:eks:${stack.region}:${stack.account}:cluster/*`],
         conditions: requestTagCondition,
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['eks:DeleteCluster', 'eks:ListUpdates', 'eks:DescribeUpdate'],
-        resources: [`arn:aws:eks:${stack.region}:${stack.account}:cluster/*`],
-        conditions: resourceTagCondition,
       }),
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
@@ -291,34 +263,8 @@ export function createNodeadmTestsCreationCleanupPolicy(
       }),
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ['cloudformation:CreateStack'],
+        actions: ['cloudformation:CreateStack', 'cloudformation:DeleteStack'],
         resources: [`arn:aws:cloudformation:${stack.region}:${stack.account}:stack/*`],
-        conditions: requestTagCondition,
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['cloudformation:DeleteStack'],
-        resources: [`arn:aws:cloudformation:${stack.region}:${stack.account}:stack/*`],
-        conditions: resourceTagCondition,
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['cloudformation:ListStacks', 'cloudformation:DescribeStacks'],
-        resources: ['*'],
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['rolesanywhere:CreateTrustAnchor', 'rolesanywhere:CreateProfile'],
-        resources: ['*'],
-        conditions: requestTagCondition,
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['rolesanywhere:TagResource'],
-        resources: [
-          `arn:aws:rolesanywhere:${stack.region}:${stack.account}:trust-anchor/*`,
-          `arn:aws:rolesanywhere:${stack.region}:${stack.account}:profile/*`,
-        ],
         conditions: requestTagCondition,
       }),
       new iam.PolicyStatement({
@@ -331,12 +277,8 @@ export function createNodeadmTestsCreationCleanupPolicy(
       }),
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ['rolesanywhere:ListTrustAnchors', 'rolesanywhere:ListProfiles'],
-        resources: ['*'],
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
         actions: [
+          'rolesanywhere:TagResource',
           'rolesanywhere:DeleteProfile',
           'rolesanywhere:DeleteTrustAnchor',
           'rolesanywhere:GetTrustAnchor',
@@ -350,7 +292,7 @@ export function createNodeadmTestsCreationCleanupPolicy(
       }),
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ['logs:TagResource'],
+        actions: ['logs:TagResource', 'logs:DeleteLogGroup'],
         resources: [`arn:aws:logs:${stack.region}:${stack.account}:log-group:/aws/eks/*`],
         conditions: requestTagCondition,
       }),
@@ -358,22 +300,6 @@ export function createNodeadmTestsCreationCleanupPolicy(
         effect: iam.Effect.ALLOW,
         actions: ['logs:PutRetentionPolicy'],
         resources: [`arn:aws:logs:${stack.region}:${stack.account}:log-group:/aws/eks/*`],
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['logs:DescribeLogGroups'],
-        resources: ['*'],
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['logs:DeleteLogGroup'],
-        resources: [`arn:aws:logs:${stack.region}:${stack.account}:log-group:/aws/eks/*`],
-        conditions: resourceTagCondition,
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['tag:GetResources'],
-        resources: ['*'],
       }),
     ],
   });

--- a/hybrid-nodes-cdk/lib/nodeadm/policies.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm/policies.ts
@@ -144,11 +144,13 @@ export function createNodeadmTestsCreationCleanupPolicy(
         effect: iam.Effect.ALLOW,
       }),
       new iam.PolicyStatement({
+        actions: ['ec2:CreateInternetGateway', 'ec2:CreateKeyPair', 'ec2:CreateTags', 'ec2:CreateVpc'],
+        resources: ['*'],
+        effect: iam.Effect.ALLOW,
+        conditions: requestTagCondition,
+      }),
+      new iam.PolicyStatement({
         actions: [
-          'ec2:CreateInternetGateway', 
-          'ec2:CreateKeyPair',
-          'ec2:CreateTags',
-          'ec2:CreateVpc',
           'ec2:DeleteInternetGateway',
           'ec2:DeleteRoute',
           'ec2:DeleteSubnet',
@@ -160,10 +162,6 @@ export function createNodeadmTestsCreationCleanupPolicy(
           'ec2:StopInstances',
           'ec2:TerminateInstances',
           'ec2-instance-connect:SendSerialConsoleSSHPublicKey',
-          'rolesanywhere:CreateTrustAnchor',
-          'rolesanywhere:CreateProfile',
-          'ssm:CreateActivation',
-          'ssm:AddTagsToResource',
         ],
         resources: ['*'],
         effect: iam.Effect.ALLOW,
@@ -182,6 +180,12 @@ export function createNodeadmTestsCreationCleanupPolicy(
         actions: ['ssm:GetCommandInvocation'],
         resources: [`arn:aws:ssm:*:${stack.account}:*`],
         effect: iam.Effect.ALLOW,
+      }),
+      new iam.PolicyStatement({
+        actions: ['ssm:CreateActivation', 'ssm:AddTagsToResource'],
+        resources: ['*'],
+        effect: iam.Effect.ALLOW,
+        conditions: requestTagCondition,
       }),
       new iam.PolicyStatement({
         actions: ['ssm:DeregisterManagedInstance'],
@@ -229,9 +233,15 @@ export function createNodeadmTestsCreationCleanupPolicy(
       }),
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ['eks:CreateCluster', 'eks:DeleteCluster', 'eks:ListUpdates', 'eks:DescribeUpdate'],
+        actions: ['eks:CreateCluster'],
         resources: [`arn:aws:eks:${stack.region}:${stack.account}:cluster/*`],
         conditions: requestTagCondition,
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['eks:DeleteCluster', 'eks:ListUpdates', 'eks:DescribeUpdate'],
+        resources: [`arn:aws:eks:${stack.region}:${stack.account}:cluster/*`],
+        conditions: resourceTagCondition,
       }),
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
@@ -263,8 +273,20 @@ export function createNodeadmTestsCreationCleanupPolicy(
       }),
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ['cloudformation:CreateStack', 'cloudformation:DeleteStack'],
+        actions: ['cloudformation:CreateStack'],
         resources: [`arn:aws:cloudformation:${stack.region}:${stack.account}:stack/*`],
+        conditions: requestTagCondition,
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['cloudformation:DeleteStack'],
+        resources: [`arn:aws:cloudformation:${stack.region}:${stack.account}:stack/*`],
+        conditions: resourceTagCondition,
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['rolesanywhere:CreateTrustAnchor', 'rolesanywhere:CreateProfile'],
+        resources: ['*'],
         conditions: requestTagCondition,
       }),
       new iam.PolicyStatement({
@@ -278,7 +300,6 @@ export function createNodeadmTestsCreationCleanupPolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: [
-          'rolesanywhere:TagResource',
           'rolesanywhere:DeleteProfile',
           'rolesanywhere:DeleteTrustAnchor',
           'rolesanywhere:GetTrustAnchor',
@@ -292,7 +313,16 @@ export function createNodeadmTestsCreationCleanupPolicy(
       }),
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ['logs:TagResource', 'logs:DeleteLogGroup'],
+        actions: ['rolesanywhere:TagResource'],
+        resources: [
+          `arn:aws:rolesanywhere:${stack.region}:${stack.account}:trust-anchor/*`,
+          `arn:aws:rolesanywhere:${stack.region}:${stack.account}:profile/*`,
+        ],
+        conditions: requestTagCondition,
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['logs:TagResource'],
         resources: [`arn:aws:logs:${stack.region}:${stack.account}:log-group:/aws/eks/*`],
         conditions: requestTagCondition,
       }),
@@ -300,6 +330,12 @@ export function createNodeadmTestsCreationCleanupPolicy(
         effect: iam.Effect.ALLOW,
         actions: ['logs:PutRetentionPolicy'],
         resources: [`arn:aws:logs:${stack.region}:${stack.account}:log-group:/aws/eks/*`],
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['logs:DeleteLogGroup'],
+        resources: [`arn:aws:logs:${stack.region}:${stack.account}:log-group:/aws/eks/*`],
+        conditions: resourceTagCondition,
       }),
     ],
   });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Got the following error message for the latest deployment in nodes build pipeline.

```
This AWS::IAM::Policy resource is in a UPDATE_FAILED state.

Resource handler returned message: "Maximum policy size of 10240 bytes exceeded for role nodeadm-build-65465437107-nodeadme2etestsprojectRol-S8mdpYtKocHA (Service: Iam, Status Code: 409, Request ID: 9dd12436-e073-428c-9a9b-3440af1e163a) (SDK Attempt Count: 1)" (RequestToken: 89246591-4d80-2d15-b790-ae68b8a3184e, HandlerErrorCode: ServiceLimitExceeded
```
Consolidate policies to reduce size of role for now. Policy should still remain the same after this change. 


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

