### PR TITLE
increase cfn stack timeout

### DIFF
--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -34,7 +34,7 @@ var setupTemplateBody []byte
 
 const (
 	creationTimeParameterKey = "CreationTime"
-	stackWaitTimeout         = 7 * time.Minute
+	stackWaitTimeout         = 9 * time.Minute
 	stackWaitInterval        = 10 * time.Second
 )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Increase timeouts on waiting stacks to be created from 7 minutes to 9 minutes. The context behind this is that there is a 5 minute timeout on the jumpbox resource signal. However, the stack first creates a role/instance profile and cfn has a hardcoded 2 (or 2.5) mins wait before assuming the instance profile is ready.

So we need to wait a bit longer than 7 minutes to ensure the tests can retry creating the instance if the signal handler times out.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

