### PR TITLE
temp: avoid deleting /var/lib/kubelet directory during cleanup

### DIFF
--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -43,7 +43,7 @@ func NewCommand() cli.Command {
 	fc.Description = "Uninstall components installed using the install sub-command"
 	fc.AdditionalHelpAppend = uninstallHelpText
 	fc.StringSlice(&cmd.skipPhases, "s", "skip", "Phases of uninstall to skip. Allowed values: [pod-validation, node-validation].")
-	fc.Bool(&cmd.force, "f", "force", "Force delete additional directories that might contain leftovers from the node process. WARNING: This will delete all contents in default Kubernetes and CNI directories (/var/lib/kubelet, /var/lib/cni, etc). Do not use this flag if you store your own data in these locations.")
+	fc.Bool(&cmd.force, "f", "force", "Force delete additional directories that might contain leftovers from the node process. WARNING: This will delete all contents in default Kubernetes and CNI directories (/var/lib/cni, /etc/cni/net.d, etc). Do not use this flag if you store your own data in these locations.")
 	cmd.flaggy = fc
 
 	return &cmd

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -11,7 +11,6 @@ import (
 
 // Directories to clean up when force flag is enabled
 var cleanupDirs = []string{
-	"/var/lib/kubelet",
 	"/var/lib/cni",
 	"/etc/cni/net.d",
 }

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -20,7 +20,6 @@ func TestCleanup(t *testing.T) {
 		{
 			name: "cleanup existing directories",
 			setupDirs: []string{
-				"/var/lib/kubelet",
 				"/var/lib/cni",
 				"/etc/cni/net.d",
 			},

--- a/test/integration/cases/uninstall-with-force/run.sh
+++ b/test/integration/cases/uninstall-with-force/run.sh
@@ -34,7 +34,6 @@ nodeadm uninstall --skip node-validation,pod-validation
 assert::path-not-exist /etc/kubernetes/test/file
 assert::path-not-exist /var/lib/kubelet/kubeconfig
 
-assert::path-exists /var/lib/kubelet/test/file
 assert::path-exists /var/lib/cni/test/file
 assert::path-exists /etc/cni/net.d/test/file
 
@@ -54,7 +53,6 @@ echo "test" > /etc/cni/net.d/test/file
 # Now uninstall with force - these directories should be removed
 nodeadm uninstall --skip node-validation,pod-validation --force
 
-assert::path-not-exist /var/lib/kubelet/test/file
 assert::path-not-exist /etc/kubernetes/test/file
 assert::path-not-exist /var/lib/cni/test/file
 assert::path-not-exist /etc/cni/net.d/test/file


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:** 
Temporary fix to exclude `/var/lib/kubelet` from the cleanup directories list during `nodeadm uninstall --force` operations. This prevents accidental deletion of kubelet data and avoids unnecessary pod mount deletions that could impact running workloads.

**Testing (if applicable):** 
- Verified that `/var/lib/kubelet` is no longer deleted during `nodeadm uninstall --force`
- Existing integration tests in `test/integration/cases/uninstall-with-force/` should be updated to reflect this change
- Manual testing confirmed kubelet data preservation

**Documentation added/planned (if applicable):** 
No documentation changes required for this temporary fix. Future permanent solution may require updates to uninstall command documentation.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
