### PR TITLE
Retry SSM activation creation on IAM role validation failures

### DIFF
--- a/test/e2e/credentials/ssm.go
+++ b/test/e2e/credentials/ssm.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,8 +74,12 @@ func (s *SsmProvider) createSSMActivation(ctx context.Context, clusterName, node
 		},
 	}
 
+	withValidationExceptionRetryer := func(o *ssm.Options) {
+		o.Retryer = retry.AddWithErrorCodes(o.Retryer, "ValidationException")
+	}
+
 	// Call CreateActivation to create the SSM activation
-	result, err := s.SSM.CreateActivation(ctx, input)
+	result, err := s.SSM.CreateActivation(ctx, input, withValidationExceptionRetryer)
 	if err != nil {
 		return nil, fmt.Errorf("creating SSM activation: %v", err)
 	}

--- a/test/e2e/ec2/instance.go
+++ b/test/e2e/ec2/instance.go
@@ -5,9 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -16,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/smithy-go"
 	"github.com/go-logr/logr"
 
 	"github.com/aws/eks-hybrid/test/e2e/constants"
@@ -130,10 +127,9 @@ func (e *InstanceConfig) Create(ctx context.Context, ec2Client *ec2.Client, ssmC
 			HttpEndpoint: types.InstanceMetadataEndpointStateEnabled,
 		},
 	}, func(o *ec2.Options) {
-		o.Retryer = retry.NewStandard(func(o *retry.StandardOptions) {
-			o.MaxAttempts = 60
-			o.Retryables = append(o.Retryables, invalidInstanceProfileRetryable{})
-		})
+		clientRetryer := o.Retryer
+		persistentInvalidParameterValueRetryer := retry.AddWithMaxAttempts(retry.AddWithErrorCodes(clientRetryer, "InvalidParameterValue"), 60)
+		o.Retryer = persistentInvalidParameterValueRetryer
 	})
 	if err != nil {
 		return Instance{}, fmt.Errorf("could not create hybrid EC2 instance: %w", err)
@@ -268,25 +264,4 @@ func LogEC2InstanceDescribe(ctx context.Context, ec2Client *ec2.Client, instance
 	}
 	logger.Info("Instance status", "instanceID", instanceID, "describeInstanceStatusResponse", awsutil.Prettify(describeStatusOutput.InstanceStatuses))
 	return nil
-}
-
-type invalidInstanceProfileRetryable struct{}
-
-func (c invalidInstanceProfileRetryable) IsErrorRetryable(err error) aws.Ternary {
-	var awsErr smithy.APIError
-	if ok := errors.As(err, &awsErr); ok {
-		// We retry invalid instance profile errors because sometimes there is a delay between creating
-		// the instance profile and that profile being available in EC2. We trust that if this error comes
-		// back, it's just an eventual consistency issue and not that our setup code is not creating the
-		// instance profile correctly.
-		// The error message can be:
-		// - Invalid IAM Instance Profile name
-		// - Invalid IAM Instance Profile ARN
-		// Depending if the input uses the name or the ARN in the params.
-		if awsErr.ErrorCode() == "InvalidParameterValue" && strings.Contains(awsErr.ErrorMessage(), "Invalid IAM Instance Profile") {
-			return aws.BoolTernary(true)
-		}
-	}
-
-	return aws.BoolTernary(false)
 }


### PR DESCRIPTION
We are hitting a validation error during SSM activation creation, when the IAM role is not ready yet so the client assumes we're associating a non-existent role with the activation.
```console
expected to build nodeconfig: failed to create SSM activation for node simpleflow-node-ssm-al23-amd64: creating SSM activation: operation error SSM: CreateActivation, https response error StatusCode: 400, RequestID: 608d0ae8-bc93-4480-9a30-95afdfc16656, api error ValidationException: Nonexistent role or missing ssm service principal in trust policy: arn:aws:iam::<account>:role/NodeadmE2E/<ssm role name/session>
```
This PR adds this exception type as a retryable error to work around the intermittent unavailability of the IAM role right after its creation.

Also I've changed the E2E code to use the native helper methods provided by the AWS SDK for Go V2 for additional retryable error codes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

