### PR TITLE
Ensure debug validations run describe cluster permissions

### DIFF
--- a/internal/network/interface.go
+++ b/internal/network/interface.go
@@ -50,7 +50,7 @@ func (v NetworkInterfaceValidator) Run(ctx context.Context, informer validation.
 
 	// Use provided cluster if available, otherwise read from EKS API
 	if v.cluster == nil {
-		informer.Starting(ctx, name, "Skipping network interface validation")
+		informer.Starting(ctx, name, "Skipping network interface validation due to node IAM role missing EKS DescribeCluster permission")
 		informer.Done(ctx, name, err)
 		return nil
 	}

--- a/internal/node/hybrid/versionskew_validator.go
+++ b/internal/node/hybrid/versionskew_validator.go
@@ -28,7 +28,7 @@ const (
 func (hnp *HybridNodeProvider) ValidateKubeletVersionSkew(ctx context.Context, informer validation.Informer, nodeConfig *api.NodeConfig) error {
 	var err error
 	if hnp.cluster == nil {
-		informer.Starting(ctx, kubeletVersionSkew, "Skipping kubelet version skew validation")
+		informer.Starting(ctx, kubeletVersionSkew, "Skipping kubelet version skew validation due to node IAM role missing EKS DescribeCluster permission")
 		informer.Done(ctx, kubeletVersionSkew, err)
 		return nil
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
debug was failing like so
```
root@hybrid-node:/home/eksahybrid# ./nodeadm debug -c file://nodeConfig.yaml
* Validating access to Kubernetes API endpoint [Failed]
  └─ Error
     └─ operation error EKS: DescribeCluster, https response error StatusCode: 403, RequestID: f20b331d-9acb-4dd7-b8ef-cb5b57f8f603, api error AccessDeniedException: User: arn:aws:sts::137991996709:assumed-role/eksHybridRole/mi-03fe76162141154f6 is not authorized to perform: eks:DescribeCluster on resource: arn:aws:eks:us-west-2:137991996709:cluster/eks-hybrid
     └─ Remediation
        └─ Ensure the node has access and permissions to call DescribeCluster EKS API. Check AWS credentials and IAM permissions.
{"level":"fatal","ts":"2025-08-06T19:44:13.662Z","caller":"./main.go:55","msg":"Command failed","error":"operation error EKS: DescribeCluster, https response error StatusCode: 403, RequestID: f20b331d-9acb-4dd7-b8ef-cb5b57f8f603, api error AccessDeniedException: User: arn:aws:sts::137991996709:assumed-role/eksHybridRole/mi-03fe76162141154f6 is not authorized to perform: eks:DescribeCluster on resource: arn:aws:eks:us-west-2:137991996709:cluster/eks-hybrid"}
```

when missing eks:DescribeCluster permissions. This modifies the debug flow to ensure validations that do not need the eks cluster still run when these permissions are missing.

*Testing (if applicable):*
missing perms:
```
root@hybrid-node:/home/eksahybrid# ./nodeadm debug -c file://nodeConfig.yaml
* Validating access to AWS SSM API endpoint [Success]
* Validating NTP synchronization status [Success]
* Validating swap configuration [Success]
* Validating ulimit configuration [Success]
* Validating authentication against AWS [Success]
* Validating proxy configuration on the hybrid node [Success]
* Validating access to Kubernetes API endpoint [Success]
* Validating unauthenticated request to Kubernetes API endpoint [Success]
* Validating authenticated request to Kubernetes API endpoint [Success]
* Validating Kubernetes identity matches a Node identity [Success]
* Validating access to Kube-API server through VPC IPs [Success]
* Validating kubelet server certificate [Success]
* Skipping network interface validation due to node IAM role missing EKS DescribeCluster permission [Success]
```
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

