### PR TITLE
Add validation for NTP sync

### DIFF
--- a/cmd/nodeadm/debug/debug.go
+++ b/cmd/nodeadm/debug/debug.go
@@ -93,10 +93,10 @@ func (c *debug) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	runner := validation.NewRunner[*api.NodeConfig](printer)
 	apiServerValidator := node.NewAPIServerValidator(kubelet.New())
 	clusterProvider := kubernetes.NewClusterProvider(awsConfig)
-	swapValidator := system.NewSwapValidator(log)
 	runner.Register(creds.Validations(awsConfig, nodeConfig)...)
 	runner.Register(
-		validation.New("swap", swapValidator.Run),
+		validation.New("ntp-sync", system.NewNTPValidator(log).Run),
+		validation.New("swap", system.NewSwapValidator(log).Run),
 		validation.New("aws-auth", sts.NewAuthenticationValidator(awsConfig).Run),
 		runner.UntilError(
 			validation.New("k8s-endpoint-network", kubernetes.NewAccessValidator(clusterProvider).Run),

--- a/cmd/nodeadm/init/init.go
+++ b/cmd/nodeadm/init/init.go
@@ -32,6 +32,7 @@ func Phases() []string {
 	return []string{
 		"install-validation",
 		"cni-validation",
+		"ntp-sync-validation",
 		"node-ip-validation",
 		"kubelet-cert-validation",
 		"ssm-api-network-validation",

--- a/internal/node/hybrid/ntp_test.go
+++ b/internal/node/hybrid/ntp_test.go
@@ -1,0 +1,122 @@
+package hybrid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/aws/eks-hybrid/internal/api"
+	"github.com/aws/eks-hybrid/internal/validation"
+)
+
+func TestHybridNodeProvider_Validate_NTPSkipped(t *testing.T) {
+	logger := zap.NewNop()
+	nodeConfig := &api.NodeConfig{
+		Spec: api.NodeConfigSpec{
+			Cluster: api.ClusterDetails{
+				Name:   "test-cluster",
+				Region: "us-west-2",
+			},
+		},
+	}
+
+	// Create provider with NTP validation skipped
+	skipPhases := []string{ntpSyncValidation}
+	hnp, err := NewHybridNodeProvider(nodeConfig, skipPhases, logger)
+	require.NoError(t, err)
+
+	// Cast to concrete type to access internal fields
+	hybridProvider := hnp.(*HybridNodeProvider)
+
+	// Mock the validator to avoid actual validation
+	hybridProvider.validator = func(config *api.NodeConfig) error {
+		return nil // Mock successful validation
+	}
+
+	// Validate should succeed without running NTP validation
+	err = hnp.Validate()
+	assert.NoError(t, err)
+}
+
+func TestHybridNodeProvider_Validate_NTPIncluded(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	nodeConfig := &api.NodeConfig{
+		Spec: api.NodeConfigSpec{
+			Cluster: api.ClusterDetails{
+				Name:   "test-cluster",
+				Region: "us-west-2",
+			},
+		},
+	}
+
+	// Create provider without skipping NTP validation
+	hnp, err := NewHybridNodeProvider(nodeConfig, []string{}, logger)
+	require.NoError(t, err)
+
+	// Cast to concrete type to access internal fields
+	hybridProvider := hnp.(*HybridNodeProvider)
+
+	// Mock the validator to avoid actual validation
+	hybridProvider.validator = func(config *api.NodeConfig) error {
+		return nil // Mock successful validation
+	}
+
+	// Validate will run NTP validation
+	err = hnp.Validate()
+	if err != nil {
+		// Check if it's a remediable error
+		if validation.IsRemediable(err) {
+			remediation := validation.Remediation(err)
+			assert.NotEmpty(t, remediation, "Remediation should not be empty")
+			assert.Contains(t, remediation, "Ensure the hybrid node has chronyd or systemd-timesyncd services running")
+		}
+	}
+}
+
+func TestHybridNodeProvider_NTPValidationIntegration(t *testing.T) {
+	// Skip this test in CI environments where NTP might not be configured
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	logger := zaptest.NewLogger(t)
+	nodeConfig := &api.NodeConfig{
+		Spec: api.NodeConfigSpec{
+			Cluster: api.ClusterDetails{
+				Name:   "test-cluster",
+				Region: "us-west-2",
+			},
+		},
+	}
+
+	hnp, err := NewHybridNodeProvider(nodeConfig, []string{}, logger)
+	require.NoError(t, err)
+
+	// Cast to concrete type to access internal fields
+	hybridProvider := hnp.(*HybridNodeProvider)
+
+	// Mock other validations to focus on NTP
+	hybridProvider.validator = func(config *api.NodeConfig) error {
+		return nil // Mock successful validation
+	}
+
+	// Test NTP validation through full validation flow
+	// Skip other validations to focus on NTP
+	skipPhases := []string{nodeIpValidation, kubeletCertValidation, kubeletVersionSkew}
+	hybridProvider.skipPhases = skipPhases
+
+	fullErr := hnp.Validate()
+
+	// Verify behavior based on result
+	if fullErr != nil {
+		// If validation failed, verify remediation is included
+		if validation.IsRemediable(fullErr) {
+			remediation := validation.Remediation(fullErr)
+			assert.NotEmpty(t, remediation, "Full validation should include remediation")
+			assert.Contains(t, remediation, "Ensure the hybrid node has chronyd or systemd-timesyncd services running")
+		}
+	}
+}

--- a/internal/system/ntp.go
+++ b/internal/system/ntp.go
@@ -1,0 +1,145 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/aws/eks-hybrid/internal/api"
+	"github.com/aws/eks-hybrid/internal/validation"
+)
+
+var localhostReferenceIDs = []string{
+	"(00000000)",
+	"(0.0.0.0)",
+	"(127.0.0.1)",
+}
+
+// NTPValidator validates NTP synchronization status
+type NTPValidator struct {
+	logger *zap.Logger
+}
+
+// NewNTPValidator creates a new NTP validator
+func NewNTPValidator(logger *zap.Logger) *NTPValidator {
+	return &NTPValidator{
+		logger: logger,
+	}
+}
+
+// Run validates NTP synchronization
+func (v *NTPValidator) Run(ctx context.Context, informer validation.Informer, nodeConfig *api.NodeConfig) error {
+	var err error
+	informer.Starting(ctx, "ntp-sync", "Checking NTP synchronization status")
+	defer func() {
+		informer.Done(ctx, "ntp-sync", err)
+	}()
+	if err = v.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Validate performs the actual NTP validation
+func (v *NTPValidator) Validate() error {
+	if v.commandExists("chronyc") {
+		if chronySynchronized, err := v.checkChronyd(); err != nil {
+			v.logger.Error("NTP synchronization validation via chronyd failed", zap.Error(err))
+			if !chronySynchronized {
+				return validation.WithRemediation(err,
+					"Ensure the hybrid node is synchronized with NTP through chronyd services. "+
+						"Verify NTP server configuration in /etc/chrony.conf. "+
+						"If using airgapped networks, ensure chrony is configured with local NTP sources and adjusted manually.",
+				)
+			}
+			return err
+		}
+	}
+
+	if v.commandExists("timedatectl") {
+		if systemdTimesyncSynchronized, err := v.checkSystemdTimesyncd(); err != nil {
+			v.logger.Error("NTP synchronization validation via timedatectl failed", zap.Error(err))
+			if !systemdTimesyncSynchronized {
+				return validation.WithRemediation(err,
+					"Ensure the hybrid node is synchronized with NTP through systemd-timesyncd services. "+
+						"Verify NTP server configuration in /etc/systemd/timesyncd.conf. ",
+				)
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkChronyd checks if chronyd is synchronized
+func (v *NTPValidator) checkChronyd() (bool, error) {
+	cmd := exec.Command("chronyc", "tracking")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return true, fmt.Errorf("failed to get chrony tracking status: %s, error: %w", output, err)
+	}
+
+	// Parse the output to check if synchronized
+	lines := strings.Split(string(output), "\n")
+	hasReference := false
+	leapStatusNormal := false
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		// Check for reference ID (indicates time source)
+		if strings.Contains(line, "Reference ID") {
+			parts := strings.Fields(line)
+			if len(parts) >= 5 && !slices.Contains(localhostReferenceIDs, parts[4]) {
+				hasReference = true
+			}
+		}
+
+		if strings.Contains(line, "Leap status") && strings.Contains(line, "Normal") {
+			leapStatusNormal = true
+		}
+	}
+
+	if !hasReference && !leapStatusNormal {
+		return false, fmt.Errorf("chronyd not synchronized")
+	}
+
+	return true, nil
+}
+
+// checkSystemdTimesyncd checks if systemd-timesyncd is synchronized
+func (v *NTPValidator) checkSystemdTimesyncd() (bool, error) {
+	cmd := exec.Command("timedatectl", "status")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return true, fmt.Errorf("failed to get timedatectl status: %s, error: %w", output, err)
+	}
+
+	lines := strings.Split(string(output), "\n")
+	ntpSynchronized := false
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		if strings.Contains(line, "System clock synchronized: yes") {
+			ntpSynchronized = true
+		}
+	}
+
+	if !ntpSynchronized {
+		return false, fmt.Errorf("systemd-timesyncd not synchronized")
+	}
+
+	return true, nil
+}
+
+func (v *NTPValidator) commandExists(command string) bool {
+	_, err := exec.LookPath(command)
+	return err == nil
+}

--- a/internal/system/ntp_test.go
+++ b/internal/system/ntp_test.go
@@ -1,0 +1,318 @@
+package system
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestNewNTPValidator(t *testing.T) {
+	logger := zap.NewNop()
+	validator := NewNTPValidator(logger)
+
+	assert.NotNil(t, validator)
+	assert.Equal(t, logger, validator.logger)
+}
+
+func TestNTPValidator_Run(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	validator := NewNTPValidator(logger)
+
+	// Create a mock informer for testing
+	informer := &ntpMockInformer{}
+
+	ctx := context.Background()
+
+	// Test the validator - this will check the actual system
+	err := validator.Run(ctx, informer, nil)
+
+	// The validator should either succeed or fail with an error
+	t.Logf("NTP validation result: %v", err)
+
+	// Verify that the informer was called correctly
+	assert.True(t, informer.startingCalled, "Expected Starting to be called")
+	assert.True(t, informer.doneCalled, "Expected Done to be called")
+	assert.Equal(t, err, informer.lastError, "Expected error to match")
+}
+
+func TestNTPValidator_commandExists(t *testing.T) {
+	logger := zap.NewNop()
+	validator := NewNTPValidator(logger)
+
+	tests := []struct {
+		name     string
+		command  string
+		expected bool
+	}{
+		{
+			name:     "existing command",
+			command:  "echo",
+			expected: true,
+		},
+		{
+			name:     "non-existing command",
+			command:  "nonexistentcommand12345",
+			expected: false,
+		},
+		{
+			name:     "empty command",
+			command:  "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validator.commandExists(tt.command)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNTPValidator_Validate(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	validator := NewNTPValidator(logger)
+
+	// Test validation - this will check the actual system
+	err := validator.Validate()
+
+	// The result depends on the system state
+	// We can't predict the exact outcome, but we can verify the behavior
+	if err != nil {
+		// If there's an error, it should be a meaningful message
+		assert.NotEmpty(t, err.Error(), "Error message should not be empty")
+		t.Logf("NTP validation failed as expected: %v", err)
+	} else {
+		// If successful, log the success
+		t.Logf("NTP validation succeeded")
+	}
+}
+
+func TestNTPValidator_checkChronyd_CommandNotFound(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	validator := NewNTPValidator(logger)
+
+	// Test checkChronyd behavior - this will depend on whether chronyc exists
+	_, err := validator.checkChronyd()
+
+	if validator.commandExists("chronyc") {
+		// If chronyc exists, we expect either success or a specific error
+		if err != nil {
+			// Should contain meaningful error message
+			assert.Contains(t, err.Error(), "failed to get chrony tracking status")
+		}
+	} else {
+		// If chronyc doesn't exist, the command should fail with exec error
+		assert.NotNil(t, err, "Expected error when chronyc command doesn't exist")
+		assert.Contains(t, err.Error(), "failed to get chrony tracking status")
+	}
+}
+
+func TestNTPValidator_checkSystemdTimesyncd_CommandNotFound(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	validator := NewNTPValidator(logger)
+
+	// Test checkSystemdTimesyncd behavior - this will depend on whether timedatectl exists
+	_, err := validator.checkSystemdTimesyncd()
+
+	if validator.commandExists("timedatectl") {
+		// If timedatectl exists, we expect either success or a specific error
+		if err != nil {
+			// Should contain meaningful error message
+			assert.Contains(t, err.Error(), "failed to get timedatectl status")
+		}
+	} else {
+		// If timedatectl doesn't exist, the command should fail with exec error
+		assert.NotNil(t, err, "Expected error when timedatectl command doesn't exist")
+		assert.Contains(t, err.Error(), "failed to get timedatectl status")
+	}
+}
+
+func TestNTPValidator_checkChronyd_ParseOutput(t *testing.T) {
+	// Test parsing logic for chrony tracking output
+	tests := []struct {
+		name          string
+		output        string
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name: "synchronized with reference",
+			output: `Reference ID    : 169.254.169.123 (169.254.169.123)
+Stratum         : 4
+Ref time (UTC)  : Thu Jan 01 00:00:00 2024
+System time     : 0.000000001 seconds fast of NTP time
+Last offset     : +0.000000001 seconds
+RMS offset      : 0.000000001 seconds
+Frequency       : 0.000 ppm slow
+Residual freq   : +0.000 ppm
+Skew            : 0.000 ppm
+Root delay      : 0.000000001 seconds
+Root dispersion : 0.000000001 seconds
+Update interval : 0.0 seconds
+Leap status     : Normal`,
+			expectedError: false,
+		},
+		{
+			name: "no reference ID",
+			output: `Reference ID    : 0.0.0.0 (0.0.0.0)
+Stratum         : 0
+Ref time (UTC)  : Thu Jan 01 00:00:00 1970
+System time     : 0.000000000 seconds slow of NTP time
+Last offset     : +0.000000000 seconds
+RMS offset      : 0.000000000 seconds
+Frequency       : 0.000 ppm slow
+Residual freq   : +0.000 ppm
+Skew            : 0.000 ppm
+Root delay      : 0.000000000 seconds
+Root dispersion : 0.000000000 seconds
+Update interval : 0.0 seconds
+Leap status     : Not synchronised`,
+			expectedError: true,
+			errorContains: "chronyd not synchronized",
+		},
+		{
+			name: "localhost reference ID",
+			output: `Reference ID    : 127.0.0.1 (127.0.0.1)
+Stratum         : 4
+Ref time (UTC)  : Thu Jan 01 00:00:00 2024
+System time     : 0.000000001 seconds fast of NTP time
+Last offset     : +0.000000001 seconds
+RMS offset      : 0.000000001 seconds
+Frequency       : 0.000 ppm slow
+Residual freq   : +0.000 ppm
+Skew            : 0.000 ppm
+Root delay      : 0.000000001 seconds
+Root dispersion : 0.000000001 seconds
+Update interval : 0.0 seconds
+Leap status     : Normal`,
+			expectedError: true,
+			errorContains: "chronyd not synchronized",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse the output to verify our logic
+			lines := strings.Split(tt.output, "\n")
+
+			hasReference := false
+			hasNormalLeap := false
+
+			for _, line := range lines {
+				line = strings.TrimSpace(line)
+
+				// Check for reference ID
+				if strings.Contains(line, "Reference ID") {
+					parts := strings.Fields(line)
+					if len(parts) >= 5 {
+						refID := parts[4]
+						if refID != "(0.0.0.0)" && refID != "(00000000)" && refID != "(127.0.0.1)" {
+							hasReference = true
+						}
+					}
+				}
+
+				// Check for leap status
+				if strings.Contains(line, "Leap status") && strings.Contains(line, "Normal") {
+					hasNormalLeap = true
+				}
+			}
+
+			// Verify our parsing logic
+			if tt.expectedError {
+				if tt.errorContains == "chronyd not synchronized" {
+					assert.False(t, hasReference && hasNormalLeap, "Should not have both valid reference and normal leap status")
+				}
+			} else {
+				assert.True(t, hasReference || hasNormalLeap, "Should have either valid reference or normal leap status")
+			}
+		})
+	}
+}
+
+func TestNTPValidator_checkSystemdTimesyncd_ParseOutput(t *testing.T) {
+	// Test parsing of timedatectl status output
+	tests := []struct {
+		name          string
+		output        string
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name: "synchronized",
+			output: `               Local time: Thu 2024-01-01 00:00:00 UTC
+           Universal time: Thu 2024-01-01 00:00:00 UTC
+                 RTC time: Thu 2024-01-01 00:00:00
+                Time zone: UTC (UTC, +0000)
+System clock synchronized: yes
+              NTP service: active
+          RTC in local TZ: no`,
+			expectedError: false,
+		},
+		{
+			name: "not synchronized",
+			output: `               Local time: Thu 2024-01-01 00:00:00 UTC
+           Universal time: Thu 2024-01-01 00:00:00 UTC
+                 RTC time: Thu 2024-01-01 00:00:00
+                Time zone: UTC (UTC, +0000)
+System clock synchronized: no
+              NTP service: active
+          RTC in local TZ: no`,
+			expectedError: true,
+			errorContains: "systemd-timesyncd not synchronized",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse the output to verify our logic
+			lines := strings.Split(tt.output, "\n")
+			ntpSynchronized := false
+
+			for _, line := range lines {
+				line = strings.TrimSpace(line)
+
+				// Check if system clock is synchronized
+				if strings.Contains(line, "System clock synchronized: yes") {
+					ntpSynchronized = true
+				}
+			}
+
+			// Verify our parsing logic matches expected results
+			if tt.expectedError {
+				if tt.errorContains == "systemd-timesyncd not synchronized" {
+					assert.False(t, ntpSynchronized, "System clock should not be synchronized")
+				}
+			} else {
+				assert.True(t, ntpSynchronized, "System clock should be synchronized for success cases")
+			}
+		})
+	}
+}
+
+func TestNTPValidator_LocalhostReferenceIDs(t *testing.T) {
+	// Verify the localhost reference IDs constant
+	expectedIDs := []string{"(00000000)", "(0.0.0.0)", "(127.0.0.1)"}
+	assert.Equal(t, expectedIDs, localhostReferenceIDs)
+}
+
+// ntpMockInformer implements validation.Informer for testing
+type ntpMockInformer struct {
+	startingCalled bool
+	doneCalled     bool
+	lastError      error
+}
+
+func (m *ntpMockInformer) Starting(ctx context.Context, name, description string) {
+	m.startingCalled = true
+}
+
+func (m *ntpMockInformer) Done(ctx context.Context, name string, err error) {
+	m.doneCalled = true
+	m.lastError = err
+}

--- a/internal/system/swap_validator.go
+++ b/internal/system/swap_validator.go
@@ -24,11 +24,16 @@ func NewSwapValidator(logger *zap.Logger) *SwapValidator {
 
 // Run validates the swap configuration
 func (v *SwapValidator) Run(ctx context.Context, informer validation.Informer, nodeConfig *api.NodeConfig) error {
-	informer.Starting(ctx, "swap", "Checking swap configuration...")
+	var err error
+	informer.Starting(ctx, "swap", "Checking swap configuration")
+	defer func() {
+		informer.Done(ctx, "swap", err)
+	}()
+	if err = v.Validate(); err != nil {
+		return err
+	}
 
-	err := v.Validate()
-	informer.Done(ctx, "swap", err)
-	return err
+	return nil
 }
 
 // Validate performs the swap validation


### PR DESCRIPTION
Add in-flight validation for NTP sync for init command, and separate validation fot debug command. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

