### PR TITLE
Fix IAM credential propagation race condition in jumpbox private key download

### DIFF
--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/eks-hybrid/test/e2e/addon"
 	"github.com/aws/eks-hybrid/test/e2e/cfn"
 	"github.com/aws/eks-hybrid/test/e2e/cleanup"
+	e2eCommands "github.com/aws/eks-hybrid/test/e2e/commands"
 	"github.com/aws/eks-hybrid/test/e2e/constants"
 	e2eErrors "github.com/aws/eks-hybrid/test/e2e/errors"
 	"github.com/aws/eks-hybrid/test/e2e/os"
@@ -352,12 +353,26 @@ func (s *stack) setupJumpbox(ctx context.Context, clusterName string) error {
 	}
 
 	command := "/root/download-private-key.sh"
-	output, err := e2eSSM.RunCommand(ctx, s.ssmClient, *jumpbox.InstanceId, command, s.logger)
-	if err != nil {
-		return fmt.Errorf("jumpbox getting private key from ssm: %w", err)
+	var output e2eCommands.RemoteCommandOutput
+
+	// Retry private key download to handle IAM role credential propagation timing.
+	// This is different from the retry for SSM call inside RunCommand since it is not the SSM API call that fails,
+	// but the command execution on the jumpbox done by that SSM API call that fails due to IAM role credentials
+	// not being available through IMDS yet, even though the instance profile is attached.
+	for range 3 {
+		output, err = e2eSSM.RunCommand(ctx, s.ssmClient, *jumpbox.InstanceId, command, s.logger)
+		if err != nil {
+			return fmt.Errorf("jumpbox getting private key from ssm: %w", err)
+		}
+		if output.Status == "Success" {
+			break
+		}
+		s.logger.Info("Private key download failed, retrying in 10 seconds")
+		time.Sleep(10 * time.Second)
 	}
+
 	if output.Status != "Success" {
-		return fmt.Errorf("jumpbox getting private key from ssm")
+		return fmt.Errorf("jumpbox getting private key from ssm after retries")
 	}
 
 	return nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We occasionally got
`Phase: SetupTestInfrastructure Failure: creating E2E test infrastructure: creating stack for cluster infra: setting up jumpbox: jumpbox getting private key from ssm Status: failure`.

I suspect whats happening is that the role's credentials were not generated and available via IMDS for the jumpbox yet at the time the test tried to run the aws ssm get-parameter call on the jumpbox (via the SSM Agent, which is unrelated to our problem but was slightly confusing since they're both ssm). I think a few retries will fix the issue since it will give more time for the role creds to become available in IMDS.

*Testing (if applicable):*

Ran E2E test suite to verify retries did not affect functionality.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

