### PR TITLE
Add CAPABILITY_AUTO_EXPAND to CFN stack update call

### DIFF
--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
-	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	cfnTypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
@@ -109,8 +109,8 @@ func (s *stack) deploy(ctx context.Context, test TestResources) (*resourcesStack
 	return result, nil
 }
 
-func (s *stack) prepareStackParameters(test TestResources, eks EKSConfig) []types.Parameter {
-	params := []types.Parameter{
+func (s *stack) prepareStackParameters(test TestResources, eks EKSConfig) []cfnTypes.Parameter {
+	params := []cfnTypes.Parameter{
 		{
 			ParameterKey:   aws.String("ClusterName"),
 			ParameterValue: aws.String(test.ClusterName),
@@ -185,14 +185,14 @@ func (s *stack) prepareStackParameters(test TestResources, eks EKSConfig) []type
 	return params
 }
 
-func (s *stack) prepareAddonParameters(ingressConfig []securitygroup.IngessConfig) []types.Parameter {
+func (s *stack) prepareAddonParameters(ingressConfig []securitygroup.IngessConfig) []cfnTypes.Parameter {
 	var ports []string
 
 	for _, cfg := range ingressConfig {
 		ports = append(ports, fmt.Sprintf("%d|%s", cfg.Port, cfg.Description))
 	}
 
-	return []types.Parameter{
+	return []cfnTypes.Parameter{
 		{
 			ParameterKey:   aws.String("AddonPortsWithDescriptions"),
 			ParameterValue: aws.String(strings.Join(ports, ",")),
@@ -200,7 +200,7 @@ func (s *stack) prepareAddonParameters(ingressConfig []securitygroup.IngessConfi
 	}
 }
 
-func (s *stack) createOrUpdateStack(ctx context.Context, stackName string, params []types.Parameter, test TestResources) error {
+func (s *stack) createOrUpdateStack(ctx context.Context, stackName string, params []cfnTypes.Parameter, test TestResources) error {
 	resp, err := s.cfn.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
 		StackName: aws.String(stackName),
 	})
@@ -215,12 +215,12 @@ func (s *stack) createOrUpdateStack(ctx context.Context, stackName string, param
 			StackName:       aws.String(stackName),
 			TemplateBody:    aws.String(string(setupTemplateBody)),
 			Parameters:      params,
-			Capabilities: []types.Capability{
-				types.CapabilityCapabilityIam,
-				types.CapabilityCapabilityNamedIam,
-				types.CapabilityCapabilityAutoExpand,
+			Capabilities: []cfnTypes.Capability{
+				cfnTypes.CapabilityCapabilityIam,
+				cfnTypes.CapabilityCapabilityNamedIam,
+				cfnTypes.CapabilityCapabilityAutoExpand,
 			},
-			Tags: []types.Tag{{
+			Tags: []cfnTypes.Tag{{
 				Key:   aws.String(constants.TestClusterTagKey),
 				Value: aws.String(test.ClusterName),
 			}},
@@ -234,7 +234,7 @@ func (s *stack) createOrUpdateStack(ctx context.Context, stackName string, param
 		if err != nil {
 			return fmt.Errorf("waiting for hybrid nodes setup cfn stack: %w", err)
 		}
-	} else if resp.Stacks[0].StackStatus == types.StackStatusCreateInProgress || resp.Stacks[0].StackStatus == types.StackStatusUpdateInProgress {
+	} else if resp.Stacks[0].StackStatus == cfnTypes.StackStatusCreateInProgress || resp.Stacks[0].StackStatus == cfnTypes.StackStatusUpdateInProgress {
 		s.logger.Info("Waiting for hybrid nodes setup stack to be created", "stackName", stackName)
 		err = cfn.WaitForStackOperation(ctx, s.cfn, stackName, stackWaitInterval, stackWaitTimeout)
 		if err != nil {
@@ -246,9 +246,10 @@ func (s *stack) createOrUpdateStack(ctx context.Context, stackName string, param
 		_, err = s.cfn.UpdateStack(ctx, &cloudformation.UpdateStackInput{
 			DisableRollback: aws.Bool(true),
 			StackName:       aws.String(stackName),
-			Capabilities: []types.Capability{
-				types.CapabilityCapabilityIam,
-				types.CapabilityCapabilityNamedIam,
+			Capabilities: []cfnTypes.Capability{
+				cfnTypes.CapabilityCapabilityIam,
+				cfnTypes.CapabilityCapabilityNamedIam,
+				cfnTypes.CapabilityCapabilityAutoExpand,
 			},
 			TemplateBody: aws.String(string(setupTemplateBody)),
 			Parameters:   params,
@@ -271,7 +272,7 @@ func (s *stack) createOrUpdateStack(ctx context.Context, stackName string, param
 	return nil
 }
 
-func (s *stack) processStackOutputs(outputs []types.Output) *resourcesStackOutput {
+func (s *stack) processStackOutputs(outputs []cfnTypes.Output) *resourcesStackOutput {
 	result := &resourcesStackOutput{}
 	// extract relevant stack outputs
 	for _, output := range outputs {
@@ -391,7 +392,7 @@ func (s *stack) emptyPodIdentityS3Bucket(ctx context.Context, clusterName string
 	return nil
 }
 
-func replaceCreationTimeParameter(existingParams, newParams []types.Parameter) []types.Parameter {
+func replaceCreationTimeParameter(existingParams, newParams []cfnTypes.Parameter) []cfnTypes.Parameter {
 	// if the stack already exists, try to find the original creation time
 	// and replace the new parameter with the original one to avoid triggering an
 	// unnecessary update

--- a/test/e2e/credentials/stack.go
+++ b/test/e2e/credentials/stack.go
@@ -163,7 +163,7 @@ func (s *Stack) deployStack(ctx context.Context, logger logr.Logger) error {
 			TemplateBody:    aws.String(buf.String()),
 			Parameters:      params,
 			Capabilities: []cfnTypes.Capability{
-				"CAPABILITY_NAMED_IAM",
+				cfnTypes.CapabilityCapabilityNamedIam,
 			},
 			Tags: []cfnTypes.Tag{{
 				Key:   aws.String(constants.TestClusterTagKey),
@@ -187,7 +187,7 @@ func (s *Stack) deployStack(ctx context.Context, logger logr.Logger) error {
 			DisableRollback: aws.Bool(true),
 			StackName:       aws.String(s.Name),
 			Capabilities: []cfnTypes.Capability{
-				"CAPABILITY_NAMED_IAM",
+				cfnTypes.CapabilityCapabilityNamedIam,
 			},
 			TemplateBody: aws.String(buf.String()),
 			Parameters:   params,


### PR DESCRIPTION
Add `CAPABILITY_AUTO_EXPAND` capability to CFN `UpdateStack` call to fix the error
```console
updating CloudFormation stack: operation error CloudFormation: UpdateStack, https response error StatusCode: 400, RequestID: 6f4548f3-4f57-496c-833a-a7203f0e2caa, InsufficientCapabilitiesException: Requires capabilities : [CAPABILITY_AUTO_EXPAND]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

