### PR TITLE
Add AWS_MAX_ATTEMPTS env var to awscli pod

### DIFF
--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -87,6 +87,14 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 				{
 					Name:  podName,
 					Image: fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/ecr-public/aws-cli/aws-cli:latest", constants.EcrAccounId, v.Region),
+					Env: []corev1.EnvVar{
+						// default value for AWS_MAX_ATTEMPTS is 3. We are seeing the s3 cp command
+						// fail due to rate limits form additional tests so increasing the number of retries
+						{
+							Name:  "AWS_MAX_ATTEMPTS",
+							Value: "10",
+						},
+					},
 					Command: []string{
 						"/bin/bash",
 						"-c",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We are seeing s3 commands with the aws cli fail due to rate limits from additional tests. Setting the AWS_MAX_ATTEMPTS env var on the awscli pod and configuring it to 10 to add retries to mitigate the issue.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

