### PR TITLE
fix e2e retry and cleanup on create node

### DIFF
--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -159,16 +159,6 @@ func (c NodeCreate) Create(ctx context.Context, spec *NodeSpec) (PeerdNode, erro
 		return PeerdNode{}, fmt.Errorf("EC2 Instance should have been created successfully: %w", err)
 	}
 
-	c.Logger.Info("Waiting for EC2 Instance to be running...", "instanceID", instance.ID)
-	if err := ec2.WaitForEC2InstanceRunning(ctx, c.EC2, instance.ID); err != nil {
-		return PeerdNode{}, fmt.Errorf("waiting for EC2 instance for node to be running: %w", err)
-	}
-
-	c.Logger.Info("Disabling source/destination check...", "instanceID", instance.ID)
-	if err := ec2.DisableSourceDestCheck(ctx, c.EC2, instance.ID); err != nil {
-		return PeerdNode{}, err
-	}
-
 	c.Logger.Info("A Hybrid EC2 instace is created", "instanceID", instance.ID)
 	return PeerdNode{
 		Instance: instance,

--- a/test/e2e/suite/test_node.go
+++ b/test/e2e/suite/test_node.go
@@ -102,6 +102,8 @@ func (n *testNode) Start(ctx context.Context) error {
 			n.waitForNodeToJoin(ctx, flakeRun)
 		})
 
+		Expect(ec2.DisableSourceDestCheck(ctx, n.EC2Client, node.Instance.ID)).Should(Succeed(), "Disable source/destination check should have succeeded")
+
 		Expect(n.PeeredNetwork.CreateRoutesForNode(ctx, n.node)).Should(Succeed(), "EC2 route to pod CIDR should have been created successfully")
 	})
 	return nil


### PR DESCRIPTION
*Issue #, if available:*
Some tests failed waiting for EC2 instance for node to be running. We expect it to retry if an ec2 never goes to running state as well as collecting logs from the ec2 on failure. However, neither of these things were happening. 

*Description of changes:*
Move wait for ec2 outside of NodeCreate.Create. We already do this step in `n.waitForNodeToJoin(ctx, flakeRun)` which is the intended place for wait. If we keep it inside NodeCreate.Create(), then it never reaches DeferCleanup() which contains the logic for collecting logs and is only called after NodeCreate.Create.

Also added wait for ec2 in `cmd/e2e-test/node/create.go`.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

