### PR TITLE
update nodeadm uninstall --force flag warning and safetytips

### DIFF
--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -26,6 +26,13 @@ const (
 	skipNodePreflightCheck = "node-validation"
 )
 
+const forceWarningText = "Force delete additional directories that might contain leftovers from the node process. " +
+	"WARNING: This will delete all contents in default Kubernetes and CNI directories (/var/lib/cni, /etc/cni/net.d, etc). " +
+	"Do not use this flag if you store your own data in these locations. " +
+	"Starting from nodeadm v1.0.9, the --force command no longer deletes the /var/lib/kubelet directory " +
+	"as it may contain Pod volumes and volume-subpath directories that sometimes include the mounted node filesystem. " +
+	"SAFE-HANDLING-TIPS: Before manually deleting /var/lib/kubelet, carefully inspect all active mounts and unmount volumes safely to avoid data loss."
+
 const uninstallHelpText = `Examples:
   # Uninstall all components
   nodeadm uninstall
@@ -43,7 +50,7 @@ func NewCommand() cli.Command {
 	fc.Description = "Uninstall components installed using the install sub-command"
 	fc.AdditionalHelpAppend = uninstallHelpText
 	fc.StringSlice(&cmd.skipPhases, "s", "skip", "Phases of uninstall to skip. Allowed values: [pod-validation, node-validation].")
-	fc.Bool(&cmd.force, "f", "force", "Force delete additional directories that might contain leftovers from the node process. WARNING: This will delete all contents in default Kubernetes and CNI directories (/var/lib/cni, /etc/cni/net.d, etc). Do not use this flag if you store your own data in these locations.")
+	fc.Bool(&cmd.force, "f", "force", forceWarningText)
 	cmd.flaggy = fc
 
 	return &cmd


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update Uninstall CLI command to call out a warning and safety tips on deletion of /val/lib/kubelet folder. 

*Testing (if applicable):*

Test on hybrid node
---
eksahybrid@hybrid-node:/tmp$ ./nodeadm uninstall --help
uninstall - Uninstall components installed using the install sub-command

Flags:
     --version       Displays the program version string.
  -h --help          Displays help with available flag, subcommand, and positional value parameters.
  -s --skip          Phases of uninstall to skip. Allowed values: [pod-validation, node-validation].
  -f --force         Force delete additional directories that might contain leftovers from the node process. WARNING: This will delete all contents in default Kubernetes and CNI directories (/var/lib/cni, /etc/cni/net.d, etc). Do not use this flag if you store your own data in these locations. Starting from nodeadm v1.0.9, the --force command no longer deletes the /var/lib/kubelet directory as it may contain Pod volumes and volume-subpath directories that sometimes include the mounted node filesystem. SAFE-HANDLING-TIPS: Before manually deleting /var/lib/kubelet, carefully inspect all active mounts and unmount volumes safely to avoid data loss.
  -d --development   Enable development mode for logging.

Examples:
  # Uninstall all components
  nodeadm uninstall

  # Uninstall all components and skip pod-validation and node-validation pre-flight validation
  nodeadm uninstall --skip node-validation,pod-validation

Documentation:
  https://docs.aws.amazon.com/eks/latest/userguide/hybrid-nodes-nodeadm.html#_uninstall
---

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

