### PR TITLE
Update minimum version to 1.28 as 1.27 reached the end of support

### DIFF
--- a/test/e2e/kubernetes/version.go
+++ b/test/e2e/kubernetes/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	MinimumVersion = "1.27"
+	MinimumVersion = "1.28"
 )
 
 func PreviousVersion(kubernetesVersion string) (string, error) {


### PR DESCRIPTION
*Issue #, if available:*
Currently we are seeing failures for upgrade test in version `1.28`, both calico and cilium. Since we removed `1.27` from our E2E tests, we should not run upgrade test for `1.28` as it is now the minimum version.

*Description of changes:*
In this PR, it updates min version to `1.28`.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

