### PR TITLE
Use meta.meta.UnsafeGuessKindToResource to convert GVK

### DIFF
--- a/test/e2e/kubernetes/unstructured.go
+++ b/test/e2e/kubernetes/unstructured.go
@@ -77,6 +77,7 @@ func UpsertManifestsWithRetries(ctx context.Context, k8s dynamic.Interface, mani
 
 func upsertManifest(ctx context.Context, k8s dynamic.Interface, obj unstructured.Unstructured) error {
 	groupVersion := obj.GroupVersionKind()
+	// ignore singular GroupVersionResource
 	resource, _ := meta.UnsafeGuessKindToResource(groupVersion)
 	k8sResource := k8s.Resource(resource).Namespace(obj.GetNamespace())
 	if _, err := k8sResource.Get(ctx, obj.GetName(), metav1.GetOptions{}); apierrors.IsNotFound(err) {
@@ -115,6 +116,7 @@ func DeleteManifestsWithRetries(ctx context.Context, k8s dynamic.Interface, mani
 
 func deleteManifest(ctx context.Context, k8s dynamic.Interface, obj unstructured.Unstructured) error {
 	groupVersion := obj.GroupVersionKind()
+	// ignore singular GroupVersionResource
 	resource, _ := meta.UnsafeGuessKindToResource(groupVersion)
 	k8sResource := k8s.Resource(resource).Namespace(obj.GetNamespace())
 	if err := k8sResource.Delete(ctx, obj.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {


### PR DESCRIPTION
*Issue #, if available:*
Previously we append `s` to generate plural for resource. However this doesn't work for resources that ends with "es" or "y"

*Description of changes:*
Use `UnsafeGuessKindToResource` from kubernetes meta package to convert GVK to plural resources.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

