### PR TITLE
Remove 1.27 and its feature gates from upgrade & kubelet config tests

### DIFF
--- a/test/integration/cases/upgrade-with-iam/expected-kubelet-config-initial
+++ b/test/integration/cases/upgrade-with-iam/expected-kubelet-config-initial
@@ -32,7 +32,6 @@
     "nodefs.inodesFree": "5%"
   },
   "featureGates": {
-    "KubeletCredentialProviders": true,
     "RotateKubeletServerCertificate": true
   },
   "hairpinMode": "hairpin-veth",

--- a/test/integration/cases/upgrade-with-ssm/expected-kubelet-config-initial
+++ b/test/integration/cases/upgrade-with-ssm/expected-kubelet-config-initial
@@ -32,7 +32,6 @@
     "nodefs.inodesFree": "5%"
   },
   "featureGates": {
-    "KubeletCredentialProviders": true,
     "RotateKubeletServerCertificate": true
   },
   "hairpinMode": "hairpin-veth",

--- a/test/integration/test-constants.sh
+++ b/test/integration/test-constants.sh
@@ -4,10 +4,10 @@
 # This file centralizes version definitions used across integration tests
 
 # Supported Kubernetes versions for install/uninstall tests
-declare SUPPORTED_VERSIONS=(1.27 1.28 1.29 1.30 1.31 1.32 1.33)
+declare SUPPORTED_VERSIONS=(1.28 1.29 1.30 1.31 1.32 1.33)
 
 # Default versions for upgrade tests and single-version tests
-declare DEFAULT_INITIAL_VERSION=1.27
+declare DEFAULT_INITIAL_VERSION=1.32
 declare CURRENT_VERSION=1.33  # Used for both upgrade target version and single-version tests
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removes k8s 1.27 from the integration tests to unblock other PRs. This includes removing the `KubeletCredentialProviders` feature gate from the kubelet config to which became default behavior in 1.28. A second PR will clean up old tests and feature gate support that is now default behavior in all supported Kubernetes versions.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

