### PR TITLE
Refactor: replace enum type for better type safety

### DIFF
--- a/internal/kubernetes/cert.go
+++ b/internal/kubernetes/cert.go
@@ -48,7 +48,8 @@ func (v KubeletCertificateValidator) Run(ctx context.Context, informer validatio
 		informer.Done(ctx, name, err)
 	}()
 	if err = hybrid.ValidateCertificate(v.certPath, cluster.CertificateAuthority); err != nil {
-		return hybrid.AddKubeletRemediation(v.certPath, err)
+		err = hybrid.AddKubeletRemediation(v.certPath, err)
+		return err
 	}
 
 	return nil

--- a/internal/node/hybrid/certificate_validator.go
+++ b/internal/node/hybrid/certificate_validator.go
@@ -9,115 +9,102 @@ import (
 	"time"
 )
 
-type ValidationErrorType int
-
-const (
-	ErrorNoCert ValidationErrorType = iota
-	ErrorCertFile
-	ErrorReadFile
-	ErrorInvalidFormat
-	ErrorClockSkewDetected
-	ErrorExpired
-	ErrorParseCA
-	ErrorInvalidCA
-)
-
-// ValidationError represents a kubelet certificate validation error with remediation information
-type ValidationError struct {
-	message             string
-	cause               error
-	validationErrorType ValidationErrorType
+type baseError struct {
+	message string
+	cause   error
 }
 
-func (e *ValidationError) ErrorType() ValidationErrorType {
-	return e.validationErrorType
-}
-
-func (e *ValidationError) Error() string {
+func (e *baseError) Error() string {
 	if e.cause != nil {
 		return fmt.Sprintf("%s: %v", e.message, e.cause)
 	}
 	return e.message
 }
 
-func (e *ValidationError) Unwrap() error {
+func (e *baseError) Unwrap() error {
 	return e.cause
 }
 
+type CertNotFoundError struct {
+	baseError
+}
+
+type CertFileError struct {
+	baseError
+}
+
+type CertReadError struct {
+	baseError
+}
+
+type CertInvalidFormatError struct {
+	baseError
+}
+
+type CertClockSkewError struct {
+	baseError
+}
+
+type CertExpiredError struct {
+	baseError
+}
+
+type CertParseCAError struct {
+	baseError
+}
+
+type CertInvalidCAError struct {
+	baseError
+}
+
 func IsDateValidationError(err error) bool {
-	var v *ValidationError
-	return errors.As(err, &v) && (v.validationErrorType == ErrorClockSkewDetected || v.validationErrorType == ErrorExpired)
+	var clockSkew *CertClockSkewError
+	var expiredCrt *CertExpiredError
+	return errors.As(err, &clockSkew) || errors.As(err, &expiredCrt)
 }
 
 func IsNoCertError(err error) bool {
-	var v *ValidationError
-	return errors.As(err, &v) && v.validationErrorType == ErrorNoCert
+	var notCrtFound *CertNotFoundError
+	return errors.As(err, &notCrtFound)
 }
 
 // ValidateCertificate checks if there is an existing certificate and validates it against the provided CA
 func ValidateCertificate(certPath string, ca []byte) error {
 	if _, err := os.Stat(certPath); os.IsNotExist(err) {
 		// Return an error for no cert, but one that can be identified
-		return &ValidationError{
-			message:             "no certificate found",
-			validationErrorType: ErrorNoCert,
-		}
+		return &CertNotFoundError{baseError{message: "no certificate found", cause: err}}
 	} else if err != nil {
-		return &ValidationError{
-			message:             "checking certificate",
-			cause:               err,
-			validationErrorType: ErrorCertFile,
-		}
+		return &CertFileError{baseError{message: "checking certificate", cause: err}}
 	}
 
 	certData, err := os.ReadFile(certPath)
 	if err != nil {
-		return &ValidationError{
-			message:             "reading certificate",
-			cause:               err,
-			validationErrorType: ErrorReadFile,
-		}
+		return &CertReadError{baseError{message: "reading certificate", cause: err}}
 	}
 
 	block, _ := pem.Decode(certData)
 	if block == nil {
-		return &ValidationError{
-			message:             "parsing certificate",
-			validationErrorType: ErrorInvalidFormat,
-		}
+		return &CertInvalidFormatError{baseError{message: "parsing certificate"}}
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return &ValidationError{
-			message:             "parsing certificate",
-			cause:               err,
-			validationErrorType: ErrorInvalidFormat,
-		}
+		return &CertInvalidFormatError{baseError{message: "parsing certificate", cause: err}}
 	}
 
 	now := time.Now()
 	if now.Before(cert.NotBefore) {
-		return &ValidationError{
-			message:             "server certificate is not yet valid",
-			validationErrorType: ErrorClockSkewDetected,
-		}
+		return &CertClockSkewError{baseError{message: "server certificate is not yet valid"}}
 	}
 
 	if now.After(cert.NotAfter) {
-		return &ValidationError{
-			message:             "server certificate has expired",
-			validationErrorType: ErrorExpired,
-		}
+		return &CertExpiredError{baseError{message: "server certificate has expired"}}
 	}
 
 	if len(ca) > 0 {
 		caPool := x509.NewCertPool()
 		if !caPool.AppendCertsFromPEM(ca) {
-			return &ValidationError{
-				message:             "parsing cluster CA certificate",
-				validationErrorType: ErrorParseCA,
-			}
+			return &CertParseCAError{baseError{message: "parsing cluster CA certificate"}}
 		}
 
 		opts := x509.VerifyOptions{
@@ -126,11 +113,7 @@ func ValidateCertificate(certPath string, ca []byte) error {
 		}
 
 		if _, err := cert.Verify(opts); err != nil {
-			return &ValidationError{
-				message:             "certificate is not valid for the current cluster",
-				cause:               err,
-				validationErrorType: ErrorInvalidCA,
-			}
+			return &CertInvalidCAError{baseError{message: "certificate is not valid for the current cluster", cause: err}}
 		}
 	}
 

--- a/internal/node/hybrid/certificate_validator_test.go
+++ b/internal/node/hybrid/certificate_validator_test.go
@@ -124,3 +124,89 @@ func TestValidateKubeletCert(t *testing.T) {
 		})
 	}
 }
+
+func TestDateValidationError(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "clock skew error",
+			err:      &CertClockSkewError{baseError{message: "cert not yet valid"}},
+			expected: true,
+		},
+		{
+			name:     "expired error",
+			err:      &CertExpiredError{baseError{message: "cert expired"}},
+			expected: true,
+		},
+		{
+			name:     "not found error",
+			err:      &CertNotFoundError{baseError{message: "cert not found"}},
+			expected: false,
+		},
+		{
+			name:     "file error",
+			err:      &CertFileError{baseError{message: "file error"}},
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsDateValidationError(tt.err)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestNoCertError(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "not found error",
+			err:      &CertNotFoundError{baseError{message: "cert not found"}},
+			expected: true,
+		},
+		{
+			name:     "clock skew error",
+			err:      &CertClockSkewError{baseError{message: "cert not yet valid"}},
+			expected: false,
+		},
+		{
+			name:     "expired error",
+			err:      &CertExpiredError{baseError{message: "cert expired"}},
+			expected: false,
+		},
+		{
+			name:     "file error",
+			err:      &CertFileError{baseError{message: "file error"}},
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsNoCertError(tt.err)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Code Refactor - replace enum-based errors with specific error types for certificate validation

- Convert ValidationError with enum types to individual error structs for better error handle

*Testing (if applicable):* yes
- Run unit test and integration test
- Test on hybrid node 

**Kubelet certificate validation**
root@hybrid-node:/home/eksahybrid# ./nodeadm debug -c file://nodeConfig.yaml
```
* Validating access to AWS SSM API endpoint [Success]
* Validating authentication against AWS [Success]
* Validating access to Kubernetes API endpoint [Success]
* Validating unauthenticated request to Kubernetes API endpoint [Success]
* Validating authenticated request to Kubernetes API endpoint [Success]
* Validating Kubernetes identity matches a Node identity [Success]
* Validating access to Kube-API server through VPC IPs [Success]
* Validating kubelet server certificate [Failed]
  └─ Error
     └─ validating kubelet certificate: parsing certificate: x509: malformed certificate
     └─ Remediation
        └─ Delete the kubelet server certificate file /var/lib/kubelet/pki/kubelet-server-current.pem and restart kubelet
```

**IAM RA certificate validation**
root@hybrid-node:/home/eksahybrid# ./nodeadm init -c file://nodeConfig_iamDemo.yaml
```
{"level":"info","ts":"2025-07-03T20:48:59.230Z","caller":"init/init.go:81","msg":"Checking user is root.."}
{"level":"info","ts":"2025-07-03T20:48:59.230Z","caller":"init/init.go:95","msg":"Loading installed components"}
{"level":"info","ts":"2025-07-03T20:48:59.525Z","caller":"init/init.go:111","msg":"Validating firewall ports for cilium and calico"}
{"level":"info","ts":"2025-07-03T20:48:59.567Z","caller":"node/node.go:13","msg":"Loading configuration..","configSource":"file://nodeConfig_iamDemo.yaml"}
{"level":"info","ts":"2025-07-03T20:48:59.568Z","caller":"node/node.go:23","msg":"Setting up hybrid node provider..."}
{"level":"info","ts":"2025-07-03T20:48:59.571Z","caller":"hybrid/validator.go:89","msg":"Validating configuration..."}
{"level":"fatal","ts":"2025-07-03T20:48:59.571Z","caller":"./main.go:55","msg":"Command failed","error":"validating iam-roles-anywhere certificate: parsing certificate"}
```



*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

