### PR TITLE
Check resourcesStackOutput params are nonempty after creating stack

### DIFF
--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -100,6 +100,11 @@ func (c *Create) Run(ctx context.Context, test TestResources) error {
 		return fmt.Errorf("creating stack for cluster infra: %w", err)
 	}
 
+	err = ensureAllStackOutputsNonEmpty(stackOut)
+	if err != nil {
+		return err
+	}
+
 	hybridCluster := hybridCluster{
 		Name:              test.ClusterName,
 		Region:            test.ClusterRegion,

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -415,3 +415,35 @@ func replaceCreationTimeParameter(existingParams, newParams []cfnTypes.Parameter
 	}
 	return newParams
 }
+
+func ensureAllStackOutputsNonEmpty(stackOut *resourcesStackOutput) error {
+	var missing []string
+
+	if stackOut.clusterRole == "" {
+		missing = append(missing, "ClusterRole")
+	}
+	if stackOut.clusterVpcConfig.vpcID == "" {
+		missing = append(missing, "ClusterVPC")
+	}
+	if stackOut.clusterVpcConfig.publicSubnet == "" {
+		missing = append(missing, "ClusterVPCPublicSubnet")
+	}
+	if stackOut.clusterVpcConfig.privateSubnet == "" {
+		missing = append(missing, "ClusterVPCPrivateSubnet")
+	}
+	if stackOut.clusterVpcConfig.securityGroup == "" {
+		missing = append(missing, "ClusterSecurityGroup")
+	}
+	if stackOut.podIdentity.roleArn == "" {
+		missing = append(missing, "PodIdentityAssociationRoleARN")
+	}
+	if stackOut.podIdentity.s3Bucket == "" {
+		missing = append(missing, "PodIdentityS3BucketName")
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required CloudFormation outputs after stack deployment: %v", missing)
+	}
+
+	return nil
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Validate that all necessary output from DescribeStack is non-empty to avoid create cluster calls like `"requestParameters": {
        "resourcesVpcConfig": {
            "securityGroupIds": [
                ""
            ],
            "subnetIds": [
                "",
                ""
            ]
        },
        "clientRequestToken": "***",
        "roleArn": "",
        "name": "***",
        "accessConfig": {
            "authenticationMode": "API_AND_CONFIG_MAP"
        },`

`
Phase: SetupTestInfrastructure Failure: creating E2E test infrastructure: creating 1.33 EKS cluster: creating EKS hybrid cluster: operation error EKS: CreateCluster, https response error StatusCode: 403, RequestID: ...... , api error AccessDeniedException: Cross-account pass role is not allowed. Status: failure`

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

