### PR TITLE
Simplify Bottlerocket OS list in E2E tests

### DIFF
--- a/test/e2e/suite/nodeadm/nodeadm_test.go
+++ b/test/e2e/suite/nodeadm/nodeadm_test.go
@@ -87,10 +87,10 @@ var _ = Describe("Hybrid Nodes", func() {
 				initEntries = append(initEntries, Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), os, provider, Label(os.Name(), string(provider.Name()), "simpleflow", "init")))
 				upgradeEntries = append(upgradeEntries, Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), os, provider, Label(os.Name(), string(provider.Name()), "upgradeflow")))
 			}
-			for _, os := range suite.BottlerocketOSList() {
-				for _, provider := range credentialProviders {
-					bottlerocketInitEntries = append(bottlerocketInitEntries, Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), os, provider, Label(os.Name(), string(provider.Name()), "simpleflow", "init")))
-				}
+			for _, osProvider := range suite.BottlerocketOSProviderList() {
+				os := osProvider.OS
+				provider := osProvider.Provider
+				bottlerocketInitEntries = append(bottlerocketInitEntries, Entry(fmt.Sprintf("With OS %s and with Credential Provider %s", os.Name(), string(provider.Name())), os, provider, Label(os.Name(), string(provider.Name()), "simpleflow", "init")))
 			}
 
 			DescribeTable("Joining a node",

--- a/test/e2e/suite/peered_vpc.go
+++ b/test/e2e/suite/peered_vpc.go
@@ -451,10 +451,12 @@ func OSProviderList(credentialProviders []e2e.NodeadmCredentialsProvider) []OSPr
 	return osProviderList
 }
 
-func BottlerocketOSList() []e2e.NodeadmOS {
-	return []e2e.NodeadmOS{
-		osystem.NewBottleRocket(),
-		osystem.NewBottleRocketARM(),
+func BottlerocketOSProviderList() []OSProvider {
+	return []OSProvider{
+		{OS: osystem.NewBottleRocket(), Provider: &credentials.SsmProvider{}},
+		{OS: osystem.NewBottleRocket(), Provider: &credentials.IamRolesAnywhereProvider{}},
+		{OS: osystem.NewBottleRocketARM(), Provider: &credentials.SsmProvider{}},
+		{OS: osystem.NewBottleRocketARM(), Provider: &credentials.IamRolesAnywhereProvider{}},
 	}
 }
 


### PR DESCRIPTION
Simplify Bottlerocket OS list in E2E tests by hardcoding it instead of doing a double for-loop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

