### PR TITLE
Remove unnecessary assignment of error

### DIFF
--- a/internal/aws/sts/validate.go
+++ b/internal/aws/sts/validate.go
@@ -65,8 +65,7 @@ func (a AuthenticationValidator) Run(ctx context.Context, informer validation.In
 	client := sts_sdk.NewFromConfig(a.aws)
 
 	if _, err = client.GetCallerIdentity(ctx, &sts_sdk.GetCallerIdentityInput{}); err != nil {
-		err = validation.WithRemediation(err, "Check your AWS configuration and make sure you can obtain valid AWS credentials.")
-		return err
+		return validation.WithRemediation(err, "Check your AWS configuration and make sure you can obtain valid AWS credentials.")
 	}
 
 	return nil

--- a/internal/iamrolesanywhere/validate.go
+++ b/internal/iamrolesanywhere/validate.go
@@ -55,8 +55,7 @@ func (a AccessValidator) Run(ctx context.Context, informer validation.Informer, 
 	}()
 
 	if err = CheckEndpointAccess(ctx, a.aws); err != nil {
-		err = validation.WithRemediation(err, "Ensure your network configuration allows access to the AWS IAM Roles Anywhere API endpoint")
-		return err
+		return validation.WithRemediation(err, "Ensure your network configuration allows access to the AWS IAM Roles Anywhere API endpoint")
 	}
 
 	return nil

--- a/internal/kubernetes/cert.go
+++ b/internal/kubernetes/cert.go
@@ -48,8 +48,7 @@ func (v KubeletCertificateValidator) Run(ctx context.Context, informer validatio
 		informer.Done(ctx, name, err)
 	}()
 	if err = hybrid.ValidateCertificate(v.certPath, cluster.CertificateAuthority); err != nil {
-		err = hybrid.AddKubeletRemediation(v.certPath, err)
-		return err
+		return hybrid.AddKubeletRemediation(v.certPath, err)
 	}
 
 	return nil

--- a/internal/kubernetes/connection.go
+++ b/internal/kubernetes/connection.go
@@ -20,16 +20,14 @@ func CheckConnection(ctx context.Context, informer validation.Informer, node *ap
 
 	endpoint, err := url.Parse(node.Spec.Cluster.APIServerEndpoint)
 	if err != nil {
-		err = validation.WithRemediation(err, "Ensure the Kubernetes API server endpoint provided is correct.")
-		return err
+		return validation.WithRemediation(err, "Ensure the Kubernetes API server endpoint provided is correct.")
 	}
 
 	err = retry.NetworkRequest(ctx, func(ctx context.Context) error {
 		return network.CheckConnectionToHost(ctx, *endpoint)
 	})
 	if err != nil {
-		err = validation.WithRemediation(err, "Ensure your network configuration allows the node to access the Kubernetes API endpoint.")
-		return err
+		return validation.WithRemediation(err, "Ensure your network configuration allows the node to access the Kubernetes API endpoint.")
 	}
 
 	return nil

--- a/internal/node/validate.go
+++ b/internal/node/validate.go
@@ -56,8 +56,7 @@ func (a APIServerValidator) MakeAuthenticatedRequest(ctx context.Context, inform
 
 	_, err = k8s.GetRetry(ctx, client.CoreV1().Endpoints("default"), "kubernetes")
 	if err != nil {
-		err = validation.WithRemediation(err, badPermissionsRemediation)
-		return err
+		return validation.WithRemediation(err, badPermissionsRemediation)
 	}
 
 	return nil
@@ -94,8 +93,7 @@ func (a APIServerValidator) CheckIdentity(ctx context.Context, informer validati
 		return err
 	})
 	if err != nil {
-		err = validation.WithRemediation(err, badPermissionsRemediation)
-		return err
+		return validation.WithRemediation(err, badPermissionsRemediation)
 	}
 
 	if !slices.Contains(self.Status.UserInfo.Groups, "system:nodes") {
@@ -148,13 +146,11 @@ func (a APIServerValidator) CheckVPCEndpointAccess(ctx context.Context, informer
 
 	kubeEndpoint, err := k8s.GetRetry(ctx, client.CoreV1().Endpoints("default"), "kubernetes")
 	if err != nil {
-		err = validation.WithRemediation(err, badPermissionsRemediation)
-		return err
+		return validation.WithRemediation(err, badPermissionsRemediation)
 	}
 
 	if len(kubeEndpoint.Subsets) == 0 {
-		err = errors.New("no subsets found in the Kubernetes endpoint, can't validate VPC API server access")
-		return err
+		return errors.New("no subsets found in the Kubernetes endpoint, can't validate VPC API server access")
 	}
 
 	for _, subset := range kubeEndpoint.Subsets {

--- a/internal/ssm/validate.go
+++ b/internal/ssm/validate.go
@@ -55,8 +55,7 @@ func (a AccessValidator) Run(ctx context.Context, informer validation.Informer, 
 	}()
 
 	if err = CheckEndpointAccess(ctx, a.aws); err != nil {
-		err = validation.WithRemediation(err, "Ensure your network configuration allows access to the AWS SSM API endpoint")
-		return err
+		return validation.WithRemediation(err, "Ensure your network configuration allows access to the AWS SSM API endpoint")
 	}
 
 	return nil


### PR DESCRIPTION
Remove unnecessary assignment of error in validations. Since we are immediately returning the error after adding the remediation message, we can combine these operations into a single return statement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

