### PR TITLE
Use manifest to determine ECR

### DIFF
--- a/internal/aws/ecr/ecr_test.go
+++ b/internal/aws/ecr/ecr_test.go
@@ -1,0 +1,178 @@
+package ecr
+
+import (
+	"testing"
+
+	awsinternal "github.com/aws/eks-hybrid/internal/aws"
+)
+
+func TestGetEKSRegistryCoordinates(t *testing.T) {
+	tests := []struct {
+		name         string
+		region       string
+		regionConfig *awsinternal.RegionData
+		expectAcct   string
+		expectRegion string
+	}{
+		{
+			name:   "manifest data available - takes precedence",
+			region: "us-east-1",
+			regionConfig: &awsinternal.RegionData{
+				EcrAccountID: "123456789012",
+			},
+			expectAcct:   "123456789012",
+			expectRegion: "us-east-1",
+		},
+		{
+			name:   "manifest data available for non-commercial region - takes precedence over hardcoded",
+			region: "cn-north-1",
+			regionConfig: &awsinternal.RegionData{
+				EcrAccountID: "123456789012",
+			},
+			expectAcct:   "123456789012",
+			expectRegion: "cn-north-1",
+		},
+		{
+			name:         "non-commercial region - cn-north-1 from hardcoded map",
+			region:       "cn-north-1",
+			regionConfig: nil,
+			expectAcct:   "918309763551",
+			expectRegion: "cn-north-1",
+		},
+		{
+			name:         "non-commercial region - cn-northwest-1 from hardcoded map",
+			region:       "cn-northwest-1",
+			regionConfig: nil,
+			expectAcct:   "961992271922",
+			expectRegion: "cn-northwest-1",
+		},
+		{
+			name:         "non-commercial region - us-gov-east-1 from hardcoded map",
+			region:       "us-gov-east-1",
+			regionConfig: nil,
+			expectAcct:   "151742754352",
+			expectRegion: "us-gov-east-1",
+		},
+		{
+			name:         "non-commercial region - us-gov-west-1 from hardcoded map",
+			region:       "us-gov-west-1",
+			regionConfig: nil,
+			expectAcct:   "013241004608",
+			expectRegion: "us-gov-west-1",
+		},
+		{
+			name:         "non-commercial region - us-iso-east-1 from hardcoded map",
+			region:       "us-iso-east-1",
+			regionConfig: nil,
+			expectAcct:   "725322719131",
+			expectRegion: "us-iso-east-1",
+		},
+		{
+			name:         "non-commercial region - us-iso-west-1 from hardcoded map",
+			region:       "us-iso-west-1",
+			regionConfig: nil,
+			expectAcct:   "608367168043",
+			expectRegion: "us-iso-west-1",
+		},
+		{
+			name:         "non-commercial region - us-isob-east-1 from hardcoded map",
+			region:       "us-isob-east-1",
+			regionConfig: nil,
+			expectAcct:   "187977181151",
+			expectRegion: "us-isob-east-1",
+		},
+		{
+			name:         "non-commercial region - us-isof-south-1 from hardcoded map",
+			region:       "us-isof-south-1",
+			regionConfig: nil,
+			expectAcct:   "676585237158",
+			expectRegion: "us-isof-south-1",
+		},
+		{
+			name:         "non-commercial region - eu-isoe-west-1 from hardcoded map",
+			region:       "eu-isoe-west-1",
+			regionConfig: nil,
+			expectAcct:   "249663109785",
+			expectRegion: "eu-isoe-west-1",
+		},
+		{
+			name:         "prefix fallback - unknown us-gov region",
+			region:       "us-gov-unknown-1",
+			regionConfig: nil,
+			expectAcct:   "013241004608",
+			expectRegion: "us-gov-west-1",
+		},
+		{
+			name:         "prefix fallback - unknown cn region",
+			region:       "cn-unknown-1",
+			regionConfig: nil,
+			expectAcct:   "961992271922",
+			expectRegion: "cn-northwest-1",
+		},
+		{
+			name:         "prefix fallback - unknown us-iso region",
+			region:       "us-iso-unknown-1",
+			regionConfig: nil,
+			expectAcct:   "725322719131",
+			expectRegion: "us-iso-east-1",
+		},
+		{
+			name:         "prefix fallback - unknown us-isob region",
+			region:       "us-isob-unknown-1",
+			regionConfig: nil,
+			expectAcct:   "187977181151",
+			expectRegion: "us-isob-east-1",
+		},
+		{
+			name:         "prefix fallback - unknown us-isof region",
+			region:       "us-isof-unknown-1",
+			regionConfig: nil,
+			expectAcct:   "676585237158",
+			expectRegion: "us-isof-south-1",
+		},
+		{
+			name:         "default fallback - commercial region not in manifest",
+			region:       "us-east-1",
+			regionConfig: nil,
+			expectAcct:   "602401143452",
+			expectRegion: "us-west-2",
+		},
+		{
+			name:         "default fallback - unknown region",
+			region:       "unknown-region",
+			regionConfig: nil,
+			expectAcct:   "602401143452",
+			expectRegion: "us-west-2",
+		},
+		{
+			name:   "empty ECR account ID in manifest - falls back to hardcoded for non-commercial",
+			region: "cn-north-1",
+			regionConfig: &awsinternal.RegionData{
+				EcrAccountID: "",
+			},
+			expectAcct:   "918309763551",
+			expectRegion: "cn-north-1",
+		},
+		{
+			name:   "empty ECR account ID in manifest - falls back to default for commercial",
+			region: "us-east-1",
+			regionConfig: &awsinternal.RegionData{
+				EcrAccountID: "",
+			},
+			expectAcct:   "602401143452",
+			expectRegion: "us-west-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account, region := getEKSRegistryCoordinatesWithRegionConfig(tt.region, tt.regionConfig)
+			if account != tt.expectAcct {
+				t.Errorf("Expected account %s, got %s", tt.expectAcct, account)
+			}
+			if region != tt.expectRegion {
+				t.Errorf("Expected region %s, got %s", tt.expectRegion, region)
+			}
+		})
+	}
+}

--- a/internal/aws/source.go
+++ b/internal/aws/source.go
@@ -138,6 +138,20 @@ func getLatestDateEksPatchRelease(patchReleases []EksPatchRelease) (EksPatchRele
 	return latestRelease, nil
 }
 
+func GetRegionConfig(ctx context.Context, region string) (*RegionData, error) {
+	manifest, err := getReleaseManifest(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	regionCfg, ok := manifest.RegionConfig[region]
+	if !ok {
+		return nil, fmt.Errorf("region %s not found in manifest", region)
+	}
+
+	return &regionCfg, nil
+}
+
 // GetKubelet satisfies kubelet.Source.
 func (as Source) GetKubelet(ctx context.Context) (artifact.Source, error) {
 	return as.getEksSource(ctx, "kubelet")

--- a/internal/configenricher/interface.go
+++ b/internal/configenricher/interface.go
@@ -1,7 +1,26 @@
 package configenricher
 
-import "context"
+import (
+	"context"
+
+	"github.com/aws/eks-hybrid/internal/aws"
+)
+
+// ConfigEnricherConfig holds the configuration options
+type ConfigEnricherConfig struct {
+	RegionConfig *aws.RegionData
+}
+
+// ConfigEnricherOption is a function that modifies ConfigEnricherConfig
+type ConfigEnricherOption func(*ConfigEnricherConfig)
+
+// WithRegionConfig creates a ConfigEnricherOption that sets the region config
+func WithRegionConfig(regionConfig *aws.RegionData) ConfigEnricherOption {
+	return func(config *ConfigEnricherConfig) {
+		config.RegionConfig = regionConfig
+	}
+}
 
 type ConfigEnricher interface {
-	Enrich(ctx context.Context) error
+	Enrich(ctx context.Context, opts ...ConfigEnricherOption) error
 }

--- a/internal/flows/init.go
+++ b/internal/flows/init.go
@@ -6,6 +6,8 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/utils/strings/slices"
 
+	"github.com/aws/eks-hybrid/internal/aws"
+	"github.com/aws/eks-hybrid/internal/configenricher"
 	"github.com/aws/eks-hybrid/internal/nodeprovider"
 )
 
@@ -33,7 +35,14 @@ func (i *Initer) Run(ctx context.Context) error {
 		return err
 	}
 
-	if err := i.NodeProvider.Enrich(ctx); err != nil {
+	// Get region config from manifest for ECR registry lookup
+	region := i.NodeProvider.GetNodeConfig().Spec.Cluster.Region
+	regionConfig, err := aws.GetRegionConfig(ctx, region)
+	if err != nil {
+		i.Logger.Warn("Failed to get region config from manifest", zap.Error(err))
+	}
+
+	if err := i.NodeProvider.Enrich(ctx, configenricher.WithRegionConfig(regionConfig)); err != nil {
 		return err
 	}
 

--- a/internal/flows/upgrade.go
+++ b/internal/flows/upgrade.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/eks-hybrid/internal/aws"
 	"github.com/aws/eks-hybrid/internal/cni"
+	"github.com/aws/eks-hybrid/internal/configenricher"
 	"github.com/aws/eks-hybrid/internal/containerd"
 	"github.com/aws/eks-hybrid/internal/creds"
 	"github.com/aws/eks-hybrid/internal/daemon"
@@ -51,7 +52,8 @@ func (u *Upgrader) Run(ctx context.Context) error {
 	if err := u.NodeProvider.ConfigureAws(ctx); err != nil {
 		return err
 	}
-	if err := u.NodeProvider.Enrich(ctx); err != nil {
+
+	if err := u.NodeProvider.Enrich(ctx, configenricher.WithRegionConfig(&u.AwsSource.RegionInfo)); err != nil {
 		return err
 	}
 	if err := initDaemons(ctx, u.NodeProvider, u.SkipPhases, u.Logger); err != nil {

--- a/internal/node/hybrid/configenricher.go
+++ b/internal/node/hybrid/configenricher.go
@@ -12,11 +12,19 @@ import (
 
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/aws/ecr"
+	"github.com/aws/eks-hybrid/internal/configenricher"
 )
 
-func (hnp *HybridNodeProvider) Enrich(ctx context.Context) error {
+func (hnp *HybridNodeProvider) Enrich(ctx context.Context, opts ...configenricher.ConfigEnricherOption) error {
 	hnp.logger.Info("Enriching configuration...")
-	eksRegistry, err := ecr.GetEKSHybridRegistry(hnp.nodeConfig.Spec.Cluster.Region)
+
+	// Apply options to build configuration
+	config := &configenricher.ConfigEnricherConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	eksRegistry, err := ecr.GetEKSHybridRegistry(hnp.nodeConfig.Spec.Cluster.Region, config.RegionConfig)
 	if err != nil {
 		return err
 	}

--- a/internal/node/hybrid/configenricher_test.go
+++ b/internal/node/hybrid/configenricher_test.go
@@ -13,6 +13,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-hybrid/internal/api"
+	internalaws "github.com/aws/eks-hybrid/internal/aws"
+	"github.com/aws/eks-hybrid/internal/configenricher"
 	"github.com/aws/eks-hybrid/internal/node/hybrid"
 	"github.com/aws/eks-hybrid/internal/test"
 )
@@ -429,7 +431,7 @@ func Test_hybridNodeProvider_Enrich(t *testing.T) {
 			)
 			g.Expect(err).To(Succeed())
 
-			err = p.Enrich(ctx)
+			err = p.Enrich(ctx, configenricher.WithRegionConfig(&internalaws.RegionData{}))
 			if tc.wantErr != "" {
 				g.Expect(err).To(MatchError(ContainSubstring(tc.wantErr)))
 			} else {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removed hardcoded ecr region to account mappings for regions where hybrid nodes is supported.
Restructured the logic to use the ecr region account mapping from the manifest instead.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

