### PR TITLE
Remove 1.27 from integration tests and use 1.32 as initial base version

### DIFF
--- a/test/integration/test-constants.sh
+++ b/test/integration/test-constants.sh
@@ -4,10 +4,10 @@
 # This file centralizes version definitions used across integration tests
 
 # Supported Kubernetes versions for install/uninstall tests
-declare SUPPORTED_VERSIONS=(1.27 1.28 1.29 1.30 1.31 1.32 1.33)
+declare SUPPORTED_VERSIONS=(1.28 1.29 1.30 1.31 1.32 1.33)
 
 # Default versions for upgrade tests and single-version tests
-declare DEFAULT_INITIAL_VERSION=1.27
+declare DEFAULT_INITIAL_VERSION=1.32
 declare CURRENT_VERSION=1.33  # Used for both upgrade target version and single-version tests
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removes 1.27 and uses 1.32 as initial base version

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

