### PR TITLE
increase cluster transition wait times

### DIFF
--- a/test/e2e/cleanup/eks.go
+++ b/test/e2e/cleanup/eks.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	activeClusterTimeout = 15 * time.Minute
-	deleteClusterTimeout = 15 * time.Minute
+	activeClusterTimeout = 20 * time.Minute
+	deleteClusterTimeout = 20 * time.Minute
 )
 
 type EKSClusterCleanup struct {


### PR DESCRIPTION
*Issue #, if available:*
At least one test run timed out waiting for cluster to delete. Looking at cloudtrail events, there was another event for that cluster 16 minutes after it received the DeleteCluster event. That event failed since the cluster did not exist, which suggests the cluster took somewhere between 15 and 16 minutes to delete. 

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

