### PR TITLE
Fix staging and prod artifact paths

### DIFF
--- a/hack/upload-dev-release-artifacts.sh
+++ b/hack/upload-dev-release-artifacts.sh
@@ -12,10 +12,10 @@ if [ "$PUBLIC_READ_ACL" = "true" ]; then
 fi
 
 # only uploading nodeadm, ATTRIBUTION.txt, and GIT_VERSION, skipping ginkgo/e2e-test/nodeadm.test
-mkdir -p _bin/latest/linux/{amd64,arm64}
+mkdir -p _bin/latest/bin/linux/{amd64,arm64}
 cp _bin/{ATTRIBUTION.txt,GIT_VERSION} _bin/latest/
-cp _bin/amd64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/linux/amd64/
-cp _bin/arm64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/linux/arm64/
+cp _bin/amd64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/bin/linux/amd64/
+cp _bin/arm64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/bin/linux/arm64/
 
 # uploading nodeadm.gz files separately to ensure the content-encoding/disposition is applied
 aws s3 sync --no-progress --exclude "*nodeadm.gz" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/ ${PUBLIC_READ_ACL_ARG}

--- a/hack/validate-release-artifacts.sh
+++ b/hack/validate-release-artifacts.sh
@@ -17,18 +17,18 @@ EXPECTED_FILES_FILE=$(mktemp)
 cat <<EOF > ${EXPECTED_FILES_FILE}
 ATTRIBUTION.txt
 GIT_VERSION
-linux/amd64/nodeadm
-linux/amd64/nodeadm.gz
-linux/amd64/nodeadm.gz.sha256
-linux/amd64/nodeadm.gz.sha512
-linux/amd64/nodeadm.sha256
-linux/amd64/nodeadm.sha512
-linux/arm64/nodeadm
-linux/arm64/nodeadm.gz
-linux/arm64/nodeadm.gz.sha256
-linux/arm64/nodeadm.gz.sha512
-linux/arm64/nodeadm.sha256
-linux/arm64/nodeadm.sha512
+bin/linux/amd64/nodeadm
+bin/linux/amd64/nodeadm.gz
+bin/linux/amd64/nodeadm.gz.sha256
+bin/linux/amd64/nodeadm.gz.sha512
+bin/linux/amd64/nodeadm.sha256
+bin/linux/amd64/nodeadm.sha512
+bin/linux/arm64/nodeadm
+bin/linux/arm64/nodeadm.gz
+bin/linux/arm64/nodeadm.gz.sha256
+bin/linux/arm64/nodeadm.gz.sha512
+bin/linux/arm64/nodeadm.sha256
+bin/linux/arm64/nodeadm.sha512
 EOF
 # *********************************************************************
 


### PR DESCRIPTION
Fix staging and prod artifact paths to include the `bin` folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

