### PR TITLE
Adding Mixed-Mode tests to e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GIT_VERSION?=0.0.0
 MANIFEST_HOST?=hybrid-assets.eks.amazonaws.com
 HYBRID_MANIFEST_URL=https://$(MANIFEST_HOST)/manifest.yaml
 
-E2E_SUITES?=./test/e2e/suite/nodeadm ./test/e2e/suite/conformance ./test/e2e/suite/addons
+E2E_SUITES?=./test/e2e/suite/nodeadm ./test/e2e/suite/conformance ./test/e2e/suite/addons ./test/e2e/suite/mixed_mode
 
 .PHONY: all
 all: crds generate fmt vet build

--- a/test/e2e/cleanup/managed_nodegroups.go
+++ b/test/e2e/cleanup/managed_nodegroups.go
@@ -1,0 +1,149 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/go-logr/logr"
+
+	"github.com/aws/eks-hybrid/test/e2e/errors"
+)
+
+const (
+	deleteNodegroupTimeout = 15 * time.Minute
+)
+
+type ManagedNodeGroupCleanup struct {
+	eksClient *eks.Client
+	logger    logr.Logger
+}
+
+func NewManagedNodeGroupCleanup(eksClient *eks.Client, logger logr.Logger) *ManagedNodeGroupCleanup {
+	return &ManagedNodeGroupCleanup{
+		eksClient: eksClient,
+		logger:    logger,
+	}
+}
+
+type NodeGroupInfo struct {
+	ClusterName   string
+	NodeGroupName string
+}
+
+func (c *ManagedNodeGroupCleanup) ListManagedNodeGroups(ctx context.Context, input FilterInput) ([]NodeGroupInfo, error) {
+	// First get list of clusters that match our filter
+	paginator := eks.NewListClustersPaginator(c.eksClient, &eks.ListClustersInput{})
+
+	var nodeGroups []NodeGroupInfo
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("listing EKS clusters: %w", err)
+		}
+
+		for _, clusterName := range page.Clusters {
+			// Check if cluster matches filter criteria
+			clusterInfo, err := c.eksClient.DescribeCluster(ctx, &eks.DescribeClusterInput{
+				Name: aws.String(clusterName),
+			})
+			if err != nil && errors.IsType(err, &types.ResourceNotFoundException{}) {
+				continue
+			}
+			if err != nil {
+				return nil, fmt.Errorf("describing cluster %s: %w", clusterName, err)
+			}
+
+			if !shouldDeleteCluster(clusterInfo.Cluster, input) {
+				continue
+			}
+
+			// List node groups for this cluster
+			ngPaginator := eks.NewListNodegroupsPaginator(c.eksClient, &eks.ListNodegroupsInput{
+				ClusterName: aws.String(clusterName),
+			})
+
+			for ngPaginator.HasMorePages() {
+				ngPage, err := ngPaginator.NextPage(ctx)
+				if err != nil {
+					return nil, fmt.Errorf("listing node groups for cluster %s: %w", clusterName, err)
+				}
+
+				for _, nodeGroupName := range ngPage.Nodegroups {
+					// Describe node group to get tags and creation time for filtering
+					ngInfo, err := c.eksClient.DescribeNodegroup(ctx, &eks.DescribeNodegroupInput{
+						ClusterName:   aws.String(clusterName),
+						NodegroupName: aws.String(nodeGroupName),
+					})
+					if err != nil && errors.IsType(err, &types.ResourceNotFoundException{}) {
+						continue
+					}
+					if err != nil {
+						return nil, fmt.Errorf("describing node group %s in cluster %s: %w", nodeGroupName, clusterName, err)
+					}
+
+					if shouldDeleteNodeGroup(ngInfo.Nodegroup, input) {
+						nodeGroups = append(nodeGroups, NodeGroupInfo{
+							ClusterName:   clusterName,
+							NodeGroupName: nodeGroupName,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return nodeGroups, nil
+}
+
+func (c *ManagedNodeGroupCleanup) DeleteManagedNodeGroup(ctx context.Context, clusterName, nodeGroupName string) error {
+	c.logger.Info("Deleting managed node group", "cluster", clusterName, "nodegroup", nodeGroupName)
+
+	_, err := c.eksClient.DeleteNodegroup(ctx, &eks.DeleteNodegroupInput{
+		ClusterName:   aws.String(clusterName),
+		NodegroupName: aws.String(nodeGroupName),
+	})
+
+	if err != nil && errors.IsType(err, &types.ResourceNotFoundException{}) {
+		c.logger.Info("Node group already deleted", "cluster", clusterName, "nodegroup", nodeGroupName)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("deleting node group %s in cluster %s: %w", nodeGroupName, clusterName, err)
+	}
+
+	// Wait for node group deletion
+	waiter := eks.NewNodegroupDeletedWaiter(c.eksClient)
+	err = waiter.Wait(ctx, &eks.DescribeNodegroupInput{
+		ClusterName:   aws.String(clusterName),
+		NodegroupName: aws.String(nodeGroupName),
+	}, deleteNodegroupTimeout)
+	if err != nil {
+		return fmt.Errorf("waiting for node group %s deletion in cluster %s: %w", nodeGroupName, clusterName, err)
+	}
+
+	c.logger.Info("Successfully deleted managed node group", "cluster", clusterName, "nodegroup", nodeGroupName)
+	return nil
+}
+
+func shouldDeleteNodeGroup(nodeGroup *types.Nodegroup, input FilterInput) bool {
+	var tags []Tag
+	for key, value := range nodeGroup.Tags {
+		tags = append(tags, Tag{
+			Key:   key,
+			Value: value,
+		})
+	}
+
+	resource := ResourceWithTags{
+		ID:           *nodeGroup.NodegroupName,
+		CreationTime: aws.ToTime(nodeGroup.CreatedAt),
+		Tags:         tags,
+	}
+
+	return shouldDeleteResource(resource, input)
+}

--- a/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
+++ b/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
@@ -22,6 +22,9 @@ Parameters:
   EC2RolePrefix:
     Type: String
     Default: 'ec2'
+  ManagedNodeRolePrefix:
+    Type: String
+    Default: 'mng'
     
 Resources:
   SSMRole:
@@ -176,6 +179,30 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Path: !Ref rolePathPrefix
 
+  # Create IAM Role for EKS Managed Node Groups
+  ManagedNodeInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      # use a predictable prefix for Managed Node role while maintaining uniqueness requirement for Managed Node role name
+      RoleName:
+        !Sub
+          - '${RolePrefix}-${TrimmedRegion}${UUID}'
+          - RolePrefix: !Ref ManagedNodeRolePrefix
+            TrimmedRegion: !Join ['', !Split ['-', !Ref AWS::Region]]
+            UUID: !Join ['', !Split ['-', !Select [2, !Split [/, !Ref AWS::StackId]]]]
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+      Path: !Ref rolePathPrefix
+
 Outputs:
   EC2Role:
     Description: The name of the IAM Role for EC2.
@@ -188,6 +215,10 @@ Outputs:
   SSMNodeRoleARN:
     Description: The ARN of the IAM Role for SSM.
     Value: !GetAtt SSMRole.Arn
+
+  ManagedNodeRoleArn:
+    Description: The ARN of the IAM Role for EKS Managed Node Groups.
+    Value: !GetAtt ManagedNodeInstanceRole.Arn
 {{- if .IncludeRolesAnywhere}}
   IRANodeRoleName:
     Description: IAM Role for IAM Roles Anywhere

--- a/test/e2e/credentials/stack.go
+++ b/test/e2e/credentials/stack.go
@@ -58,6 +58,7 @@ type StackOutput struct {
 	IRANodeRoleARN     string `json:"iraNodeRoleARN"`
 	IRATrustAnchorARN  string `json:"iraTrustAnchorARN"`
 	IRAProfileARN      string `json:"iraProfileARN"`
+	ManagedNodeRoleArn string `json:"managedNodeRoleArn"`
 }
 
 func (s *Stack) Deploy(ctx context.Context, logger logr.Logger) (*StackOutput, error) {
@@ -296,6 +297,8 @@ func (s *Stack) readStackOutput(ctx context.Context, logger logr.Logger) (*Stack
 			result.IRATrustAnchorARN = *output.OutputValue
 		case "IRAProfileARN":
 			result.IRAProfileARN = *output.OutputValue
+		case "ManagedNodeRoleArn":
+			result.ManagedNodeRoleArn = *output.OutputValue
 		}
 	}
 

--- a/test/e2e/kubernetes/deployment.go
+++ b/test/e2e/kubernetes/deployment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -18,5 +19,33 @@ func DeploymentWaitForReplicas(ctx context.Context, timeout time.Duration, k8s k
 		return fmt.Errorf("deployment %s replicas never became ready: %v", name, err)
 	}
 
+	return nil
+}
+
+// DeleteDeploymentAndWait deletes a deployment and waits for it to be fully removed
+func DeleteDeploymentAndWait(ctx context.Context, k8s kubernetes.Interface, deploymentName, namespace string, logger logr.Logger) error {
+	logger.Info("Deleting deployment and waiting for removal", "deployment", deploymentName)
+
+	err := ik8s.IdempotentDelete(ctx, k8s.AppsV1().Deployments(namespace), deploymentName)
+	if err != nil {
+		return fmt.Errorf("deleting deployment %s in namespace %s: %w", deploymentName, namespace, err)
+	}
+
+	// Wait for deployment to be fully deleted
+	_, err = ik8s.ListAndWait(ctx, 60*time.Second, k8s.AppsV1().Deployments(namespace), func(deployments *appsv1.DeploymentList) bool {
+		for _, deployment := range deployments.Items {
+			if deployment.Name == deploymentName {
+				return false
+			}
+		}
+		return true
+	}, func(opts *ik8s.ListOptions) {
+		opts.FieldSelector = "metadata.name=" + deploymentName
+	})
+	if err != nil {
+		return fmt.Errorf("waiting for deployment %s to be deleted: %w", deploymentName, err)
+	}
+
+	logger.Info("Deployment fully deleted", "deployment", deploymentName)
 	return nil
 }

--- a/test/e2e/kubernetes/deployment.go
+++ b/test/e2e/kubernetes/deployment.go
@@ -7,10 +7,82 @@ import (
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	ik8s "github.com/aws/eks-hybrid/internal/kubernetes"
+	"github.com/aws/eks-hybrid/test/e2e/constants"
 )
+
+// CreateDeployment creates a deployment with the specified configuration
+func CreateDeployment(
+	ctx context.Context,
+	k8s kubernetes.Interface,
+	name, namespace, region string,
+	nodeSelector map[string]string,
+	targetPort int32,
+	replicas int32,
+	logger logr.Logger,
+	additionalLabels ...map[string]string,
+) (*appsv1.Deployment, error) {
+	actualTargetPort := int32(80) // nginx deployments use port 80
+	containerCommand := []string{"nginx", "-g", "daemon off;"}
+
+	// Start with default labels
+	labels := map[string]string{
+		"app": name,
+	}
+
+	// Add additional labels if provided
+	if len(additionalLabels) > 0 {
+		for _, labelMap := range additionalLabels {
+			for key, value := range labelMap {
+				labels[key] = value
+			}
+		}
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: nodeSelector,
+					Containers: []corev1.Container{
+						{
+							Name:    name,
+							Image:   fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/ecr-public/nginx/nginx:latest", constants.EcrAccounId, region),
+							Command: containerCommand,
+							Ports: []corev1.ContainerPort{
+								{ContainerPort: actualTargetPort, Protocol: corev1.ProtocolTCP},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	createdDeployment, err := k8s.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("creating deployment %s: %w", name, err)
+	}
+
+	logger.Info("Created deployment", "name", name, "namespace", namespace, "replicas", replicas)
+	return createdDeployment, nil
+}
 
 func DeploymentWaitForReplicas(ctx context.Context, timeout time.Duration, k8s kubernetes.Interface, namespace, name string) error {
 	if _, err := ik8s.GetAndWait(ctx, timeout, k8s.AppsV1().Deployments(namespace), name, func(d *appsv1.Deployment) bool {
@@ -47,5 +119,35 @@ func DeleteDeploymentAndWait(ctx context.Context, k8s kubernetes.Interface, depl
 	}
 
 	logger.Info("Deployment fully deleted", "deployment", deploymentName)
+	return nil
+}
+
+// ListDeploymentsWithLabels lists deployments in a namespace that match the given label selector
+func ListDeploymentsWithLabels(ctx context.Context, k8s kubernetes.Interface, namespace, labelSelector string) (*appsv1.DeploymentList, error) {
+	deployments, err := k8s.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list deployments with selector %s: %w", labelSelector, err)
+	}
+	return deployments, nil
+}
+
+// DeleteDeploymentsWithLabels deletes all deployments in a namespace that match the given label selector
+func DeleteDeploymentsWithLabels(ctx context.Context, k8s kubernetes.Interface, namespace, labelSelector string, logger logr.Logger) error {
+	logger.Info("Deleting deployments with label selector", "selector", labelSelector, "namespace", namespace)
+
+	deployments, err := ListDeploymentsWithLabels(ctx, k8s, namespace, labelSelector)
+	if err != nil {
+		return fmt.Errorf("failed to list deployments with selector %s: %w", labelSelector, err)
+	}
+
+	for _, deployment := range deployments.Items {
+		if err := DeleteDeploymentAndWait(ctx, k8s, deployment.Name, namespace, logger); err != nil {
+			logger.Info("Deployment cleanup: resource not found or already deleted", "name", deployment.Name)
+		}
+	}
+
+	logger.Info("Completed deployments deletion", "selector", labelSelector, "count", len(deployments.Items))
 	return nil
 }

--- a/test/e2e/kubernetes/pod.go
+++ b/test/e2e/kubernetes/pod.go
@@ -31,12 +31,32 @@ func GetNginxPodName(name string) string {
 	return "nginx-" + name
 }
 
-func CreateNginxPodInNode(ctx context.Context, k8s kubernetes.Interface, nodeName, namespace, region string, logger logr.Logger) error {
-	podName := GetNginxPodName(nodeName)
+func CreateNginxPodInNode(ctx context.Context, k8s kubernetes.Interface, nodeName, namespace, region string, logger logr.Logger, options ...interface{}) error {
+	var podName string
+	var labels map[string]string
+
+	// Parse optional parameters
+	for _, option := range options {
+		switch v := option.(type) {
+		case string:
+			if v != "" {
+				podName = v
+			}
+		case map[string]string:
+			labels = v
+		}
+	}
+
+	// Use default pod name if not provided
+	if podName == "" {
+		podName = GetNginxPodName(nodeName)
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
 			Namespace: namespace,
+			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -61,7 +81,6 @@ func CreateNginxPodInNode(ctx context.Context, k8s kubernetes.Interface, nodeNam
 					},
 				},
 			},
-			// schedule the pod on the specific node using nodeSelector
 			NodeSelector: map[string]string{
 				"kubernetes.io/hostname": nodeName,
 			},
@@ -271,14 +290,14 @@ func TestPodToPodConnectivity(ctx context.Context, config *restclient.Config, k8
 	targetIP := targetPod.Status.PodIP
 	logger.Info("Testing pod-to-pod connectivity", "from", clientPodName, "to", targetPodName, "ip", targetIP)
 
-	cmd := []string{"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", fmt.Sprintf("http://%s:8080", targetIP), "--connect-timeout", "10", "--max-time", "30"}
+	cmd := []string{"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", fmt.Sprintf("http://%s:80", targetIP), "--connect-timeout", "10", "--max-time", "30"}
 
 	_, err = ik8s.GetAndWait(ctx, 2*time.Minute, k8s.CoreV1().Pods(namespace), clientPodName, func(pod *corev1.Pod) bool {
 		if pod.Status.Phase != corev1.PodRunning {
 			return false
 		}
 
-		result, execErr := ExecInPod(ctx, config, k8s, clientPodName, namespace, cmd)
+		result, _, execErr := execPod(ctx, config, k8s, clientPodName, namespace, cmd...)
 		if execErr != nil {
 			logger.Info("Pod connectivity test failed", "error", execErr.Error())
 			return false
@@ -294,16 +313,43 @@ func TestPodToPodConnectivity(ctx context.Context, config *restclient.Config, k8
 	return nil
 }
 
-// ExecInPod executes a command in a pod and returns stdout (simplified version of ExecPodWithRetries)
-func ExecInPod(ctx context.Context, config *restclient.Config, k8s kubernetes.Interface, podName, namespace string, command []string) (string, error) {
-	stdout, _, err := execPod(ctx, config, k8s, podName, namespace, command...)
-	return stdout, err
-}
-
 func WaitForDaemonSetPodToBeRunning(ctx context.Context, k8s kubernetes.Interface, namespace, daemonSetName, nodeName string, logger logr.Logger) error {
 	listOptions := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", "app.kubernetes.io/name", daemonSetName),
 		FieldSelector: fmt.Sprintf("%s=%s", "spec.nodeName", nodeName),
 	}
 	return WaitForPodsToBeRunning(ctx, k8s, listOptions, namespace, logger)
+}
+
+// ListPodsWithLabels lists pods in a namespace that match the given label selector
+func ListPodsWithLabels(ctx context.Context, k8s kubernetes.Interface, namespace, labelSelector string) (*corev1.PodList, error) {
+	pods, err := k8s.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods with selector %s: %w", labelSelector, err)
+	}
+	return pods, nil
+}
+
+// DeletePodsWithLabels deletes all pods in a namespace that match the given label selector
+func DeletePodsWithLabels(ctx context.Context, k8s kubernetes.Interface, namespace, labelSelector string, logger logr.Logger) error {
+	pods, err := ListPodsWithLabels(ctx, k8s, namespace, labelSelector)
+	if err != nil {
+		return fmt.Errorf("failed to list pods for deletion: %w", err)
+	}
+
+	for _, pod := range pods.Items {
+		// Force delete pods to prevent resource accumulation issues
+		gracePeriodSeconds := int64(0)
+		deleteOptions := metav1.DeleteOptions{
+			GracePeriodSeconds: &gracePeriodSeconds,
+		}
+		if err := k8s.CoreV1().Pods(namespace).Delete(ctx, pod.Name, deleteOptions); err != nil {
+			logger.Info("Pod cleanup: resource not found or already deleted", "name", pod.Name)
+		} else {
+			logger.Info("Force deleted pod", "name", pod.Name)
+		}
+	}
+	return nil
 }

--- a/test/e2e/kubernetes/service.go
+++ b/test/e2e/kubernetes/service.go
@@ -1,0 +1,179 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+
+	ik8s "github.com/aws/eks-hybrid/internal/kubernetes"
+)
+
+// CreateServiceWithDeployment creates a service and deployment with the specified configuration
+func CreateServiceWithDeployment(
+	ctx context.Context,
+	k8s kubernetes.Interface,
+	name, image string,
+	nodeSelector map[string]string,
+	servicePort, targetPort int32,
+	replicas int32,
+	logger logr.Logger,
+) (*corev1.Service, *appsv1.Deployment, error) {
+	actualTargetPort := targetPort
+	var containerCommand []string
+	if strings.Contains(image, "nginx") {
+		actualTargetPort = 8080
+		containerCommand = []string{"sh", "-c", "sed -i 's/listen.*80;/listen 8080;/' /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"}
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{"app": name},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: nodeSelector,
+					Containers: []corev1.Container{
+						{
+							Name:    name,
+							Image:   image,
+							Command: containerCommand,
+							Ports: []corev1.ContainerPort{
+								{ContainerPort: actualTargetPort, Protocol: corev1.ProtocolTCP},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	createdDeployment, err := k8s.AppsV1().Deployments("default").Create(ctx, deployment, metav1.CreateOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating deployment %s: %w", name, err)
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{"app": name},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": name},
+			Ports: []corev1.ServicePort{
+				{
+					Port:       8080,
+					TargetPort: intstr.FromInt(int(actualTargetPort)),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	createdService, err := k8s.CoreV1().Services("default").Create(ctx, service, metav1.CreateOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating service %s: %w", name, err)
+	}
+
+	logger.Info("Created service with deployment", "name", name, "replicas", replicas)
+	return createdService, createdDeployment, nil
+}
+
+// WaitForServiceReady waits for service endpoints to be ready
+func WaitForServiceReady(ctx context.Context, k8s kubernetes.Interface, serviceName, namespace string, logger logr.Logger) error {
+	logger.Info("Waiting for service endpoints", "service", serviceName)
+
+	_, err := ik8s.ListAndWait(ctx, 3*time.Minute, k8s.DiscoveryV1().EndpointSlices(namespace), func(endpointSlices *discoveryv1.EndpointSliceList) bool {
+		for _, slice := range endpointSlices.Items {
+			if ownerService, exists := slice.Labels["kubernetes.io/service-name"]; exists && ownerService == serviceName {
+				for _, endpoint := range slice.Endpoints {
+					if endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	})
+	if err != nil {
+		return fmt.Errorf("service %s endpoints never became ready: %w", serviceName, err)
+	}
+
+	logger.Info("Service has endpoints", "service", serviceName)
+	return nil
+}
+
+// TestServiceConnectivityWithRetries tests service connectivity using short name with 5-minute retry window
+func TestServiceConnectivityWithRetries(ctx context.Context, config *restclient.Config, k8s kubernetes.Interface, clientPodName, serviceName, namespace string, port int32, logger logr.Logger) error {
+	logger.Info("Testing service connectivity with retries", "from", clientPodName, "service", serviceName, "port", port)
+
+	serviceURL := fmt.Sprintf("http://%s:%d", serviceName, port)
+	cmd := []string{"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", serviceURL, "--connect-timeout", "30", "--max-time", "60"}
+
+	_, err := ik8s.GetAndWait(ctx, 5*time.Minute, k8s.CoreV1().Pods(namespace), clientPodName, func(pod *corev1.Pod) bool {
+		if pod.Status.Phase != corev1.PodRunning {
+			return false
+		}
+
+		result, execErr := ExecInPod(ctx, config, k8s, clientPodName, namespace, cmd)
+		if execErr != nil {
+			logger.Info("Service connectivity test failed", "error", execErr.Error())
+			return false
+		}
+
+		return strings.Contains(result, "200")
+	})
+	if err != nil {
+		return fmt.Errorf("service connectivity test failed from %s to %s: %w", clientPodName, serviceName, err)
+	}
+
+	logger.Info("Service connectivity test completed successfully", "from", clientPodName, "to", serviceName)
+	return nil
+}
+
+// DeleteServiceAndWait deletes a service and waits for it to be fully removed
+func DeleteServiceAndWait(ctx context.Context, k8s kubernetes.Interface, serviceName, namespace string, logger logr.Logger) error {
+	logger.Info("Deleting service and waiting for removal", "service", serviceName)
+
+	err := ik8s.IdempotentDelete(ctx, k8s.CoreV1().Services(namespace), serviceName)
+	if err != nil {
+		return fmt.Errorf("deleting service %s in namespace %s: %w", serviceName, namespace, err)
+	}
+
+	_, err = ik8s.ListAndWait(ctx, 30*time.Second, k8s.CoreV1().Services(namespace), func(services *corev1.ServiceList) bool {
+		for _, service := range services.Items {
+			if service.Name == serviceName {
+				return false
+			}
+		}
+		return true
+	}, func(opts *ik8s.ListOptions) {
+		opts.FieldSelector = "metadata.name=" + serviceName
+	})
+	if err != nil {
+		return fmt.Errorf("waiting for service %s to be deleted: %w", serviceName, err)
+	}
+
+	logger.Info("Service fully deleted", "service", serviceName)
+	return nil
+}

--- a/test/e2e/kubernetes/service.go
+++ b/test/e2e/kubernetes/service.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,85 +17,55 @@ import (
 	ik8s "github.com/aws/eks-hybrid/internal/kubernetes"
 )
 
-// CreateServiceWithDeployment creates a service and deployment with the specified configuration
-func CreateServiceWithDeployment(
+// CreateService creates a service with the specified configuration
+func CreateService(
 	ctx context.Context,
 	k8s kubernetes.Interface,
-	name, image string,
-	nodeSelector map[string]string,
+	name, namespace string,
+	selector map[string]string,
 	servicePort, targetPort int32,
-	replicas int32,
 	logger logr.Logger,
-) (*corev1.Service, *appsv1.Deployment, error) {
-	actualTargetPort := targetPort
-	var containerCommand []string
-	if strings.Contains(image, "nginx") {
-		actualTargetPort = 8080
-		containerCommand = []string{"sh", "-c", "sed -i 's/listen.*80;/listen 8080;/' /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"}
+	additionalLabels ...map[string]string,
+) (*corev1.Service, error) {
+	// Start with default labels
+	labels := map[string]string{
+		"app": name,
 	}
 
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-			Labels:    map[string]string{"app": name},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": name},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": name},
-				},
-				Spec: corev1.PodSpec{
-					NodeSelector: nodeSelector,
-					Containers: []corev1.Container{
-						{
-							Name:    name,
-							Image:   image,
-							Command: containerCommand,
-							Ports: []corev1.ContainerPort{
-								{ContainerPort: actualTargetPort, Protocol: corev1.ProtocolTCP},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	createdDeployment, err := k8s.AppsV1().Deployments("default").Create(ctx, deployment, metav1.CreateOptions{})
-	if err != nil {
-		return nil, nil, fmt.Errorf("creating deployment %s: %w", name, err)
+	// Add additional labels if provided
+	if len(additionalLabels) > 0 {
+		for _, labelMap := range additionalLabels {
+			for key, value := range labelMap {
+				labels[key] = value
+			}
+		}
 	}
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "default",
-			Labels:    map[string]string{"app": name},
+			Namespace: namespace,
+			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{"app": name},
+			Selector: selector,
 			Ports: []corev1.ServicePort{
 				{
-					Port:       8080,
-					TargetPort: intstr.FromInt(int(actualTargetPort)),
+					Port:       servicePort,
+					TargetPort: intstr.FromInt(int(targetPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
 		},
 	}
 
-	createdService, err := k8s.CoreV1().Services("default").Create(ctx, service, metav1.CreateOptions{})
+	createdService, err := k8s.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
-		return nil, nil, fmt.Errorf("creating service %s: %w", name, err)
+		return nil, fmt.Errorf("creating service %s: %w", name, err)
 	}
 
-	logger.Info("Created service with deployment", "name", name, "replicas", replicas)
-	return createdService, createdDeployment, nil
+	logger.Info("Created service", "name", name, "namespace", namespace)
+	return createdService, nil
 }
 
 // WaitForServiceReady waits for service endpoints to be ready
@@ -104,22 +73,37 @@ func WaitForServiceReady(ctx context.Context, k8s kubernetes.Interface, serviceN
 	logger.Info("Waiting for service endpoints", "service", serviceName)
 
 	_, err := ik8s.ListAndWait(ctx, 3*time.Minute, k8s.DiscoveryV1().EndpointSlices(namespace), func(endpointSlices *discoveryv1.EndpointSliceList) bool {
+		var totalEndpoints int
+		var readyEndpoints int
+
 		for _, slice := range endpointSlices.Items {
 			if ownerService, exists := slice.Labels["kubernetes.io/service-name"]; exists && ownerService == serviceName {
 				for _, endpoint := range slice.Endpoints {
+					totalEndpoints++
 					if endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready {
-						return true
+						readyEndpoints++
 					}
 				}
 			}
 		}
+
+		// Service is ready when all endpoints are ready
+		if totalEndpoints > 0 && readyEndpoints == totalEndpoints {
+			logger.Info("All service endpoints are ready", "service", serviceName, "ready", readyEndpoints, "total", totalEndpoints)
+			return true
+		}
+
+		if totalEndpoints > 0 {
+			logger.Info("Waiting for all service endpoints to be ready", "service", serviceName, "ready", readyEndpoints, "total", totalEndpoints)
+		}
+
 		return false
 	})
 	if err != nil {
 		return fmt.Errorf("service %s endpoints never became ready: %w", serviceName, err)
 	}
 
-	logger.Info("Service has endpoints", "service", serviceName)
+	logger.Info("Service has all endpoints ready", "service", serviceName)
 	return nil
 }
 
@@ -128,14 +112,14 @@ func TestServiceConnectivityWithRetries(ctx context.Context, config *restclient.
 	logger.Info("Testing service connectivity with retries", "from", clientPodName, "service", serviceName, "port", port)
 
 	serviceURL := fmt.Sprintf("http://%s:%d", serviceName, port)
-	cmd := []string{"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", serviceURL, "--connect-timeout", "30", "--max-time", "60"}
+	cmd := []string{"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", serviceURL, "--connect-timeout", "300", "--max-time", "420"}
 
-	_, err := ik8s.GetAndWait(ctx, 5*time.Minute, k8s.CoreV1().Pods(namespace), clientPodName, func(pod *corev1.Pod) bool {
+	_, err := ik8s.GetAndWait(ctx, 15*time.Minute, k8s.CoreV1().Pods(namespace), clientPodName, func(pod *corev1.Pod) bool {
 		if pod.Status.Phase != corev1.PodRunning {
 			return false
 		}
 
-		result, execErr := ExecInPod(ctx, config, k8s, clientPodName, namespace, cmd)
+		result, _, execErr := execPod(ctx, config, k8s, clientPodName, namespace, cmd...)
 		if execErr != nil {
 			logger.Info("Service connectivity test failed", "error", execErr.Error())
 			return false
@@ -175,5 +159,35 @@ func DeleteServiceAndWait(ctx context.Context, k8s kubernetes.Interface, service
 	}
 
 	logger.Info("Service fully deleted", "service", serviceName)
+	return nil
+}
+
+// ListServicesWithLabels lists services in a namespace that match the given label selector
+func ListServicesWithLabels(ctx context.Context, k8s kubernetes.Interface, namespace, labelSelector string) (*corev1.ServiceList, error) {
+	services, err := k8s.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list services with selector %s: %w", labelSelector, err)
+	}
+	return services, nil
+}
+
+// DeleteServicesWithLabels deletes all services in a namespace that match the given label selector
+func DeleteServicesWithLabels(ctx context.Context, k8s kubernetes.Interface, namespace, labelSelector string, logger logr.Logger) error {
+	logger.Info("Deleting services with label selector", "selector", labelSelector, "namespace", namespace)
+
+	services, err := ListServicesWithLabels(ctx, k8s, namespace, labelSelector)
+	if err != nil {
+		return fmt.Errorf("failed to list services with selector %s: %w", labelSelector, err)
+	}
+
+	for _, service := range services.Items {
+		if err := DeleteServiceAndWait(ctx, k8s, service.Name, namespace, logger); err != nil {
+			logger.Info("Service cleanup: resource not found or already deleted", "name", service.Name)
+		}
+	}
+
+	logger.Info("Completed services deletion", "selector", labelSelector, "count", len(services.Items))
 	return nil
 }

--- a/test/e2e/peered/cluster.go
+++ b/test/e2e/peered/cluster.go
@@ -18,6 +18,7 @@ type HybridCluster struct {
 	KubernetesVersion string
 	SubnetID          string
 	SecurityGroupID   string
+	SubnetIds         []string
 }
 
 // GetHybridCluster returns the hybrid cluster details.
@@ -34,6 +35,7 @@ func GetHybridCluster(ctx context.Context, eksClient *eks.Client, ec2Client *ec2
 
 	cluster.KubernetesVersion = *clusterDetails.Version
 	cluster.Arn = *clusterDetails.Arn
+	cluster.SubnetIds = clusterDetails.ResourcesVpcConfig.SubnetIds
 
 	hybridVpcID, err := findHybridVPC(ctx, ec2Client, *clusterDetails.ResourcesVpcConfig.VpcId)
 	if err != nil {

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -35,8 +35,8 @@ func (a *AddonEc2Test) NewNodeMonitoringAgentTest() *addon.NodeMonitoringAgentTe
 	labelReq, _ := labels.NewRequirement("os.bottlerocket.aws/version", selection.DoesNotExist, []string{})
 	return &addon.NodeMonitoringAgentTest{
 		Cluster:       a.Cluster.Name,
-		K8S:           a.k8sClient,
-		EKSClient:     a.eksClient,
+		K8S:           a.K8sClient,
+		EKSClient:     a.EKSClient,
 		K8SConfig:     a.K8sClientConfig,
 		Logger:        a.Logger,
 		Command:       defaultNodeMonitoringAgentCommand,
@@ -51,8 +51,8 @@ func (a *AddonEc2Test) NewVerifyPodIdentityAddon(nodeName string) *addon.VerifyP
 		Cluster:             a.Cluster.Name,
 		NodeName:            nodeName,
 		PodIdentityS3Bucket: a.podIdentityS3Bucket,
-		K8S:                 a.k8sClient,
-		EKSClient:           a.eksClient,
+		K8S:                 a.K8sClient,
+		EKSClient:           a.EKSClient,
 		IAMClient:           a.iamClient,
 		S3Client:            a.s3Client,
 		Logger:              a.Logger,
@@ -65,8 +65,8 @@ func (a *AddonEc2Test) NewVerifyPodIdentityAddon(nodeName string) *addon.VerifyP
 func (a *AddonEc2Test) NewKubeStateMetricsTest() *addon.KubeStateMetricsTest {
 	return &addon.KubeStateMetricsTest{
 		Cluster:   a.Cluster.Name,
-		K8S:       a.k8sClient,
-		EKSClient: a.eksClient,
+		K8S:       a.K8sClient,
+		EKSClient: a.EKSClient,
 		K8SConfig: a.K8sClientConfig,
 		Logger:    a.Logger,
 	}
@@ -80,8 +80,8 @@ func (a *AddonEc2Test) NewMetricsServerTest() *addon.MetricsServerTest {
 	}
 	return &addon.MetricsServerTest{
 		Cluster:       a.Cluster.Name,
-		K8S:           a.k8sClient,
-		EKSClient:     a.eksClient,
+		K8S:           a.K8sClient,
+		EKSClient:     a.EKSClient,
 		Logger:        a.Logger,
 		MetricsClient: metricsClient,
 	}
@@ -91,8 +91,8 @@ func (a *AddonEc2Test) NewMetricsServerTest() *addon.MetricsServerTest {
 func (a *AddonEc2Test) NewPrometheusNodeExporterTest() *addon.PrometheusNodeExporterTest {
 	return &addon.PrometheusNodeExporterTest{
 		Cluster:   a.Cluster.Name,
-		K8S:       a.k8sClient,
-		EKSClient: a.eksClient,
+		K8S:       a.K8sClient,
+		EKSClient: a.EKSClient,
 		K8SConfig: a.K8sClientConfig,
 		Logger:    a.Logger,
 	}
@@ -103,8 +103,8 @@ func (a *AddonEc2Test) NewNvidiaDevicePluginTest(nodeName string) *addon.NvidiaD
 	commandRunner := ssm.NewStandardLinuxSSHOnSSMCommandRunner(a.SSMClient, a.JumpboxInstanceId, a.Logger)
 	return &addon.NvidiaDevicePluginTest{
 		Cluster:       a.Cluster.Name,
-		K8S:           a.k8sClient,
-		EKSClient:     a.eksClient,
+		K8S:           a.K8sClient,
+		EKSClient:     a.EKSClient,
 		K8SConfig:     a.K8sClientConfig,
 		Logger:        a.Logger,
 		Command:       defaultNvidiaDevicePluginCommand,
@@ -141,8 +141,8 @@ func (a *AddonEc2Test) NewCertManagerTest(ctx context.Context) (*addon.CertManag
 	pcaIssuer := &addon.PCAIssuerTest{
 		Cluster:            a.Cluster.Name,
 		Namespace:          "cert-test",
-		K8S:                a.k8sClient,
-		EKSClient:          a.eksClient,
+		K8S:                a.K8sClient,
+		EKSClient:          a.EKSClient,
 		CertClient:         certClient,
 		K8sPcaClient:       k8sPcaClient,
 		PCAClient:          pcaClient,
@@ -153,8 +153,8 @@ func (a *AddonEc2Test) NewCertManagerTest(ctx context.Context) (*addon.CertManag
 
 	return &addon.CertManagerTest{
 		Cluster:        a.Cluster.Name,
-		K8S:            a.k8sClient,
-		EKSClient:      a.eksClient,
+		K8S:            a.K8sClient,
+		EKSClient:      a.EKSClient,
 		K8SConfig:      a.K8sClientConfig,
 		Logger:         a.Logger,
 		CertClient:     certClient,

--- a/test/e2e/suite/mixed_mode/mixed_mode_test.go
+++ b/test/e2e/suite/mixed_mode/mixed_mode_test.go
@@ -1,0 +1,408 @@
+//go:build e2e
+// +build e2e
+
+package mixed_mode
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	ec2v2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2v2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	smithyTime "github.com/aws/smithy-go/time"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/aws/eks-hybrid/test/e2e"
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+	"github.com/aws/eks-hybrid/test/e2e/suite"
+)
+
+var (
+	filePath    string
+	suiteConfig *suite.SuiteConfiguration
+
+	// Node selectors as constants
+	cloudNodeSelector  = map[string]string{"node.kubernetes.io/instance-type": "m5.large"}
+	hybridNodeSelector = map[string]string{"eks.amazonaws.com/compute-type": "hybrid"}
+)
+
+func init() {
+	flag.StringVar(&filePath, "filepath", "", "Path to configuration")
+}
+
+func TestMixedModeE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mixed Mode E2E Suite")
+}
+
+var _ = SynchronizedBeforeSuite(
+	// This function only runs once, on the first process
+	func(ctx context.Context) []byte {
+		suiteConfig := suite.BeforeSuiteCredentialSetup(ctx, filePath)
+
+		test := suite.BeforeVPCTest(ctx, &suiteConfig)
+		credentialProviders := suite.AddClientsToCredentialProviders(suite.CredentialProviders(), test)
+		osProviderList := suite.OSProviderList(credentialProviders)
+		randomOSProvider := osProviderList[rand.Intn(len(osProviderList))]
+
+		hybridNode := suite.NodeCreate{
+			InstanceName: "mixed-mode-hybrid",
+			InstanceSize: e2e.Large,
+			NodeName:     "mixed-mode-hybrid",
+			OS:           randomOSProvider.OS,
+			Provider:     randomOSProvider.Provider,
+			ComputeType:  e2e.CPUInstance,
+		}
+		suite.CreateNodes(ctx, test, []suite.NodeCreate{hybridNode})
+
+		Expect(test.CreateManagedNodeGroups(ctx)).To(Succeed(), "managed node group should be created successfully")
+
+		// Ensure mixed mode connectivity by adding required security group rules
+		err := ensureMixedModeConnectivity(ctx, test)
+		Expect(err).NotTo(HaveOccurred(), "Mixed mode connectivity rules should be added successfully")
+
+		suiteJson, err := yaml.Marshal(suiteConfig)
+		Expect(err).NotTo(HaveOccurred(), "suite config should be marshalled successfully")
+		return suiteJson
+	},
+	// This function runs on all processes
+	func(ctx context.Context, data []byte) {
+		// add a small sleep to add jitter to the start of each test
+		randomSleep := rand.Intn(10)
+		err := smithyTime.SleepWithContext(ctx, time.Duration(randomSleep)*time.Second)
+		Expect(err).NotTo(HaveOccurred(), "failed to sleep")
+		suiteConfig = suite.BeforeSuiteCredentialUnmarshal(ctx, data)
+	},
+)
+
+var _ = Describe("Mixed Mode Testing", func() {
+	When("hybrid and cloud-managed nodes coexist", func() {
+		var test *suite.PeeredVPCTest
+
+		BeforeEach(func(ctx context.Context) {
+			test = suite.BeforeVPCTest(ctx, suiteConfig)
+
+			// Comprehensive cleanup before each test
+			test.Logger.Info("Running comprehensive cleanup to ensure clean state")
+			cleanupTestResources(ctx, test)
+		})
+
+		AfterEach(func(ctx context.Context) {
+			test.Logger.Info("Running comprehensive cleanup after test")
+			cleanupTestResources(ctx, test)
+		})
+
+		Context("Pod-to-Pod Communication", func() {
+			It("should enable cross-VPC pod-to-pod communication from hybrid to cloud nodes", func(ctx context.Context) {
+				cloudPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nginx-cloud",
+						Namespace: "default",
+						Labels:    map[string]string{"app": "nginx-cloud"},
+					},
+					Spec: corev1.PodSpec{
+						NodeSelector: cloudNodeSelector,
+						Containers: []corev1.Container{{
+							Name:    "nginx-cloud",
+							Image:   "nginx:1.21",
+							Command: []string{"sh", "-c", "sed -i 's/listen.*80;/listen 8080;/' /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"},
+							Ports:   []corev1.ContainerPort{{ContainerPort: 8080, Protocol: corev1.ProtocolTCP}},
+						}},
+					},
+				}
+				err := kubernetes.CreatePod(ctx, test.K8sClient(), cloudPod, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "creating cloud pod")
+				test.Logger.Info("Cloud pod created and ready", "name", cloudPod.Name, "uid", cloudPod.UID)
+
+				clientPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-client-hybrid",
+						Namespace: "default",
+						Labels:    map[string]string{"app": "test-client-hybrid"},
+					},
+					Spec: corev1.PodSpec{
+						NodeSelector: hybridNodeSelector,
+						Containers: []corev1.Container{{
+							Name:    "test-client-hybrid",
+							Image:   "curlimages/curl:7.85.0",
+							Command: []string{"sleep", "3600"},
+						}},
+					},
+				}
+				err = kubernetes.CreatePod(ctx, test.K8sClient(), clientPod, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "creating client pod")
+				test.Logger.Info("Client pod created and ready", "name", clientPod.Name, "uid", clientPod.UID)
+
+				test.Logger.Info("Testing cross-VPC pod-to-pod connectivity (hybrid → cloud)")
+				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient(), clientPod.Name, cloudPod.Name, "default", test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "testing pod-to-pod connectivity")
+
+				test.Logger.Info("Cross-VPC pod-to-pod communication test completed successfully")
+			})
+
+			It("should enable cross-VPC pod-to-pod communication from cloud to hybrid nodes", func(ctx context.Context) {
+				hybridPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nginx-hybrid-reverse",
+						Namespace: "default",
+						Labels:    map[string]string{"app": "nginx-hybrid-reverse"},
+					},
+					Spec: corev1.PodSpec{
+						NodeSelector: hybridNodeSelector,
+						Containers: []corev1.Container{{
+							Name:    "nginx-hybrid-reverse",
+							Image:   "nginx:1.21",
+							Command: []string{"sh", "-c", "sed -i 's/listen.*80;/listen 8080;/' /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"},
+							Ports:   []corev1.ContainerPort{{ContainerPort: 8080, Protocol: corev1.ProtocolTCP}},
+						}},
+					},
+				}
+				err := kubernetes.CreatePod(ctx, test.K8sClient(), hybridPod, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "creating hybrid pod")
+				test.Logger.Info("Hybrid pod created and ready", "name", hybridPod.Name, "uid", hybridPod.UID)
+
+				clientPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-client-cloud",
+						Namespace: "default",
+						Labels:    map[string]string{"app": "test-client-cloud"},
+					},
+					Spec: corev1.PodSpec{
+						NodeSelector: cloudNodeSelector,
+						Containers: []corev1.Container{{
+							Name:    "test-client-cloud",
+							Image:   "curlimages/curl:7.85.0",
+							Command: []string{"sleep", "3600"},
+						}},
+					},
+				}
+				err = kubernetes.CreatePod(ctx, test.K8sClient(), clientPod, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "creating client pod")
+				test.Logger.Info("Cloud client pod created and ready", "name", clientPod.Name, "uid", clientPod.UID)
+
+				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient(), clientPod.Name, hybridPod.Name, "default", test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "testing pod-to-pod connectivity")
+
+				test.Logger.Info("Cross-VPC pod-to-pod communication test completed successfully")
+			})
+		})
+
+		Context("Cross-VPC Service Discovery", func() {
+			It("should enable cross-VPC service discovery from hybrid to cloud services", func(ctx context.Context) {
+				service, _, err := kubernetes.CreateServiceWithDeployment(ctx, test.K8sClient(), "nginx-service-cloud", "nginx:1.21", cloudNodeSelector, 80, 80, 1, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "creating service with deployment")
+
+				clientPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-client-hybrid-service",
+						Namespace: "default",
+						Labels:    map[string]string{"app": "test-client-hybrid-service"},
+					},
+					Spec: corev1.PodSpec{
+						NodeSelector: hybridNodeSelector,
+						Containers: []corev1.Container{{
+							Name:    "test-client-hybrid-service",
+							Image:   "curlimages/curl:7.85.0",
+							Command: []string{"sleep", "3600"},
+						}},
+					},
+				}
+				err = kubernetes.CreatePod(ctx, test.K8sClient(), clientPod, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "creating client pod")
+				test.Logger.Info("Client pod created and ready", "name", clientPod.Name, "uid", clientPod.UID)
+
+				err = kubernetes.WaitForServiceReady(ctx, test.K8sClient(), service.Name, "default", test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "waiting for service to be ready")
+
+				// Test service connectivity with integrated DNS resolution testing
+				err = kubernetes.TestServiceConnectivityWithRetries(ctx, test.K8sClientConfig, test.K8sClient(), clientPod.Name, service.Name, "default", 8080, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "testing service connectivity")
+
+				test.Logger.Info("Cross-VPC service discovery test (hybrid → cloud) completed successfully")
+			})
+
+			It("should enable cross-VPC service discovery from cloud to hybrid services", func(ctx context.Context) {
+				test.Logger.Info("Testing bidirectional service discovery (cloud → hybrid service)")
+				service, _, err := kubernetes.CreateServiceWithDeployment(ctx, test.K8sClient(), "nginx-service-hybrid", "nginx:1.21", hybridNodeSelector, 80, 80, 1, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "creating service with deployment")
+
+				clientPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-client-cloud-bidirectional",
+						Namespace: "default",
+						Labels:    map[string]string{"app": "test-client-cloud-bidirectional"},
+					},
+					Spec: corev1.PodSpec{
+						NodeSelector: cloudNodeSelector,
+						Containers: []corev1.Container{{
+							Name:    "test-client-cloud-bidirectional",
+							Image:   "curlimages/curl:7.85.0",
+							Command: []string{"sleep", "3600"},
+						}},
+					},
+				}
+				err = kubernetes.CreatePod(ctx, test.K8sClient(), clientPod, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "creating client pod")
+				test.Logger.Info("Client pod created and ready", "name", clientPod.Name, "uid", clientPod.UID)
+
+				err = kubernetes.WaitForServiceReady(ctx, test.K8sClient(), service.Name, "default", test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "waiting for service to be ready")
+
+				// Test service connectivity with integrated DNS resolution testing
+				err = kubernetes.TestServiceConnectivityWithRetries(ctx, test.K8sClientConfig, test.K8sClient(), clientPod.Name, service.Name, "default", 8080, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "testing service connectivity")
+
+				test.Logger.Info("Bidirectional service discovery test (cloud → hybrid) completed successfully")
+			})
+		})
+	})
+})
+
+// cleanupTestResources performs comprehensive cleanup
+func cleanupTestResources(ctx context.Context, test *suite.PeeredVPCTest) {
+	resourceNames := []string{
+		"nginx-cloud", "nginx-hybrid-reverse", "test-client-hybrid",
+		"test-client-cloud", "nginx-service-cloud", "nginx-service-hybrid",
+		"test-client-hybrid-service", "test-client-cloud-bidirectional",
+	}
+
+	for _, name := range resourceNames {
+
+		test.Logger.Info("Cleaning up pod ", "name", name)
+		if err := kubernetes.DeletePod(ctx, test.K8sClient(), name, "default"); err != nil {
+			test.Logger.Info("Pod cleanup: resource not found or already deleted", "name", name)
+		}
+
+		test.Logger.Info("Cleaning up service ", "name", name)
+		if err := kubernetes.DeleteServiceAndWait(ctx, test.K8sClient(), name, "default", test.Logger); err != nil {
+			test.Logger.Info("Service cleanup: resource not found or already deleted", "name", name)
+		}
+
+		test.Logger.Info("Cleaning up deployment ", "name", name)
+		if err := kubernetes.DeleteDeploymentAndWait(ctx, test.K8sClient(), name, "default", test.Logger); err != nil {
+			test.Logger.Info("Deployment cleanup: resource not found or already deleted", "name", name)
+		}
+	}
+
+	test.Logger.Info("Comprehensive cleanup completed ")
+}
+
+// ensureMixedModeConnectivity adds required security group rules for mixed mode testing
+func ensureMixedModeConnectivity(ctx context.Context, test *suite.PeeredVPCTest) error {
+	clusterName := test.Cluster.Name
+	cluster, err := test.EKSClient().DescribeCluster(ctx, &eks.DescribeClusterInput{
+		Name: &clusterName,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to describe cluster: %w", err)
+	}
+
+	clusterSG := cluster.Cluster.ResourcesVpcConfig.ClusterSecurityGroupId
+	if clusterSG == nil {
+		return fmt.Errorf("cluster security group ID not found")
+	}
+
+	test.Logger.Info("Found EKS cluster security group", "sgId", *clusterSG)
+
+	rules := []struct {
+		protocol string
+		port     int32
+		cidr     string
+		desc     string
+	}{
+		// HTTP connectivity for pod-to-pod and service tests
+		{"tcp", 8080, "10.1.0.0/16", "HTTP 8080 from hybrid VPC"},
+		{"tcp", 8080, "10.0.0.0/16", "HTTP 8080 from cloud VPC"},
+
+		// DNS resolution for both internal and external DNS
+		{"udp", 53, "10.1.0.0/16", "DNS UDP from hybrid VPC"},
+		{"tcp", 53, "10.1.0.0/16", "DNS TCP from hybrid VPC"},
+		{"udp", 53, "10.0.0.0/16", "DNS UDP from cloud VPC"},
+		{"tcp", 53, "10.0.0.0/16", "DNS TCP from cloud VPC"},
+	}
+
+	for _, rule := range rules {
+		ipPermission := &ec2v2types.IpPermission{
+			IpProtocol: &rule.protocol,
+			FromPort:   &rule.port,
+			ToPort:     &rule.port,
+			IpRanges: []ec2v2types.IpRange{
+				{CidrIp: &rule.cidr},
+			},
+		}
+		_, err := test.EC2Client().AuthorizeSecurityGroupIngress(ctx, &ec2v2.AuthorizeSecurityGroupIngressInput{
+			GroupId:       clusterSG,
+			IpPermissions: []ec2v2types.IpPermission{*ipPermission},
+		})
+
+		// Ignore "already exists" errors since rules might already be in place
+		if err != nil && !strings.Contains(err.Error(), "InvalidPermission.Duplicate") {
+			return fmt.Errorf("failed to add %s rule for %s: %w", rule.protocol, rule.cidr, err)
+		}
+
+	}
+
+	if err := ensureCoreDNSDistribution(ctx, test); err != nil {
+		test.Logger.Info("CoreDNS distribution configuration had issues - mixed mode will still work", "error", err.Error())
+	} else {
+		test.Logger.Info("CoreDNS distribution configured for optimal mixed mode performance")
+	}
+
+	return nil
+}
+
+// ensureCoreDNSDistribution configures CoreDNS for guaranteed 1+1 distribution
+func ensureCoreDNSDistribution(ctx context.Context, test *suite.PeeredVPCTest) error {
+	test.Logger.Info("Configuring CoreDNS for optimal mixed mode distribution (1+1)")
+
+	// Apply both topology spread constraint AND anti-affinity for guaranteed distribution
+	combinedPatch := `{
+		"spec": {
+			"replicas": 2,
+			"template": {
+				"spec": {
+					"topologySpreadConstraints": [
+						{
+							"maxSkew": 1,
+							"topologyKey": "eks.amazonaws.com/compute-type",
+							"whenUnsatisfiable": "ScheduleAnyway",
+							"labelSelector": {
+								"matchLabels": {"k8s-app": "kube-dns"}
+							}
+						}
+					],
+					"affinity": {
+						"podAntiAffinity": {
+							"requiredDuringSchedulingIgnoredDuringExecution": [
+								{
+									"labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
+									"topologyKey": "kubernetes.io/hostname"
+								}
+							]
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	_, err := test.K8sClient().AppsV1().Deployments("kube-system").Patch(ctx, "coredns",
+		types.MergePatchType, []byte(combinedPatch), metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to configure CoreDNS distribution: %w", err)
+	}
+
+	test.Logger.Info("CoreDNS configured for guaranteed 1+1 mixed mode distribution")
+	return nil
+}

--- a/test/e2e/suite/mixed_mode/mixed_mode_test.go
+++ b/test/e2e/suite/mixed_mode/mixed_mode_test.go
@@ -19,7 +19,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -32,10 +31,42 @@ var (
 	filePath    string
 	suiteConfig *suite.SuiteConfiguration
 
-	// Node selectors as constants
+	// Namespace constants
+	testNamespace = "default"
+
+	// Labels for mixed mode test resources
+	mixedModeLabels = map[string]string{
+		"test-suite": "mixed-mode",
+	}
+
+	// Network CIDR constants (match defaults from create.go)
+	cloudVPCCIDR  = "10.20.0.0/16"
+	hybridVPCCIDR = "10.80.0.0/16"
+	podCIDR       = "10.87.0.0/16"
+
+	// Port constants
+	httpPort int32 = 80
+	dnsPort  int32 = 53
+
+	// Timing constants
+	crossVPCPropagationWait = 120 * time.Second
+
+	// Node selector constants
 	cloudNodeSelector  = map[string]string{"node.kubernetes.io/instance-type": "m5.large"}
 	hybridNodeSelector = map[string]string{"eks.amazonaws.com/compute-type": "hybrid"}
+
+	// Node label constants (derived from selectors)
+	cloudNodeLabelKey, cloudNodeLabelValue   = getFirstKeyValue(cloudNodeSelector)
+	hybridNodeLabelKey, hybridNodeLabelValue = getFirstKeyValue(hybridNodeSelector)
 )
+
+// getFirstKeyValue extracts the first key-value pair from a map
+func getFirstKeyValue(selector map[string]string) (string, string) {
+	for k, v := range selector {
+		return k, v
+	}
+	return "", ""
+}
 
 func init() {
 	flag.StringVar(&filePath, "filepath", "", "Path to configuration")
@@ -95,103 +126,53 @@ var _ = Describe("Mixed Mode Testing", func() {
 
 			// Comprehensive cleanup before each test
 			test.Logger.Info("Running comprehensive cleanup to ensure clean state")
-			cleanupTestResources(ctx, test)
+			cleanupTestResources(ctx, test, mixedModeLabels)
 		})
 
 		AfterEach(func(ctx context.Context) {
 			test.Logger.Info("Running comprehensive cleanup after test")
-			cleanupTestResources(ctx, test)
+			cleanupTestResources(ctx, test, mixedModeLabels)
 		})
 
 		Context("Pod-to-Pod Communication", func() {
 			It("should enable cross-VPC pod-to-pod communication from hybrid to cloud nodes", func(ctx context.Context) {
-				cloudPod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "nginx-cloud",
-						Namespace: "default",
-						Labels:    map[string]string{"app": "nginx-cloud"},
-					},
-					Spec: corev1.PodSpec{
-						NodeSelector: cloudNodeSelector,
-						Containers: []corev1.Container{{
-							Name:    "nginx-cloud",
-							Image:   "nginx:1.21",
-							Command: []string{"sh", "-c", "sed -i 's/listen.*80;/listen 8080;/' /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"},
-							Ports:   []corev1.ContainerPort{{ContainerPort: 8080, Protocol: corev1.ProtocolTCP}},
-						}},
-					},
-				}
-				err := kubernetes.CreatePod(ctx, test.K8sClient(), cloudPod, test.Logger)
-				Expect(err).NotTo(HaveOccurred(), "creating cloud pod")
-				test.Logger.Info("Cloud pod created and ready", "name", cloudPod.Name, "uid", cloudPod.UID)
+				// Find cloud node and create nginx pod
+				cloudNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, cloudNodeLabelKey, cloudNodeLabelValue, test.Logger)
 
-				clientPod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-client-hybrid",
-						Namespace: "default",
-						Labels:    map[string]string{"app": "test-client-hybrid"},
-					},
-					Spec: corev1.PodSpec{
-						NodeSelector: hybridNodeSelector,
-						Containers: []corev1.Container{{
-							Name:    "test-client-hybrid",
-							Image:   "curlimages/curl:7.85.0",
-							Command: []string{"sleep", "3600"},
-						}},
-					},
-				}
-				err = kubernetes.CreatePod(ctx, test.K8sClient(), clientPod, test.Logger)
+				err := kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, testNamespace, test.Cluster.Region, test.Logger, "nginx-cloud", mixedModeLabels)
+				Expect(err).NotTo(HaveOccurred(), "creating cloud pod")
+				test.Logger.Info("Cloud pod created and ready", "name", "nginx-cloud")
+
+				// Find hybrid node and create client nginx pod
+				hybridNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
+
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, testNamespace, test.Cluster.Region, test.Logger, "test-client-hybrid", mixedModeLabels)
 				Expect(err).NotTo(HaveOccurred(), "creating client pod")
-				test.Logger.Info("Client pod created and ready", "name", clientPod.Name, "uid", clientPod.UID)
+				test.Logger.Info("Client pod created and ready", "name", "test-client-hybrid")
 
 				test.Logger.Info("Testing cross-VPC pod-to-pod connectivity (hybrid → cloud)")
-				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient(), clientPod.Name, cloudPod.Name, "default", test.Logger)
+				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "test-client-hybrid", "nginx-cloud", testNamespace, test.Logger)
 				Expect(err).NotTo(HaveOccurred(), "testing pod-to-pod connectivity")
 
 				test.Logger.Info("Cross-VPC pod-to-pod communication test completed successfully")
 			})
 
 			It("should enable cross-VPC pod-to-pod communication from cloud to hybrid nodes", func(ctx context.Context) {
-				hybridPod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "nginx-hybrid-reverse",
-						Namespace: "default",
-						Labels:    map[string]string{"app": "nginx-hybrid-reverse"},
-					},
-					Spec: corev1.PodSpec{
-						NodeSelector: hybridNodeSelector,
-						Containers: []corev1.Container{{
-							Name:    "nginx-hybrid-reverse",
-							Image:   "nginx:1.21",
-							Command: []string{"sh", "-c", "sed -i 's/listen.*80;/listen 8080;/' /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"},
-							Ports:   []corev1.ContainerPort{{ContainerPort: 8080, Protocol: corev1.ProtocolTCP}},
-						}},
-					},
-				}
-				err := kubernetes.CreatePod(ctx, test.K8sClient(), hybridPod, test.Logger)
+				// Find hybrid node and create nginx pod
+				hybridNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
+
+				err := kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, testNamespace, test.Cluster.Region, test.Logger, "nginx-hybrid-reverse", mixedModeLabels)
 				Expect(err).NotTo(HaveOccurred(), "creating hybrid pod")
-				test.Logger.Info("Hybrid pod created and ready", "name", hybridPod.Name, "uid", hybridPod.UID)
+				test.Logger.Info("Hybrid pod created and ready", "name", "nginx-hybrid-reverse")
 
-				clientPod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-client-cloud",
-						Namespace: "default",
-						Labels:    map[string]string{"app": "test-client-cloud"},
-					},
-					Spec: corev1.PodSpec{
-						NodeSelector: cloudNodeSelector,
-						Containers: []corev1.Container{{
-							Name:    "test-client-cloud",
-							Image:   "curlimages/curl:7.85.0",
-							Command: []string{"sleep", "3600"},
-						}},
-					},
-				}
-				err = kubernetes.CreatePod(ctx, test.K8sClient(), clientPod, test.Logger)
+				// Find cloud node and create client nginx pod
+				cloudNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, cloudNodeLabelKey, cloudNodeLabelValue, test.Logger)
+
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, testNamespace, test.Cluster.Region, test.Logger, "test-client-cloud", mixedModeLabels)
 				Expect(err).NotTo(HaveOccurred(), "creating client pod")
-				test.Logger.Info("Cloud client pod created and ready", "name", clientPod.Name, "uid", clientPod.UID)
+				test.Logger.Info("Cloud client pod created and ready", "name", "test-client-cloud")
 
-				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient(), clientPod.Name, hybridPod.Name, "default", test.Logger)
+				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "test-client-cloud", "nginx-hybrid-reverse", testNamespace, test.Logger)
 				Expect(err).NotTo(HaveOccurred(), "testing pod-to-pod connectivity")
 
 				test.Logger.Info("Cross-VPC pod-to-pod communication test completed successfully")
@@ -200,33 +181,30 @@ var _ = Describe("Mixed Mode Testing", func() {
 
 		Context("Cross-VPC Service Discovery", func() {
 			It("should enable cross-VPC service discovery from hybrid to cloud services", func(ctx context.Context) {
-				service, _, err := kubernetes.CreateServiceWithDeployment(ctx, test.K8sClient(), "nginx-service-cloud", "nginx:1.21", cloudNodeSelector, 80, 80, 1, test.Logger)
-				Expect(err).NotTo(HaveOccurred(), "creating service with deployment")
+				// Create deployment
+				_, err := kubernetes.CreateDeployment(ctx, test.K8sClient.Interface, "nginx-service-cloud", testNamespace, test.Cluster.Region, cloudNodeSelector, httpPort, 1, test.Logger, mixedModeLabels)
+				Expect(err).NotTo(HaveOccurred(), "creating deployment")
 
-				clientPod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-client-hybrid-service",
-						Namespace: "default",
-						Labels:    map[string]string{"app": "test-client-hybrid-service"},
-					},
-					Spec: corev1.PodSpec{
-						NodeSelector: hybridNodeSelector,
-						Containers: []corev1.Container{{
-							Name:    "test-client-hybrid-service",
-							Image:   "curlimages/curl:7.85.0",
-							Command: []string{"sleep", "3600"},
-						}},
-					},
-				}
-				err = kubernetes.CreatePod(ctx, test.K8sClient(), clientPod, test.Logger)
+				// Create service (port 80 to target port 80)
+				service, err := kubernetes.CreateService(ctx, test.K8sClient.Interface, "nginx-service-cloud", testNamespace, map[string]string{"app": "nginx-service-cloud"}, httpPort, httpPort, test.Logger, mixedModeLabels)
+				Expect(err).NotTo(HaveOccurred(), "creating service")
+
+				// Find hybrid node and create client nginx pod
+				hybridNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
+
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, testNamespace, test.Cluster.Region, test.Logger, "test-client-hybrid-service", mixedModeLabels)
 				Expect(err).NotTo(HaveOccurred(), "creating client pod")
-				test.Logger.Info("Client pod created and ready", "name", clientPod.Name, "uid", clientPod.UID)
+				test.Logger.Info("Client pod created and ready", "name", "test-client-hybrid-service")
 
-				err = kubernetes.WaitForServiceReady(ctx, test.K8sClient(), service.Name, "default", test.Logger)
+				err = kubernetes.WaitForServiceReady(ctx, test.K8sClient.Interface, service.Name, testNamespace, test.Logger)
 				Expect(err).NotTo(HaveOccurred(), "waiting for service to be ready")
 
-				// Test service connectivity with integrated DNS resolution testing
-				err = kubernetes.TestServiceConnectivityWithRetries(ctx, test.K8sClientConfig, test.K8sClient(), clientPod.Name, service.Name, "default", 8080, test.Logger)
+				// Allow time for network rules and DNS to fully propagate across VPCs
+				test.Logger.Info("Waiting for network rules and DNS to propagate across VPCs")
+				time.Sleep(crossVPCPropagationWait)
+
+				// Test service connectivity with integrated DNS resolution testing (port 80)
+				err = kubernetes.TestServiceConnectivityWithRetries(ctx, test.K8sClientConfig, test.K8sClient.Interface, "test-client-hybrid-service", service.Name, testNamespace, httpPort, test.Logger)
 				Expect(err).NotTo(HaveOccurred(), "testing service connectivity")
 
 				test.Logger.Info("Cross-VPC service discovery test (hybrid → cloud) completed successfully")
@@ -234,33 +212,27 @@ var _ = Describe("Mixed Mode Testing", func() {
 
 			It("should enable cross-VPC service discovery from cloud to hybrid services", func(ctx context.Context) {
 				test.Logger.Info("Testing bidirectional service discovery (cloud → hybrid service)")
-				service, _, err := kubernetes.CreateServiceWithDeployment(ctx, test.K8sClient(), "nginx-service-hybrid", "nginx:1.21", hybridNodeSelector, 80, 80, 1, test.Logger)
-				Expect(err).NotTo(HaveOccurred(), "creating service with deployment")
 
-				clientPod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-client-cloud-bidirectional",
-						Namespace: "default",
-						Labels:    map[string]string{"app": "test-client-cloud-bidirectional"},
-					},
-					Spec: corev1.PodSpec{
-						NodeSelector: cloudNodeSelector,
-						Containers: []corev1.Container{{
-							Name:    "test-client-cloud-bidirectional",
-							Image:   "curlimages/curl:7.85.0",
-							Command: []string{"sleep", "3600"},
-						}},
-					},
-				}
-				err = kubernetes.CreatePod(ctx, test.K8sClient(), clientPod, test.Logger)
+				_, err := kubernetes.CreateDeployment(ctx, test.K8sClient.Interface, "nginx-service-hybrid", testNamespace, test.Cluster.Region, hybridNodeSelector, httpPort, 1, test.Logger, mixedModeLabels)
+				Expect(err).NotTo(HaveOccurred(), "creating deployment")
+
+				service, err := kubernetes.CreateService(ctx, test.K8sClient.Interface, "nginx-service-hybrid", testNamespace, map[string]string{"app": "nginx-service-hybrid"}, httpPort, httpPort, test.Logger, mixedModeLabels)
+				Expect(err).NotTo(HaveOccurred(), "creating service")
+
+				// Find cloud node and create client nginx pod
+				cloudNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, cloudNodeLabelKey, cloudNodeLabelValue, test.Logger)
+
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, testNamespace, test.Cluster.Region, test.Logger, "test-client-cloud-bidirectional", mixedModeLabels)
 				Expect(err).NotTo(HaveOccurred(), "creating client pod")
-				test.Logger.Info("Client pod created and ready", "name", clientPod.Name, "uid", clientPod.UID)
+				test.Logger.Info("Client pod created and ready", "name", "test-client-cloud-bidirectional")
 
-				err = kubernetes.WaitForServiceReady(ctx, test.K8sClient(), service.Name, "default", test.Logger)
+				err = kubernetes.WaitForServiceReady(ctx, test.K8sClient.Interface, service.Name, testNamespace, test.Logger)
 				Expect(err).NotTo(HaveOccurred(), "waiting for service to be ready")
-
-				// Test service connectivity with integrated DNS resolution testing
-				err = kubernetes.TestServiceConnectivityWithRetries(ctx, test.K8sClientConfig, test.K8sClient(), clientPod.Name, service.Name, "default", 8080, test.Logger)
+				// Allow time for network rules and DNS to fully propagate across VPCs
+				test.Logger.Info("Waiting for network rules and DNS to propagate across VPCs")
+				time.Sleep(crossVPCPropagationWait)
+				// Test service connectivity with integrated DNS resolution testing (port 80)
+				err = kubernetes.TestServiceConnectivityWithRetries(ctx, test.K8sClientConfig, test.K8sClient.Interface, "test-client-cloud-bidirectional", service.Name, testNamespace, httpPort, test.Logger)
 				Expect(err).NotTo(HaveOccurred(), "testing service connectivity")
 
 				test.Logger.Info("Bidirectional service discovery test (cloud → hybrid) completed successfully")
@@ -269,51 +241,44 @@ var _ = Describe("Mixed Mode Testing", func() {
 	})
 })
 
-// cleanupTestResources performs comprehensive cleanup
-func cleanupTestResources(ctx context.Context, test *suite.PeeredVPCTest) {
-	resourceNames := []string{
-		"nginx-cloud", "nginx-hybrid-reverse", "test-client-hybrid",
-		"test-client-cloud", "nginx-service-cloud", "nginx-service-hybrid",
-		"test-client-hybrid-service", "test-client-cloud-bidirectional",
+// cleanupTestResources performs comprehensive cleanup using provided labels
+func cleanupTestResources(ctx context.Context, test *suite.PeeredVPCTest, labels map[string]string) {
+	// Construct label selector from provided labels map
+	var labelParts []string
+	for key, value := range labels {
+		labelParts = append(labelParts, fmt.Sprintf("%s=%s", key, value))
+	}
+	labelSelector := strings.Join(labelParts, ",")
+
+	test.Logger.Info("Starting comprehensive cleanup using label", "selector", labelSelector)
+
+	// Clean up pods
+	err := kubernetes.DeletePodsWithLabels(ctx, test.K8sClient.Interface, testNamespace, labelSelector, test.Logger)
+	if err != nil {
+		test.Logger.Info("Failed to delete pods with selector", "selector", labelSelector, "error", err.Error())
 	}
 
-	for _, name := range resourceNames {
-
-		test.Logger.Info("Cleaning up pod ", "name", name)
-		if err := kubernetes.DeletePod(ctx, test.K8sClient(), name, "default"); err != nil {
-			test.Logger.Info("Pod cleanup: resource not found or already deleted", "name", name)
-		}
-
-		test.Logger.Info("Cleaning up service ", "name", name)
-		if err := kubernetes.DeleteServiceAndWait(ctx, test.K8sClient(), name, "default", test.Logger); err != nil {
-			test.Logger.Info("Service cleanup: resource not found or already deleted", "name", name)
-		}
-
-		test.Logger.Info("Cleaning up deployment ", "name", name)
-		if err := kubernetes.DeleteDeploymentAndWait(ctx, test.K8sClient(), name, "default", test.Logger); err != nil {
-			test.Logger.Info("Deployment cleanup: resource not found or already deleted", "name", name)
-		}
+	// Clean up services
+	err = kubernetes.DeleteServicesWithLabels(ctx, test.K8sClient.Interface, testNamespace, labelSelector, test.Logger)
+	if err != nil {
+		test.Logger.Info("Failed to delete services with selector", "selector", labelSelector, "error", err.Error())
 	}
 
-	test.Logger.Info("Comprehensive cleanup completed ")
+	// Clean up deployments
+	err = kubernetes.DeleteDeploymentsWithLabels(ctx, test.K8sClient.Interface, testNamespace, labelSelector, test.Logger)
+	if err != nil {
+		test.Logger.Info("Failed to delete deployments with selector", "selector", labelSelector, "error", err.Error())
+	}
+
+	test.Logger.Info("Comprehensive cleanup completed", "selector", labelSelector)
 }
 
 // ensureMixedModeConnectivity adds required security group rules for mixed mode testing
 func ensureMixedModeConnectivity(ctx context.Context, test *suite.PeeredVPCTest) error {
-	clusterName := test.Cluster.Name
-	cluster, err := test.EKSClient().DescribeCluster(ctx, &eks.DescribeClusterInput{
-		Name: &clusterName,
-	})
+	clusterSG, hybridSG, err := getSecurityGroupsForMixedMode(ctx, test)
 	if err != nil {
-		return fmt.Errorf("failed to describe cluster: %w", err)
+		return fmt.Errorf("failed to get security groups: %w", err)
 	}
-
-	clusterSG := cluster.Cluster.ResourcesVpcConfig.ClusterSecurityGroupId
-	if clusterSG == nil {
-		return fmt.Errorf("cluster security group ID not found")
-	}
-
-	test.Logger.Info("Found EKS cluster security group", "sgId", *clusterSG)
 
 	rules := []struct {
 		protocol string
@@ -322,35 +287,42 @@ func ensureMixedModeConnectivity(ctx context.Context, test *suite.PeeredVPCTest)
 		desc     string
 	}{
 		// HTTP connectivity for pod-to-pod and service tests
-		{"tcp", 8080, "10.1.0.0/16", "HTTP 8080 from hybrid VPC"},
-		{"tcp", 8080, "10.0.0.0/16", "HTTP 8080 from cloud VPC"},
-
-		// DNS resolution for both internal and external DNS
-		{"udp", 53, "10.1.0.0/16", "DNS UDP from hybrid VPC"},
-		{"tcp", 53, "10.1.0.0/16", "DNS TCP from hybrid VPC"},
-		{"udp", 53, "10.0.0.0/16", "DNS UDP from cloud VPC"},
-		{"tcp", 53, "10.0.0.0/16", "DNS TCP from cloud VPC"},
+		{"tcp", httpPort, cloudVPCCIDR, "HTTP 80 from cloud VPC"},
+		{"tcp", httpPort, podCIDR, "HTTP 80 from pod CIDR"},
+		{"tcp", httpPort, hybridVPCCIDR, "HTTP 80 from hybrid subnet"},
+		// DNS connectivity for cross-VPC CoreDNS resolution
+		{"tcp", dnsPort, cloudVPCCIDR, "DNS TCP from cloud VPC"},
+		{"udp", dnsPort, cloudVPCCIDR, "DNS UDP from cloud VPC"},
+		{"tcp", dnsPort, podCIDR, "DNS TCP from pod CIDR"},
+		{"udp", dnsPort, podCIDR, "DNS UDP from pod CIDR"},
+		{"tcp", dnsPort, hybridVPCCIDR, "DNS TCP from hybrid subnet"},
+		{"udp", dnsPort, hybridVPCCIDR, "DNS UDP from hybrid subnet"},
 	}
 
-	for _, rule := range rules {
-		ipPermission := &ec2v2types.IpPermission{
-			IpProtocol: &rule.protocol,
-			FromPort:   &rule.port,
-			ToPort:     &rule.port,
-			IpRanges: []ec2v2types.IpRange{
-				{CidrIp: &rule.cidr},
-			},
-		}
-		_, err := test.EC2Client().AuthorizeSecurityGroupIngress(ctx, &ec2v2.AuthorizeSecurityGroupIngressInput{
-			GroupId:       clusterSG,
-			IpPermissions: []ec2v2types.IpPermission{*ipPermission},
-		})
+	// Apply rules to both cluster security group and hybrid node security group
+	securityGroups := []*string{clusterSG, hybridSG}
 
-		// Ignore "already exists" errors since rules might already be in place
-		if err != nil && !strings.Contains(err.Error(), "InvalidPermission.Duplicate") {
-			return fmt.Errorf("failed to add %s rule for %s: %w", rule.protocol, rule.cidr, err)
-		}
+	for _, sg := range securityGroups {
+		test.Logger.Info("Adding security group rules", "sgId", *sg)
+		for _, rule := range rules {
+			ipPermission := &ec2v2types.IpPermission{
+				IpProtocol: &rule.protocol,
+				FromPort:   &rule.port,
+				ToPort:     &rule.port,
+				IpRanges: []ec2v2types.IpRange{
+					{CidrIp: &rule.cidr},
+				},
+			}
+			_, err := test.EC2Client.AuthorizeSecurityGroupIngress(ctx, &ec2v2.AuthorizeSecurityGroupIngressInput{
+				GroupId:       sg,
+				IpPermissions: []ec2v2types.IpPermission{*ipPermission},
+			})
 
+			// Ignore "already exists" errors since rules might already be in place
+			if err != nil && !strings.Contains(err.Error(), "InvalidPermission.Duplicate") {
+				return fmt.Errorf("failed to add %s rule for %s on SG %s: %w", rule.protocol, rule.cidr, *sg, err)
+			}
+		}
 	}
 
 	if err := ensureCoreDNSDistribution(ctx, test); err != nil {
@@ -362,32 +334,111 @@ func ensureMixedModeConnectivity(ctx context.Context, test *suite.PeeredVPCTest)
 	return nil
 }
 
-// ensureCoreDNSDistribution configures CoreDNS for guaranteed 1+1 distribution
-func ensureCoreDNSDistribution(ctx context.Context, test *suite.PeeredVPCTest) error {
-	test.Logger.Info("Configuring CoreDNS for optimal mixed mode distribution (1+1)")
+// getSecurityGroupsForMixedMode returns both cluster and hybrid node security groups
+func getSecurityGroupsForMixedMode(ctx context.Context, test *suite.PeeredVPCTest) (*string, *string, error) {
+	clusterName := test.Cluster.Name
+	cluster, err := test.EKSClient.DescribeCluster(ctx, &eks.DescribeClusterInput{
+		Name: &clusterName,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to describe cluster: %w", err)
+	}
 
-	// Apply both topology spread constraint AND anti-affinity for guaranteed distribution
-	combinedPatch := `{
+	clusterSG := cluster.Cluster.ResourcesVpcConfig.ClusterSecurityGroupId
+	if clusterSG == nil {
+		return nil, nil, fmt.Errorf("cluster security group ID not found")
+	}
+
+	test.Logger.Info("Found EKS cluster security group", "sgId", *clusterSG)
+
+	hybridSG, err := findHybridNodeSecurityGroup(ctx, test)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to find hybrid node security group: %w", err)
+	}
+
+	test.Logger.Info("Found hybrid node security group", "sgId", hybridSG)
+	return clusterSG, &hybridSG, nil
+}
+
+// findHybridNodeSecurityGroup finds the security group of the hybrid node
+func findHybridNodeSecurityGroup(ctx context.Context, test *suite.PeeredVPCTest) (string, error) {
+	// Find hybrid node instance by name tag (created with InstanceName: "mixed-mode-hybrid")
+	instances, err := test.EC2Client.DescribeInstances(ctx, &ec2v2.DescribeInstancesInput{
+		Filters: []ec2v2types.Filter{
+			{
+				Name:   &[]string{"tag:Name"}[0],
+				Values: []string{"mixed-mode-hybrid"},
+			},
+			{
+				Name:   &[]string{"instance-state-name"}[0],
+				Values: []string{"running"},
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to describe instances: %w", err)
+	}
+
+	if len(instances.Reservations) == 0 || len(instances.Reservations[0].Instances) == 0 {
+		return "", fmt.Errorf("no hybrid node instance found with name 'mixed-mode-hybrid'")
+	}
+
+	instance := instances.Reservations[0].Instances[0]
+	if len(instance.SecurityGroups) == 0 {
+		return "", fmt.Errorf("no security groups found for hybrid node instance %s", *instance.InstanceId)
+	}
+
+	return *instance.SecurityGroups[0].GroupId, nil
+}
+
+// ensureCoreDNSDistribution configures CoreDNS for optimal mixed mode distribution using AWS best practices
+func ensureCoreDNSDistribution(ctx context.Context, test *suite.PeeredVPCTest) error {
+	test.Logger.Info("Configuring CoreDNS distribution using AWS best practices")
+
+	// Step 1: Label hybrid nodes with topology.kubernetes.io/zone=onprem
+	err := labelHybridNodesForTopology(ctx, test)
+	if err != nil {
+		return fmt.Errorf("failed to label hybrid nodes: %w", err)
+	}
+
+	// Step 2: Apply AWS recommended preferred anti-affinity configuration
+	coreDNSPatch := `{
 		"spec": {
 			"replicas": 2,
 			"template": {
 				"spec": {
-					"topologySpreadConstraints": [
-						{
-							"maxSkew": 1,
-							"topologyKey": "eks.amazonaws.com/compute-type",
-							"whenUnsatisfiable": "ScheduleAnyway",
-							"labelSelector": {
-								"matchLabels": {"k8s-app": "kube-dns"}
-							}
-						}
-					],
 					"affinity": {
 						"podAntiAffinity": {
-							"requiredDuringSchedulingIgnoredDuringExecution": [
+							"preferredDuringSchedulingIgnoredDuringExecution": [
 								{
-									"labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
-									"topologyKey": "kubernetes.io/hostname"
+									"weight": 100,
+									"podAffinityTerm": {
+										"labelSelector": {
+											"matchExpressions": [
+												{
+													"key": "k8s-app",
+													"operator": "In",
+													"values": ["kube-dns"]
+												}
+											]
+										},
+										"topologyKey": "kubernetes.io/hostname"
+									}
+								},
+								{
+									"weight": 50,
+									"podAffinityTerm": {
+										"labelSelector": {
+											"matchExpressions": [
+												{
+													"key": "k8s-app",
+													"operator": "In", 
+													"values": ["kube-dns"]
+												}
+											]
+										},
+										"topologyKey": "topology.kubernetes.io/zone"
+									}
 								}
 							]
 						}
@@ -397,12 +448,59 @@ func ensureCoreDNSDistribution(ctx context.Context, test *suite.PeeredVPCTest) e
 		}
 	}`
 
-	_, err := test.K8sClient().AppsV1().Deployments("kube-system").Patch(ctx, "coredns",
-		types.MergePatchType, []byte(combinedPatch), metav1.PatchOptions{})
+	_, err = test.K8sClient.Interface.AppsV1().Deployments("kube-system").Patch(ctx, "coredns",
+		types.MergePatchType, []byte(coreDNSPatch), metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to configure CoreDNS distribution: %w", err)
+		return fmt.Errorf("failed to configure CoreDNS preferred anti-affinity: %w", err)
 	}
 
-	test.Logger.Info("CoreDNS configured for guaranteed 1+1 mixed mode distribution")
+	// Step 3: Configure kube-dns service for traffic distribution
+	serviceTrafficPatch := `{
+		"spec": {
+			"trafficDistribution": "PreferClose"
+		}
+	}`
+
+	_, err = test.K8sClient.Interface.CoreV1().Services("kube-system").Patch(ctx, "kube-dns",
+		types.MergePatchType, []byte(serviceTrafficPatch), metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to configure kube-dns traffic distribution: %w", err)
+	}
+
+	test.Logger.Info("CoreDNS configured with AWS best practices: preferred anti-affinity, traffic distribution, and optimal pod placement")
+	return nil
+}
+
+// labelHybridNodesForTopology adds topology.kubernetes.io/zone=onprem label to hybrid nodes
+func labelHybridNodesForTopology(ctx context.Context, test *suite.PeeredVPCTest) error {
+	// Find all hybrid nodes
+	nodes, err := kubernetes.ListNodesWithLabels(ctx, test.K8sClient.Interface, "eks.amazonaws.com/compute-type=hybrid")
+	if err != nil {
+		return fmt.Errorf("failed to list hybrid nodes: %w", err)
+	}
+
+	if len(nodes.Items) == 0 {
+		test.Logger.Info("No hybrid nodes found to label")
+		return nil
+	}
+
+	// Label each hybrid node with topology zone
+	for _, node := range nodes.Items {
+		labelPatch := `{
+			"metadata": {
+				"labels": {
+					"topology.kubernetes.io/zone": "onprem"
+				}
+			}
+		}`
+
+		err = kubernetes.PatchNode(ctx, test.K8sClient.Interface, node.Name, []byte(labelPatch), test.Logger)
+		if err != nil {
+			return fmt.Errorf("failed to label hybrid node %s: %w", node.Name, err)
+		}
+
+		test.Logger.Info("Labeled hybrid node with topology zone", "node", node.Name, "zone", "onprem")
+	}
+
 	return nil
 }

--- a/test/integration/cases/containerd-config/run.sh
+++ b/test/integration/cases/containerd-config/run.sh
@@ -7,7 +7,7 @@ set -o pipefail
 source /helpers.sh
 
 mock::aws
-mock::kubelet 1.27.0
+mock::kubelet 1.28.0
 wait::dbus-ready
 
 nodeadm init --skip run,install-validation --config-source file://config.yaml

--- a/test/integration/cases/image-credential-provider/run.sh
+++ b/test/integration/cases/image-credential-provider/run.sh
@@ -15,7 +15,7 @@ nodeadm init --skip run,install-validation --config-source file://config.yaml
 
 assert::json-files-equal /etc/eks/image-credential-provider/config.json expected-image-credential-provider-config-126.json
 
-mock::kubelet 1.27.0
+mock::kubelet 1.28.0
 
 nodeadm init --skip run,install-validation --config-source file://config.yaml
 

--- a/test/integration/cases/kubelet-config-new-instance-type/expected-kubelet-config.json
+++ b/test/integration/cases/kubelet-config-new-instance-type/expected-kubelet-config.json
@@ -26,7 +26,6 @@
     "clusterDomain": "cluster.local",
     "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
     "featureGates": {
-        "KubeletCredentialProviders": true,
         "RotateKubeletServerCertificate": true
     },
     "hairpinMode": "hairpin-veth",

--- a/test/integration/cases/kubelet-config-new-instance-type/run.sh
+++ b/test/integration/cases/kubelet-config-new-instance-type/run.sh
@@ -9,7 +9,7 @@ source /helpers.sh
 config_path=/tmp/aemm-default-config.json
 cat /etc/aemm-default-config.json | jq '.metadata.values."instance-type" = "mock-type.large" | .dynamic.values."instance-identity-document".instanceType = "mock-type.large"' | tee ${config_path}
 mock::aws ${config_path}
-mock::kubelet 1.27.0
+mock::kubelet 1.28.0
 wait::dbus-ready
 
 for config in config.*; do

--- a/test/integration/cases/kubelet-config-set-empty/expected-kubelet-config.json
+++ b/test/integration/cases/kubelet-config-set-empty/expected-kubelet-config.json
@@ -26,7 +26,6 @@
     "clusterDomain": "cluster.local",
     "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
     "featureGates": {
-        "KubeletCredentialProviders": true,
         "RotateKubeletServerCertificate": true
     },
     "hairpinMode": "hairpin-veth",

--- a/test/integration/cases/kubelet-config-set-empty/run.sh
+++ b/test/integration/cases/kubelet-config-set-empty/run.sh
@@ -7,7 +7,7 @@ set -o pipefail
 source /helpers.sh
 
 mock::aws
-mock::kubelet 1.27.0
+mock::kubelet 1.28.0
 wait::dbus-ready
 
 # this test covers cases where the user wants to utilize `reservedSystemCPUs`,

--- a/test/integration/cases/kubelet-config/expected-kubelet-config.json
+++ b/test/integration/cases/kubelet-config/expected-kubelet-config.json
@@ -26,7 +26,6 @@
     "clusterDomain": "cluster.local",
     "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
     "featureGates": {
-        "KubeletCredentialProviders": true,
         "RotateKubeletServerCertificate": true
     },
     "hairpinMode": "hairpin-veth",

--- a/test/integration/cases/kubelet-config/run.sh
+++ b/test/integration/cases/kubelet-config/run.sh
@@ -7,7 +7,7 @@ set -o pipefail
 source /helpers.sh
 
 mock::aws
-mock::kubelet 1.27.0
+mock::kubelet 1.28.0
 wait::dbus-ready
 
 for config in config.*; do

--- a/test/integration/cases/kubelet-flags/run.sh
+++ b/test/integration/cases/kubelet-flags/run.sh
@@ -7,7 +7,7 @@ set -o pipefail
 source /helpers.sh
 
 mock::aws
-mock::kubelet 1.27.0
+mock::kubelet 1.28.0
 wait::dbus-ready
 
 nodeadm init --skip run,install-validation --config-source file://config.yaml

--- a/test/integration/cases/kubelet-version/run.sh
+++ b/test/integration/cases/kubelet-version/run.sh
@@ -34,7 +34,7 @@ nodeadm init --skip run,install-validation --config-source file://config.yaml
 assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS": 10'
 assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst": 20'
 
-mock::kubelet 1.27.0-eks-5e0fdde
+mock::kubelet 1.28.0-eks-5e0fdde
 nodeadm init --skip run,install-validation --config-source file://config.yaml
 assert::file-not-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS"'
 assert::file-not-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst"'


### PR DESCRIPTION
Adding end-to-end testing for mixed mode EKS clusters where hybrid nodes and cloud-managed nodes coexist. 

Test Coverage :

- Cross-VPC pod-to-pod communication (both directions)

- Cross-VPC service discovery with DNS resolution across node types (both directions)

- CoreDNS optimization for mixed mode



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


