### PR TITLE
Add permissions for PCA operations in E2E tests

### DIFF
--- a/hybrid-nodes-cdk/lib/nodeadm/policies.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm/policies.ts
@@ -337,6 +337,11 @@ export function createNodeadmTestsCreationCleanupPolicy(
         resources: [`arn:aws:logs:${stack.region}:${stack.account}:log-group:/aws/eks/*`],
         conditions: resourceTagCondition,
       }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['acm-pca:*'],
+        resources: [`arn:aws:acm-pca:${stack.region}:${stack.account}:certificate-authority/*`],
+      }),
     ],
   });
 }


### PR DESCRIPTION
*Issue #, if available:*

We are seeing the following permission issues in e2e test pipelines.
```
FAILED] runs cert manager and AWS PCA issuer tests
	Expected cert manager and AWS PCA issuer should have been validated successfully
		Expected success, but got an error:
		    <*fmt.wrapError | 0xc000b982e0>: 
		    AWS PCA Issuer validation failed: failed to setup AWS Private CA: create certificate authority: operation error ACM PCA: CreateCertificateAuthority, https response error StatusCode: 400, RequestID: ed68dd85-5a68-4b56-b28b-aca4206b00d3, api error AccessDeniedException: User: arn:aws:sts::654654371076:assumed-role/nodeadm-build-65465437107-nodeadmintegrationtestrol-sfSQqHt0m9M1/AWSCodeBuild-62f121f4-60ea-4c8d-8512-09063b59d1a3 is not authorized to perform: acm-pca:CreateCertificateAuthority on resource: arn:aws:acm-pca:us-west-2:654654371076:certificate-authority/* because no identity-based policy allows the acm-pca:CreateCertificateAuthority action
		    {
		        msg: "AWS PCA Issuer validation failed: failed to setup AWS Private CA: create certificate authority: operation error ACM PCA: CreateCertificateAuthority, https response error StatusCode: 400, RequestID: ed68dd85-5a68-4b56-b28b-aca4206b00d3, api error AccessDeniedException: User: arn:aws:sts::654654371076:assumed-role/nodeadm-build-65465437107-nodeadmintegrationtestrol-sfSQqHt0m9M1/AWSCodeBuild-62f121f4-60ea-4c8d-8512-09063b59d1a3 is not authorized to perform: acm-pca:CreateCertificateAuthority on resource: arn:aws:acm-pca:us-west-2:654654371076:certificate-authority/* because no identity-based policy allows the acm-pca:CreateCertificateAuthority action",
		        err: <*errors.errorString | 0xc0009417e0>{
		            s: "failed to setup AWS Private CA: create certificate authority: operation error ACM PCA: CreateCertificateAuthority, https response error StatusCode: 400, RequestID: ed68dd85-5a68-4b56-b28b-aca4206b00d3, api error AccessDeniedException: User: arn:aws:sts::654654371076:assumed-role/nodeadm-build-65465437107-nodeadmintegrationtestrol-sfSQqHt0m9M1/AWSCodeBuild-62f121f4-60ea-4c8d-8512-09063b59d1a3 is not authorized to perform: acm-pca:CreateCertificateAuthority on resource: arn:aws:acm-pca:us-west-2:654654371076:certificate-authority/* because no identity-based policy allows the acm-pca:CreateCertificateAuthority action",
		        },
		    }
	In [It] at: /codebuild/output/src388960552/src/test/e2e/suite/addons/addons_test.go:291 @ 2025-07-31 20:35:41


```

*Description of changes:*
Now add permissions for PCA in this PR. I tried to only specify permissions we need but have the following errors when run `cdk deploy`.

```
Resource handler returned message: "Maximum policy size of 10240 bytes exceeded for role HybridNodesCdkStack-nodeadme2etestsprojectRoleA79B2-I13Umf
hdSVen (Service: Iam, Status Code: 409, Request ID: 4e77a6ae-5343-4b72-929d-50a94132d1b6) (SDK Attempt Count: 1)" (RequestToken: a67eab76-a48a-efe1
-af41-e837f776be93, HandlerErrorCode: ServiceLimitExceeded)
```

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

