### PR TITLE
Adding validation to ensure node cleanup and inactive

### DIFF
--- a/cmd/nodeadm/init/init.go
+++ b/cmd/nodeadm/init/init.go
@@ -43,6 +43,7 @@ func Phases() []string {
 		"kubelet-version-skew-validation",
 		"api-server-endpoint-resolution-validation",
 		"proxy-validation",
+		"node-inactive-validation",
 		"preprocess",
 		"config",
 		"run",

--- a/internal/node/hybrid/hybrid.go
+++ b/internal/node/hybrid/hybrid.go
@@ -24,6 +24,7 @@ const (
 	ntpSyncValidation           = "ntp-sync-validation"
 	apiServerEndpointResolution = "api-server-endpoint-resolution-validation"
 	proxyValidation             = "proxy-validation"
+	nodeInActiveValidation      = "node-inactive-validation"
 )
 
 type HybridNodeProvider struct {
@@ -95,6 +96,13 @@ func WithCertPath(path string) NodeProviderOpt {
 func WithKubelet(kubelet Kubelet) NodeProviderOpt {
 	return func(hnp *HybridNodeProvider) {
 		hnp.kubelet = kubelet
+	}
+}
+
+// WithDaemonManager adds a DaemonManager to the HybridNodeProvider for testing purposes.
+func WithDaemonManager(dm daemon.DaemonManager) NodeProviderOpt {
+	return func(hnp *HybridNodeProvider) {
+		hnp.daemonManager = dm
 	}
 }
 

--- a/internal/node/hybrid/hybrid.go
+++ b/internal/node/hybrid/hybrid.go
@@ -138,6 +138,7 @@ func (hnp *HybridNodeProvider) Validate(ctx context.Context) error {
 		validation.New(kubeletVersionSkew, hnp.ValidateKubeletVersionSkew),
 		validation.New(apiServerEndpointResolution, kubernetes.ValidateAPIServerEndpointResolution),
 		validation.New(proxyValidation, network.NewProxyValidator().Run),
+		validation.New(nodeInActiveValidation, hnp.ValidateNodeIsInactive),
 	)
 
 	// Run all validations sequentially

--- a/internal/node/hybrid/nodeinactive_validator.go
+++ b/internal/node/hybrid/nodeinactive_validator.go
@@ -1,0 +1,42 @@
+package hybrid
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/eks-hybrid/internal/daemon"
+	"github.com/aws/eks-hybrid/internal/kubelet"
+)
+
+const (
+	kubeletEnvironmentFilePath = "/etc/eks/kubelet/environment"
+	etcKubernetesDir           = "/etc/kubernetes"
+)
+
+// ValidateNodeIsInactive checks to see if the node is potentially active.
+func (hnp *HybridNodeProvider) ValidateNodeIsInactive() error {
+	if _, err := os.Stat(kubeletEnvironmentFilePath); !os.IsNotExist(err) {
+		if err == nil {
+			return fmt.Errorf("kubelet args environment file %s exists", kubeletEnvironmentFilePath)
+		}
+		return fmt.Errorf("checking kubelet environment file %s cleanup: %w", kubeletEnvironmentFilePath, err)
+	}
+
+	if _, err := os.Stat(etcKubernetesDir); !os.IsNotExist(err) {
+		if err == nil {
+			return fmt.Errorf("kubernetes directory %s still exists", etcKubernetesDir)
+		}
+		return fmt.Errorf("checking kubernetes directory %s cleanup: %w", etcKubernetesDir, err)
+	}
+
+	kubeletStatus, err := hnp.daemonManager.GetDaemonStatus(kubelet.KubeletDaemonName)
+	if err != nil {
+		return err
+	}
+
+	if kubeletStatus == daemon.DaemonStatusRunning {
+		return fmt.Errorf("kubelet service is still active, likely connected to old cluster")
+	}
+
+	return nil
+}

--- a/internal/node/hybrid/nodeinactive_validator.go
+++ b/internal/node/hybrid/nodeinactive_validator.go
@@ -1,41 +1,57 @@
 package hybrid
 
 import (
+	"context"
 	"fmt"
 	"os"
 
+	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/daemon"
 	"github.com/aws/eks-hybrid/internal/kubelet"
+	"github.com/aws/eks-hybrid/internal/validation"
 )
 
 const (
 	kubeletEnvironmentFilePath = "/etc/eks/kubelet/environment"
 	etcKubernetesDir           = "/etc/kubernetes"
+	nodeActiveRemediation      = "Ensure the hybrid node is made inactive by running 'nodeadm uninstall' before attaching to the EKS cluster"
 )
 
 // ValidateNodeIsInactive checks to see if the node is potentially active.
-func (hnp *HybridNodeProvider) ValidateNodeIsInactive() error {
-	if _, err := os.Stat(kubeletEnvironmentFilePath); !os.IsNotExist(err) {
-		if err == nil {
-			return fmt.Errorf("kubelet args environment file %s exists", kubeletEnvironmentFilePath)
+func (hnp *HybridNodeProvider) ValidateNodeIsInactive(ctx context.Context, informer validation.Informer, _ *api.NodeConfig) error {
+	var err error
+	informer.Starting(ctx, nodeInActiveValidation, "Validating that the node is inactive")
+	defer func() {
+		informer.Done(ctx, nodeInActiveValidation, err)
+	}()
+
+	if _, statErr := os.Stat(kubeletEnvironmentFilePath); !os.IsNotExist(statErr) {
+		if statErr == nil {
+			err = validation.WithWarning(fmt.Errorf("kubelet args environment file %s exists", kubeletEnvironmentFilePath), nodeActiveRemediation)
+			return err
 		}
-		return fmt.Errorf("checking kubelet environment file %s cleanup: %w", kubeletEnvironmentFilePath, err)
+		err = validation.WithWarning(fmt.Errorf("checking kubelet environment file %s cleanup: %w", kubeletEnvironmentFilePath, statErr), nodeActiveRemediation)
+		return err
 	}
 
-	if _, err := os.Stat(etcKubernetesDir); !os.IsNotExist(err) {
-		if err == nil {
-			return fmt.Errorf("kubernetes directory %s still exists", etcKubernetesDir)
+	if _, statErr := os.Stat(etcKubernetesDir); !os.IsNotExist(statErr) {
+		if statErr == nil {
+			err = validation.WithWarning(fmt.Errorf("kubernetes directory %s still exists", etcKubernetesDir), nodeActiveRemediation)
+			return err
 		}
-		return fmt.Errorf("checking kubernetes directory %s cleanup: %w", etcKubernetesDir, err)
+		err = validation.WithWarning(fmt.Errorf("checking kubernetes directory %s cleanup: %w", etcKubernetesDir, statErr), nodeActiveRemediation)
+		return err
 	}
 
-	kubeletStatus, err := hnp.daemonManager.GetDaemonStatus(kubelet.KubeletDaemonName)
-	if err != nil {
+	kubeletStatus, daemonErr := hnp.daemonManager.GetDaemonStatus(kubelet.KubeletDaemonName)
+	if daemonErr != nil {
+		err = validation.WithWarning(daemonErr, nodeActiveRemediation)
 		return err
 	}
 
 	if kubeletStatus == daemon.DaemonStatusRunning {
-		return fmt.Errorf("kubelet service is still active, likely connected to old cluster")
+		err = validation.WithWarning(fmt.Errorf("kubelet service is still active and may be connected to a previous cluster"), nodeActiveRemediation)
+		return err
 	}
 
 	return nil

--- a/internal/node/hybrid/nodeinactive_validator_test.go
+++ b/internal/node/hybrid/nodeinactive_validator_test.go
@@ -1,0 +1,127 @@
+package hybrid_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/aws/eks-hybrid/internal/api"
+	"github.com/aws/eks-hybrid/internal/daemon"
+	"github.com/aws/eks-hybrid/internal/node/hybrid"
+)
+
+// mockDaemonManager implements the daemon.DaemonManager interface for testing
+type mockDaemonManager struct {
+	status daemon.DaemonStatus
+	err    error
+}
+
+func (m *mockDaemonManager) GetDaemonStatus(name string) (daemon.DaemonStatus, error) {
+	return m.status, m.err
+}
+
+func (m *mockDaemonManager) StartDaemon(name string) error {
+	return nil
+}
+
+func (m *mockDaemonManager) StopDaemon(name string) error {
+	return nil
+}
+
+func (m *mockDaemonManager) RestartDaemon(ctx context.Context, name string, opts ...daemon.OperationOption) error {
+	return nil
+}
+
+func (m *mockDaemonManager) EnableDaemon(name string) error {
+	return nil
+}
+
+func (m *mockDaemonManager) DisableDaemon(name string) error {
+	return nil
+}
+
+func (m *mockDaemonManager) DaemonReload() error {
+	return nil
+}
+
+func (m *mockDaemonManager) Close() {}
+
+func TestHybridNodeProvider_ValidateNodeIsInactive(t *testing.T) {
+	tests := []struct {
+		name                string
+		kubeletDaemonStatus daemon.DaemonStatus
+		daemonError         error
+		expectWarning       bool
+		expectedLogMsg      string
+	}{
+		{
+			name:                "success - node is inactive",
+			kubeletDaemonStatus: daemon.DaemonStatusStopped,
+			expectWarning:       false,
+		},
+		{
+			name:                "warning - kubelet daemon running",
+			kubeletDaemonStatus: daemon.DaemonStatusRunning,
+			expectWarning:       true,
+			expectedLogMsg:      "kubelet service is still active",
+		},
+		{
+			name:                "warning - daemon manager error",
+			kubeletDaemonStatus: daemon.DaemonStatusUnknown,
+			daemonError:         fmt.Errorf("daemon manager error"),
+			expectWarning:       true,
+			expectedLogMsg:      "daemon manager error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Create an observed zap logger
+			observedZapCore, observedLogs := observer.New(zap.WarnLevel)
+			observedLogger := zap.New(observedZapCore)
+
+			// Create mock daemon manager
+			mockDaemon := &mockDaemonManager{
+				status: tt.kubeletDaemonStatus,
+				err:    tt.daemonError,
+			}
+
+			// Create provider with observed logger
+			hnp, err := hybrid.NewHybridNodeProvider(
+				&api.NodeConfig{},
+				[]string{"node-ip-validation", "kubelet-cert-validation", "api-server-endpoint-resolution-validation"},
+				observedLogger,
+				hybrid.WithDaemonManager(mockDaemon),
+			)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			err = hnp.Validate(context.Background())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Check logs
+			if tt.expectWarning {
+				g.Expect(observedLogs.Len()).To(BeNumerically(">", 0))
+				g.Expect(observedLogs.All()).To(ContainElement(
+					WithTransform(func(log observer.LoggedEntry) string {
+						return log.Message
+					}, ContainSubstring("Validation failed")),
+				))
+				if tt.expectedLogMsg != "" {
+					g.Expect(observedLogs.All()).To(ContainElement(
+						WithTransform(func(log observer.LoggedEntry) string {
+							return fmt.Sprint(log.ContextMap()["error"])
+						}, ContainSubstring(tt.expectedLogMsg)),
+					))
+				}
+			} else {
+				g.Expect(observedLogs.Len()).To(BeZero())
+			}
+		})
+	}
+}

--- a/internal/node/hybrid/nodeinactive_validator_test.go
+++ b/internal/node/hybrid/nodeinactive_validator_test.go
@@ -67,7 +67,7 @@ func TestHybridNodeProvider_ValidateNodeIsInactive(t *testing.T) {
 			name:                "warning - kubelet daemon running",
 			kubeletDaemonStatus: daemon.DaemonStatusRunning,
 			expectWarning:       true,
-			expectedLogMsg:      "kubelet service is still active",
+			expectedLogMsg:      "kubelet service is still active and may be connected to a previous cluster",
 		},
 		{
 			name:                "warning - daemon manager error",
@@ -95,7 +95,13 @@ func TestHybridNodeProvider_ValidateNodeIsInactive(t *testing.T) {
 			// Create provider with observed logger
 			hnp, err := hybrid.NewHybridNodeProvider(
 				&api.NodeConfig{},
-				[]string{"node-ip-validation", "kubelet-cert-validation", "api-server-endpoint-resolution-validation"},
+				[]string{
+					"node-ip-validation",
+					"kubelet-version-skew-validation",
+					"kubelet-cert-validation",
+					"api-server-endpoint-resolution-validation",
+					"proxy-validation",
+				},
 				observedLogger,
 				hybrid.WithDaemonManager(mockDaemon),
 			)

--- a/internal/node/hybrid/versionskew_validator_test.go
+++ b/internal/node/hybrid/versionskew_validator_test.go
@@ -114,7 +114,13 @@ func TestHybridNodeProvider_ValidateKubeletVersionSkew(t *testing.T) {
 			}
 			hnp, err := hybrid.NewHybridNodeProvider(
 				&api.NodeConfig{},
-				[]string{"node-ip-validation", "kubelet-cert-validation", "api-server-endpoint-resolution-validation", "proxy-validation"},
+				[]string{
+					"node-ip-validation",
+					"kubelet-cert-validation",
+					"api-server-endpoint-resolution-validation",
+					"proxy-validation",
+					"node-inactive-validation",
+				},
 				zap.NewNop(),
 				hybrid.WithCluster(tt.cluster),
 				hybrid.WithKubelet(mockKubelet),

--- a/internal/validation/error.go
+++ b/internal/validation/error.go
@@ -1,6 +1,8 @@
 package validation
 
-import "errors"
+import (
+	"errors"
+)
 
 // Remediable is an error that provides a possible remediation.
 type Remediable interface {
@@ -49,4 +51,48 @@ func Remediation(err error) string {
 	}
 
 	return fixable.Remediation()
+}
+
+// Warning represents a validation warning that doesn't prevent execution
+type Warning interface {
+	IsWarning() bool
+	Error() string
+}
+
+// warningError implements Warning around a generic error.
+type warningError struct {
+	error
+	remediation string
+}
+
+// IsWarning returns true to indicate this is a warning.
+func (e *warningError) IsWarning() bool {
+	return true
+}
+
+// Remediation returns a possible solution to the warning.
+func (e *warningError) Remediation() string {
+	return e.remediation
+}
+
+// NewWarning returns a new Warning error.
+func NewWarning(err, remediation string) error {
+	return &warningError{
+		error:       errors.New(err),
+		remediation: remediation,
+	}
+}
+
+// WithWarning makes an error a Warning.
+func WithWarning(err error, remediation string) error {
+	return &warningError{
+		error:       err,
+		remediation: remediation,
+	}
+}
+
+// IsWarning checks if an error is a warning.
+func IsWarning(err error) bool {
+	_, ok := err.(Warning)
+	return ok
 }


### PR DESCRIPTION
*Issue:*
https://github.com/aws/eks-anywhere-internal/issues/3380
*Description of changes:*
These changes adds a validation that checks if node was cleaned up properly and not potentially joined to another cluster when doing `nodeadm init`.

*Testing:*
```bash
{"level":"info","ts":"2025-08-01T01:08:17.562Z","caller":"hybrid/hybrid.go:162","msg":"Validating proxy configuration..."}
{"level":"info","ts":"2025-08-01T01:08:17.562Z","caller":"hybrid/hybrid.go:170","msg":"Validating node is inactive..."}
{"level":"warn","ts":"2025-08-01T01:08:17.562Z","caller":"hybrid/hybrid.go:172","msg":"Validation failed","error":"kubelet args environment file /etc/eks/kubelet/environment exists","remediation":"Ensure the hybrid node is made inactive by running 'nodeadm uninstall' before attaching to the EKS cluster"}
{"level":"info","ts":"2025-08-01T01:08:17.563Z","caller":"flows/init.go:54","msg":"Setting up system aspects..."}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

