### PR TITLE
Add init validations for AWS/K8s creds

### DIFF
--- a/cmd/nodeadm/debug/debug.go
+++ b/cmd/nodeadm/debug/debug.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aws/eks-hybrid/internal/kubernetes"
 	"github.com/aws/eks-hybrid/internal/logger"
 	"github.com/aws/eks-hybrid/internal/network"
-	"github.com/aws/eks-hybrid/internal/node"
 	"github.com/aws/eks-hybrid/internal/system"
 	"github.com/aws/eks-hybrid/internal/validation"
 )
@@ -93,7 +92,7 @@ func (c *debug) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	os.Stderr = printer.File
 
 	runner := validation.NewRunner[*api.NodeConfig](printer)
-	apiServerValidator := node.NewAPIServerValidator(kubelet.New())
+	apiServerValidator := kubernetes.NewAPIServerValidator(kubelet.New())
 	clusterProvider := kubernetes.NewClusterProvider(awsConfig)
 
 	// Register validations that do not require cluster details first

--- a/cmd/nodeadm/init/init.go
+++ b/cmd/nodeadm/init/init.go
@@ -83,7 +83,7 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	ctx := context.Background()
 	ctx = logger.NewContext(ctx, log)
 
-	log.Info("Checking user is root..")
+	log.Info("Checking user is root...")
 	root, err := cli.IsRunningAsRoot()
 	if err != nil {
 		return err

--- a/cmd/nodeadm/uninstall/uninstall.go
+++ b/cmd/nodeadm/uninstall/uninstall.go
@@ -87,7 +87,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		return err
 	}
 
-	log.Info("Creating daemon manager..")
+	log.Info("Creating daemon manager...")
 	daemonManager, err := daemon.NewDaemonManager()
 	if err != nil {
 		return err

--- a/cmd/nodeadm/upgrade/upgrade.go
+++ b/cmd/nodeadm/upgrade/upgrade.go
@@ -119,7 +119,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		}
 	}
 
-	log.Info("Loading configuration..", zap.String("configSource", c.configSource))
+	log.Info("Loading configuration...", zap.String("configSource", c.configSource))
 	nodeProvider, err := node.NewNodeProvider(c.configSource, c.skipPhases, log)
 	if err != nil {
 		return err
@@ -157,7 +157,7 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 	log.Info("Using Kubernetes version", zap.Reflect("kubernetes version", awsSource.Eks.Version))
 
-	log.Info("Creating daemon manager..")
+	log.Info("Creating daemon manager...")
 	daemonManager, err := daemon.NewDaemonManager()
 	if err != nil {
 		return err

--- a/internal/containerd/config.go
+++ b/internal/containerd/config.go
@@ -41,13 +41,13 @@ func writeContainerdConfig(cfg *api.NodeConfig) error {
 	if err != nil {
 		return err
 	}
-	zap.L().Info("Writing containerd config to file..", zap.String("path", containerdConfigFile))
+	zap.L().Info("Writing containerd config to file...", zap.String("path", containerdConfigFile))
 	if err := util.WriteFileWithDir(containerdConfigFile, containerdConfig, containerdConfigPerm); err != nil {
 		return err
 	}
 	if len(cfg.Spec.Containerd.Config) > 0 {
 		containerConfigImportPath := filepath.Join(containerdConfigImportDir, "00-nodeadm.toml")
-		zap.L().Info("Writing user containerd config to drop-in file..", zap.String("path", containerConfigImportPath))
+		zap.L().Info("Writing user containerd config to drop-in file...", zap.String("path", containerConfigImportPath))
 		return util.WriteFileWithDir(containerConfigImportPath, []byte(cfg.Spec.Containerd.Config), containerdConfigPerm)
 	}
 	return nil

--- a/internal/containerd/sandbox.go
+++ b/internal/containerd/sandbox.go
@@ -18,7 +18,7 @@ import (
 var containerdSandboxImageRegex = regexp.MustCompile(`sandbox_image = "(.*)"`)
 
 func cacheSandboxImage(awsConfig *aws.Config) error {
-	zap.L().Info("Looking up current sandbox image in containerd config..")
+	zap.L().Info("Looking up current sandbox image in containerd config...")
 	// capture the output of a `containerd config dump`, which is the final
 	// containerd configuration used after all of the applied transformations
 	dump, err := exec.Command("containerd", "config", "dump").Output()
@@ -32,7 +32,7 @@ func cacheSandboxImage(awsConfig *aws.Config) error {
 	sandboxImage := string(matches[1])
 	zap.L().Info("Found sandbox image", zap.String("image", sandboxImage))
 
-	zap.L().Info("Fetching ECR authorization token..")
+	zap.L().Info("Fetching ECR authorization token...")
 	ecrUserToken, err := ecr.GetAuthorizationToken(awsConfig)
 	if err != nil {
 		return err
@@ -46,7 +46,7 @@ func cacheSandboxImage(awsConfig *aws.Config) error {
 	authConfig := &v1.AuthConfig{Auth: ecrUserToken}
 
 	return util.RetryExponentialBackoff(3, 2*time.Second, func() error {
-		zap.L().Info("Pulling sandbox image..", zap.String("image", sandboxImage))
+		zap.L().Info("Pulling sandbox image...", zap.String("image", sandboxImage))
 		imageRef, err := client.PullImage(imageSpec, authConfig, nil)
 		if err != nil {
 			return err

--- a/internal/flows/init.go
+++ b/internal/flows/init.go
@@ -54,7 +54,7 @@ func (i *Initer) Run(ctx context.Context) error {
 	i.Logger.Info("Setting up system aspects...")
 	for _, aspect := range aspects {
 		nameField := zap.String("name", aspect.Name())
-		i.Logger.Info("Setting up system aspect..", nameField)
+		i.Logger.Info("Setting up system aspect...", nameField)
 		if err := aspect.Setup(); err != nil {
 			return err
 		}
@@ -97,13 +97,13 @@ func initDaemons(ctx context.Context, nodeProvider nodeprovider.NodeProvider, sk
 		for _, daemon := range daemons {
 			nameField := zap.String("name", daemon.Name())
 
-			logger.Info("Ensuring daemon is running..", nameField)
+			logger.Info("Ensuring daemon is running...", nameField)
 			if err := daemon.EnsureRunning(ctx); err != nil {
 				return err
 			}
 			logger.Info("Daemon is running", nameField)
 
-			logger.Info("Running post-launch tasks..", nameField)
+			logger.Info("Running post-launch tasks...", nameField)
 			if err := daemon.PostLaunch(); err != nil {
 				return err
 			}

--- a/internal/kubelet/config.go
+++ b/internal/kubelet/config.go
@@ -181,7 +181,7 @@ func (ksc *kubeletConfig) withFallbackClusterDns(cluster *api.ClusterDetails) er
 //     disconnected state.
 func (ksc *kubeletConfig) withOutpostSetup(cfg *api.NodeConfig) error {
 	if enabled := cfg.Spec.Cluster.EnableOutpost; enabled != nil && *enabled {
-		zap.L().Info("Setting up outpost..")
+		zap.L().Info("Setting up outpost...")
 
 		if cfg.Spec.Cluster.ID == "" {
 			return fmt.Errorf("clusterId cannot be empty when outpost is enabled.")
@@ -436,7 +436,7 @@ func (k *kubelet) writeKubeletConfigToFile() error {
 	configPath := path.Join(kubeletConfigRoot, kubeletConfigFile)
 	k.flags["config"] = configPath
 
-	zap.L().Info("Writing kubelet config to file..", zap.String("path", configPath))
+	zap.L().Info("Writing kubelet config to file...", zap.String("path", configPath))
 	return util.WriteFileWithDir(configPath, kubeletConfigBytes, kubeletConfigPerm)
 }
 
@@ -457,7 +457,7 @@ func (k *kubelet) writeKubeletConfigToDir() error {
 	configPath := path.Join(kubeletConfigRoot, kubeletConfigFile)
 	k.flags["config"] = configPath
 
-	zap.L().Info("Writing kubelet config to file..", zap.String("path", configPath))
+	zap.L().Info("Writing kubelet config to file...", zap.String("path", configPath))
 	if err := util.WriteFileWithDir(configPath, kubeletConfigBytes, kubeletConfigPerm); err != nil {
 		return err
 	}
@@ -466,7 +466,7 @@ func (k *kubelet) writeKubeletConfigToDir() error {
 		dirPath := path.Join(kubeletConfigRoot, kubeletConfigDir)
 		k.flags["config-dir"] = dirPath
 
-		zap.L().Info("Enabling kubelet config drop-in dir..")
+		zap.L().Info("Enabling kubelet config drop-in dir...")
 		k.setEnv("KUBELET_CONFIG_DROPIN_DIR_ALPHA", "on")
 		filePath := path.Join(dirPath, "00-nodeadm.conf")
 
@@ -478,7 +478,7 @@ func (k *kubelet) writeKubeletConfigToDir() error {
 			return err
 		}
 
-		zap.L().Info("Writing user kubelet config to drop-in file..", zap.String("path", filePath))
+		zap.L().Info("Writing user kubelet config to drop-in file...", zap.String("path", filePath))
 		userKubeletConfigBytes, err := json.MarshalIndent(userKubeletConfigMap, "", strings.Repeat(" ", 4))
 		if err != nil {
 			return err

--- a/internal/kubelet/install.go
+++ b/internal/kubelet/install.go
@@ -27,7 +27,7 @@ const (
 	artifactFilePerms = 0o755
 )
 
-var KubeletCurrentCertPath = path.Join(kubeconfigRoot, "pki", "kubelet-server-current.pem")
+var kubeletCurrentCertPath = path.Join(kubeconfigRoot, "pki", "kubelet-server-current.pem")
 
 //go:embed kubelet.service
 var kubeletUnitFile []byte
@@ -113,13 +113,13 @@ func Uninstall(opts UninstallOptions) error {
 		filepath.Join(opts.InstallRoot, UnitPath),
 		filepath.Join(opts.InstallRoot, kubeconfigPath),
 		filepath.Join(opts.InstallRoot, path.Dir(kubeletConfigRoot)),
-		filepath.Join(opts.InstallRoot, KubeletCurrentCertPath),
+		filepath.Join(opts.InstallRoot, kubeletCurrentCertPath),
 	}
 
 	allErrors := []error{}
 
 	// resolve the symlink and add actual file to remove
-	actualCertPath, err := filepath.EvalSymlinks(filepath.Join(opts.InstallRoot, KubeletCurrentCertPath))
+	actualCertPath, err := filepath.EvalSymlinks(filepath.Join(opts.InstallRoot, kubeletCurrentCertPath))
 	if err != nil && !os.IsNotExist(err) {
 		allErrors = append(allErrors, errors.Wrap(err, "resolving symlink for kubelet cert"))
 	}

--- a/internal/kubernetes/cert.go
+++ b/internal/kubernetes/cert.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/aws/eks-hybrid/internal/api"
 	"github.com/aws/eks-hybrid/internal/certificate"
-	"github.com/aws/eks-hybrid/internal/kubelet"
 	"github.com/aws/eks-hybrid/internal/validation"
 )
+
+const kubeletCurrentCertPath = "/var/lib/kubelet/pki/kubelet-server-current.pem"
 
 type KubeletCertificateValidator struct {
 	// CertPath is the full path to the kubelet certificate
@@ -32,7 +33,7 @@ func WithIgnoreDateAndNoCertErrors(ignore bool) func(*KubeletCertificateValidato
 func NewKubeletCertificateValidator(cluster *api.ClusterDetails, opts ...func(*KubeletCertificateValidator)) KubeletCertificateValidator {
 	v := &KubeletCertificateValidator{
 		cluster:  cluster,
-		certPath: kubelet.KubeletCurrentCertPath,
+		certPath: kubeletCurrentCertPath,
 	}
 	for _, opt := range opts {
 		opt(v)

--- a/internal/kubernetes/cert_test.go
+++ b/internal/kubernetes/cert_test.go
@@ -14,10 +14,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/eks-hybrid/internal/api"
-	"github.com/aws/eks-hybrid/internal/kubelet"
 	"github.com/aws/eks-hybrid/internal/kubernetes"
 	"github.com/aws/eks-hybrid/internal/test"
 )
+
+const kubeletCurrentCertPath = "/var/lib/kubelet/pki/kubelet-server-current.pem"
 
 func TestCheckKubeletCertificate(t *testing.T) {
 	g := NewGomegaWithT(t)
@@ -168,7 +169,7 @@ func TestCheckKubeletCertificate(t *testing.T) {
 			informer := test.NewFakeInformer()
 
 			tmpDir := t.TempDir()
-			certPath := filepath.Join(tmpDir, kubelet.KubeletCurrentCertPath)
+			certPath := filepath.Join(tmpDir, kubeletCurrentCertPath)
 			g.Expect(os.MkdirAll(filepath.Dir(certPath), 0o755)).To(Succeed())
 			if tt.cert != nil {
 				err := os.WriteFile(certPath, tt.cert, 0o600)

--- a/internal/kubernetes/validate.go
+++ b/internal/kubernetes/validate.go
@@ -1,4 +1,4 @@
-package node
+package kubernetes
 
 import (
 	"context"
@@ -14,7 +14,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/aws/eks-hybrid/internal/api"
-	k8s "github.com/aws/eks-hybrid/internal/kubernetes"
 	"github.com/aws/eks-hybrid/internal/network"
 	"github.com/aws/eks-hybrid/internal/retry"
 	"github.com/aws/eks-hybrid/internal/validation"
@@ -54,7 +53,7 @@ func (a APIServerValidator) MakeAuthenticatedRequest(ctx context.Context, inform
 		return err
 	}
 
-	_, err = k8s.GetRetry(ctx, client.CoreV1().Endpoints("default"), "kubernetes")
+	_, err = GetRetry(ctx, client.CoreV1().Endpoints("default"), "kubernetes")
 	if err != nil {
 		err = validation.WithRemediation(err, badPermissionsRemediation)
 		return err
@@ -146,7 +145,7 @@ func (a APIServerValidator) CheckVPCEndpointAccess(ctx context.Context, informer
 		return err
 	}
 
-	kubeEndpoint, err := k8s.GetRetry(ctx, client.CoreV1().Endpoints("default"), "kubernetes")
+	kubeEndpoint, err := GetRetry(ctx, client.CoreV1().Endpoints("default"), "kubernetes")
 	if err != nil {
 		err = validation.WithRemediation(err, badPermissionsRemediation)
 		return err

--- a/internal/node/ec2/configenricher.go
+++ b/internal/node/ec2/configenricher.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (enp *ec2NodeProvider) Enrich(ctx context.Context, opts ...configenricher.ConfigEnricherOption) error {
-	enp.logger.Info("Fetching instance details..")
+	enp.logger.Info("Fetching instance details...")
 	imdsClient := imds.New(imds.Options{})
 	awsConfig, err := config.LoadDefaultConfig(ctx, config.WithClientLogMode(aws.LogRetries), config.WithEC2IMDSRegion(func(o *config.UseEC2IMDSRegion) {
 		o.Client = imdsClient

--- a/internal/node/ec2/daemons.go
+++ b/internal/node/ec2/daemons.go
@@ -25,7 +25,7 @@ func (enp *ec2NodeProvider) GetDaemons() ([]daemon.Daemon, error) {
 	}
 	return []daemon.Daemon{
 		containerd.NewContainerdDaemon(enp.daemonManager, enp.nodeConfig, enp.awsConfig, enp.logger),
-		kubelet.NewKubeletDaemon(enp.daemonManager, enp.nodeConfig, enp.awsConfig, kubelet.CredentialProviderAwsConfig{}),
+		kubelet.NewKubeletDaemon(enp.daemonManager, enp.nodeConfig, enp.awsConfig, kubelet.CredentialProviderAwsConfig{}, nil, nil),
 	}, nil
 }
 

--- a/internal/node/hybrid/daemons.go
+++ b/internal/node/hybrid/daemons.go
@@ -31,7 +31,7 @@ func (hnp *HybridNodeProvider) GetDaemons() ([]daemon.Daemon, error) {
 	}
 	return []daemon.Daemon{
 		containerd.NewContainerdDaemon(hnp.daemonManager, hnp.nodeConfig, hnp.awsConfig, hnp.logger),
-		kubelet.NewKubeletDaemon(hnp.daemonManager, hnp.nodeConfig, hnp.awsConfig, credentialProviderAwsConfig),
+		kubelet.NewKubeletDaemon(hnp.daemonManager, hnp.nodeConfig, hnp.awsConfig, credentialProviderAwsConfig, hnp.logger, hnp.skipPhases),
 	}, nil
 }
 

--- a/internal/node/hybrid/nodeinactive_validator.go
+++ b/internal/node/hybrid/nodeinactive_validator.go
@@ -20,9 +20,9 @@ const (
 // ValidateNodeIsInactive checks to see if the node is potentially active.
 func (hnp *HybridNodeProvider) ValidateNodeIsInactive(ctx context.Context, informer validation.Informer, _ *api.NodeConfig) error {
 	var err error
-	informer.Starting(ctx, nodeInActiveValidation, "Validating that the node is inactive")
+	informer.Starting(ctx, nodeInactiveValidation, "Validating that the node is inactive")
 	defer func() {
-		informer.Done(ctx, nodeInActiveValidation, err)
+		informer.Done(ctx, nodeInactiveValidation, err)
 	}()
 
 	if _, statErr := os.Stat(kubeletEnvironmentFilePath); !os.IsNotExist(statErr) {

--- a/internal/node/hybrid/versionskew_validator_test.go
+++ b/internal/node/hybrid/versionskew_validator_test.go
@@ -120,6 +120,7 @@ func TestHybridNodeProvider_ValidateKubeletVersionSkew(t *testing.T) {
 					"api-server-endpoint-resolution-validation",
 					"proxy-validation",
 					"node-inactive-validation",
+					"aws-auth-validation",
 				},
 				zap.NewNop(),
 				hybrid.WithCluster(tt.cluster),

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewNodeProvider(configSource string, skipPhases []string, logger *zap.Logger) (nodeprovider.NodeProvider, error) {
-	logger.Info("Loading configuration..", zap.String("configSource", configSource))
+	logger.Info("Loading configuration...", zap.String("configSource", configSource))
 	provider, err := configprovider.BuildConfigProvider(configSource)
 	if err != nil {
 		return nil, err

--- a/internal/node/validate_test.go
+++ b/internal/node/validate_test.go
@@ -21,7 +21,7 @@ import (
 	fakeTesting "k8s.io/client-go/testing"
 
 	"github.com/aws/eks-hybrid/internal/api"
-	"github.com/aws/eks-hybrid/internal/node"
+	k8s "github.com/aws/eks-hybrid/internal/kubernetes"
 	"github.com/aws/eks-hybrid/internal/test"
 	"github.com/aws/eks-hybrid/internal/validation"
 )
@@ -60,7 +60,7 @@ func TestAPIServerValidator_MakeAuthenticatedRequest(t *testing.T) {
 			nodeConfig := &api.NodeConfig{}
 			kubelet := newMockKubelet(client, "v1.28.0")
 
-			v := node.NewAPIServerValidator(kubelet)
+			v := k8s.NewAPIServerValidator(kubelet)
 			err := v.MakeAuthenticatedRequest(ctx, informer, nodeConfig)
 			if tc.wantErr == "" {
 				g.Expect(err).To(BeNil())
@@ -83,7 +83,7 @@ func TestAPIServerValidator_MakeAuthenticatedRequest_FailBuildingClient(t *testi
 	kubelet := newMockKubelet(nil, "v1.28.0")
 	kubelet.clientError = errors.New("can't build client")
 
-	v := node.NewAPIServerValidator(kubelet)
+	v := k8s.NewAPIServerValidator(kubelet)
 	err := v.MakeAuthenticatedRequest(ctx, informer, nodeConfig)
 
 	g.Expect(err).To(MatchError(ContainSubstring("can't build client")))
@@ -214,7 +214,7 @@ func TestAPIServerValidator_CheckVPCEndpointAccess(t *testing.T) {
 			nodeConfig := &api.NodeConfig{}
 			kubelet := newMockKubelet(client, "v1.28.0")
 
-			v := node.NewAPIServerValidator(kubelet)
+			v := k8s.NewAPIServerValidator(kubelet)
 			err := v.CheckVPCEndpointAccess(ctx, informer, nodeConfig)
 			if tc.wantErr == "" {
 				g.Expect(err).To(BeNil())
@@ -329,7 +329,7 @@ func TestAPIServerValidator_CheckIdentity(t *testing.T) {
 			nodeConfig := &api.NodeConfig{}
 			kubelet := newMockKubelet(client, tc.kubeletVersion)
 
-			v := node.NewAPIServerValidator(kubelet)
+			v := k8s.NewAPIServerValidator(kubelet)
 			err := v.CheckIdentity(ctx, informer, nodeConfig)
 			if tc.wantErr == "" {
 				g.Expect(err).To(BeNil())

--- a/test/integration/cases/containerd-config/run.sh
+++ b/test/integration/cases/containerd-config/run.sh
@@ -10,7 +10,7 @@ mock::aws
 mock::kubelet 1.28.0
 wait::dbus-ready
 
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 
 assert::files-equal /etc/containerd/config.toml expected-containerd-config.toml
 assert::files-equal /etc/containerd/config.d/00-nodeadm.toml expected-user-containerd-config.toml

--- a/test/integration/cases/hybrid-node-system-aspects/run.sh
+++ b/test/integration/cases/hybrid-node-system-aspects/run.sh
@@ -22,7 +22,7 @@ systemctl start firewalld
 # allow cilium vxlan
 firewall-cmd --permanent --add-port=4789/udp
 
-nodeadm init --skip run,install-validation,node-ip-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,node-ip-validation,aws-auth-validation,k8s-authentication-validation --config-source file://config.yaml
 
 # Check if aws config file has been created as specifed in NodeConfig
 assert::files-equal /.aws/config expected-aws-config
@@ -41,7 +41,7 @@ assert::allowed-by-firewalld "30000-32767" "tcp"
 
 exit_code=0
 systemctl stop firewalld
-STDERR=$(nodeadm init --skip run,install-validation --config-source file://config.yaml 2>&1) || exit_code=$?
+STDERR=$(nodeadm init --skip run,install-validation,aws-auth-validation,k8s-authentication-validation --config-source file://config.yaml 2>&1) || exit_code=$?
 if [ $exit_code -ne 0]; then
   echo "nodeadm init should not fail with firewall-cmd installed but firewalld service not running"
   exit 1

--- a/test/integration/cases/image-credential-provider/run.sh
+++ b/test/integration/cases/image-credential-provider/run.sh
@@ -11,12 +11,12 @@ wait::dbus-ready
 
 mock::kubelet 1.26.0
 
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 
 assert::json-files-equal /etc/eks/image-credential-provider/config.json expected-image-credential-provider-config-126.json
 
 mock::kubelet 1.28.0
 
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 
 assert::json-files-equal /etc/eks/image-credential-provider/config.json expected-image-credential-provider-config-127.json

--- a/test/integration/cases/init-with-config-enrichment/run.sh
+++ b/test/integration/cases/init-with-config-enrichment/run.sh
@@ -21,7 +21,7 @@ nodeadm install $CURRENT_VERSION  --credential-provider iam-ra
 mock::aws_signing_helper
 
 exit_code=0
-STDERR=$(nodeadm init --skip run,node-ip-validation --config-source file://config.yaml 2>&1) || exit_code=$?
+STDERR=$(nodeadm init --skip run,node-ip-validation,k8s-authentication-validation --config-source file://config.yaml 2>&1) || exit_code=$?
 if [ $exit_code -ne 0 ]; then
     assert::is-substring "$STDERR" "ResourceNotFoundException"
 else
@@ -37,7 +37,7 @@ aws eks create-cluster \
     --resources-vpc-config subnetIds=subnet-123456789012,subnet-123456789013,securityGroupIds=sg-123456789014,endpointPrivateAccess=true,endpointPublicAccess=false \
     --remote-network-config '{"remoteNodeNetworks":[{"cidrs":["10.100.0.0/16"]}],"remotePodNetworks":[{"cidrs":["10.101.0.0/16"]}]}'
 
-if ! nodeadm init --skip run,node-ip-validation --config-source file://config.yaml; then
+if ! nodeadm init --skip run,node-ip-validation,k8s-authentication-validation --config-source file://config.yaml; then
     echo "nodeadm init should have succeeded after creating the cluster"
     exit 1
 fi

--- a/test/integration/cases/init-with-iam-custom-cert-path/run.sh
+++ b/test/integration/cases/init-with-iam-custom-cert-path/run.sh
@@ -29,7 +29,7 @@ VALIDATION_CERT="$PKI_DIR/my-server_cert_validation.crt"
 VALIDATION_KEY="$PKI_DIR/my-server_key_validation.key"
 
 # Test 1: Verify that nodeadm init fails when the certificate doesn't exist
-if nodeadm init --skip run,node-ip-validation --config-source file://config-certificate-validation.yaml; then
+if nodeadm init --skip run,node-ip-validation,aws-auth-validation,k8s-authentication-validation --config-source file://config-certificate-validation.yaml; then
     echo "nodeadm init should have failed with iam-roles-anywhere certificate not exist but succeeded unexpectedly"
     exit 1
 fi
@@ -37,7 +37,7 @@ fi
 # Test 2: Verify that INIT fails when the certificate is empty
 touch $VALIDATION_CERT
 touch $VALIDATION_KEY
-if nodeadm init --skip run,node-ip-validation --config-source file://config-certificate-validation.yaml; then
+if nodeadm init --skip run,node-ip-validation,aws-auth-validation,k8s-authentication-validation --config-source file://config-certificate-validation.yaml; then
     echo "nodeadm init should have failed with iam-roles-anywhere certificate file empty but succeeded unexpectedly"
     exit 1
 fi
@@ -48,7 +48,7 @@ rm $VALIDATION_KEY
 # Test 3: Verify that INIT fails when the certificate is corrupted by adding random data
 echo "CORRUPTED_DATA" >> $VALIDATION_CERT
 cp $KEY $VALIDATION_KEY
-if nodeadm init --skip run,node-ip-validation --config-source file://config-certificate-validation.yaml; then
+if nodeadm init --skip run,node-ip-validation,aws-auth-validation,k8s-authentication-validation --config-source file://config-certificate-validation.yaml; then
     echo "nodeadm init should have failed with iam-roles-anywhere certificate wrong file but succeeded unexpectedly"
     exit 1
 fi
@@ -60,7 +60,7 @@ VALIDATION_CERT="$PKI_DIR/my-server_cert_validation.crt"
 cp $CERT $VALIDATION_CERT
 cp $KEY $VALIDATION_KEY
 sed -i '2s/$/A/' "$VALIDATION_CERT"
-if nodeadm init --skip run,node-ip-validation --config-source file://config-certificate-validation.yaml; then
+if nodeadm init --skip run,node-ip-validation,aws-auth-validatio,k8s-authentication-validation --config-source file://config-certificate-validation.yaml; then
     echo "nodeadm init should have failed with iam-roles-anywhere certificate with corrupted file but succeeded unexpectedly"
     exit 1
 fi
@@ -68,6 +68,6 @@ rm $VALIDATION_CERT
 rm $VALIDATION_KEY
 
 # Success case
-nodeadm init --skip run,node-ip-validation --config-source file://config.yaml
+nodeadm init --skip run,node-ip-validation,aws-auth-validation,k8s-authentication-validation --config-source file://config.yaml
 validate-file /etc/systemd/system/aws_signing_helper_update.service 644 expected-aws-signing-helper-systemd-unit
 validate-file /.aws/config 644 expected-aws-config

--- a/test/integration/cases/init-with-node-ip-validation/run.sh
+++ b/test/integration/cases/init-with-node-ip-validation/run.sh
@@ -28,10 +28,10 @@ nodeadm install $CURRENT_VERSION --credential-provider iam-ra
 mock::aws_signing_helper
 
 # should fail when --node-ip set to ip not in remote node networks
-if nodeadm init --skip run --config-source file://config-ip-out-of-range.yaml; then
+if nodeadm init --skip run,k8s-authentication-validation --config-source file://config-ip-out-of-range.yaml; then
     echo "nodeadm init should have failed with ip out of range but succeeded unexpectedly"
     exit 1
 fi
 
 # should succeed when --node-ip set to ip in remote node networks
-nodeadm init --skip run --config-source file://config-ip-in-range.yaml
+nodeadm init --skip run,k8s-authentication-validation --config-source file://config-ip-in-range.yaml

--- a/test/integration/cases/init-with-ssm/run.sh
+++ b/test/integration/cases/init-with-ssm/run.sh
@@ -16,7 +16,7 @@ dnf remove -y containerd
 nodeadm install $CURRENT_VERSION --credential-provider ssm
 
 mock::ssm
-nodeadm init --skip run,preprocess,node-ip-validation --config-source file://config.yaml
+nodeadm init --skip run,preprocess,node-ip-validation,k8s-authentication-validation --config-source file://config.yaml
 
 assert::path-exists /root/.aws
 assert::path-exists /eks-hybrid/.aws

--- a/test/integration/cases/init-with-swap-partition/run.sh
+++ b/test/integration/cases/init-with-swap-partition/run.sh
@@ -21,7 +21,7 @@ mount --bind $(pwd)/swaps-partition /proc/swaps
 assert::path-exists /usr/bin/containerd
 
 exit_code=0
-STDERR=$(nodeadm init --config-source file://config.yaml --skip node-ip-validation 2>&1) || exit_code=$?
+STDERR=$(nodeadm init --config-source file://config.yaml --skip node-ip-validation,aws-auth-validation,k8s-authentication-validation 2>&1) || exit_code=$?
 if [ $exit_code -ne 0 ]; then
     assert::is-substring "$STDERR" "partition type swap found on the host"
 else
@@ -30,7 +30,7 @@ else
 fi
 
 mount --bind $(pwd)/swaps-file /proc/swaps
-if ! nodeadm init --skip run,node-ip-validation --config-source file://config.yaml; then
+if ! nodeadm init --skip run,node-ip-validation,aws-auth-validation,k8s-authentication-validation --config-source file://config.yaml; then
     echo "nodeadm should have successfully completed init"
     exit 1
 fi

--- a/test/integration/cases/kubeconfig-outpost/run.sh
+++ b/test/integration/cases/kubeconfig-outpost/run.sh
@@ -10,6 +10,6 @@ mock::aws
 wait::dbus-ready
 
 mock::kubelet 1.28.0
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::file-contains /etc/hosts $'127.0.0.1\tlocalhost'
 assert::file-contains /etc/hosts $'::1\tlocalhost'

--- a/test/integration/cases/kubeconfig/run.sh
+++ b/test/integration/cases/kubeconfig/run.sh
@@ -10,9 +10,9 @@ mock::aws
 wait::dbus-ready
 
 mock::kubelet 1.23.0
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::files-equal /var/lib/kubelet/kubeconfig expected-kubeconfig.yaml
 
 mock::kubelet 1.28.0
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::files-equal /var/lib/kubelet/kubeconfig expected-kubeconfig.yaml

--- a/test/integration/cases/kubelet-config-dir/run.sh
+++ b/test/integration/cases/kubelet-config-dir/run.sh
@@ -11,7 +11,7 @@ mock::kubelet 1.29.0
 wait::dbus-ready
 
 for config in config.*; do
-  nodeadm init --skip run,install-validation --config-source file://${config}
+  nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://${config}
   assert::json-files-equal /etc/kubernetes/kubelet/config.json expected-kubelet-config.json
   assert::json-files-equal /etc/kubernetes/kubelet/config.json.d/00-nodeadm.conf expected-kubelet-config-drop-in.json
 done

--- a/test/integration/cases/kubelet-config-new-instance-type/run.sh
+++ b/test/integration/cases/kubelet-config-new-instance-type/run.sh
@@ -13,6 +13,6 @@ mock::kubelet 1.28.0
 wait::dbus-ready
 
 for config in config.*; do
-  nodeadm init --skip run,install-validation --config-source file://${config}
+  nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://${config}
   assert::json-files-equal /etc/kubernetes/kubelet/config.json expected-kubelet-config.json
 done

--- a/test/integration/cases/kubelet-config-set-empty/run.sh
+++ b/test/integration/cases/kubelet-config-set-empty/run.sh
@@ -16,5 +16,5 @@ wait::dbus-ready
 #
 # see: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
 
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::json-files-equal /etc/kubernetes/kubelet/config.json expected-kubelet-config.json

--- a/test/integration/cases/kubelet-config/run.sh
+++ b/test/integration/cases/kubelet-config/run.sh
@@ -11,6 +11,6 @@ mock::kubelet 1.28.0
 wait::dbus-ready
 
 for config in config.*; do
-  nodeadm init --skip run,install-validation --config-source file://${config}
+  nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://${config}
   assert::json-files-equal /etc/kubernetes/kubelet/config.json expected-kubelet-config.json
 done

--- a/test/integration/cases/kubelet-flags/run.sh
+++ b/test/integration/cases/kubelet-flags/run.sh
@@ -10,6 +10,6 @@ mock::aws
 mock::kubelet 1.28.0
 wait::dbus-ready
 
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 
 assert::file-contains /etc/eks/kubelet/environment '--v=5 --node-labels=foo=bar,foo2=baz --register-with-taints=foo=bar:NoSchedule"$'

--- a/test/integration/cases/kubelet-version/run.sh
+++ b/test/integration/cases/kubelet-version/run.sh
@@ -10,31 +10,31 @@ mock::aws
 wait::dbus-ready
 
 mock::kubelet 1.21.0
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::file-not-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS"'
 assert::file-not-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst"'
 
 mock::kubelet 1.22.0-eks-5e0fdde
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS": 10'
 assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst": 20'
 
 mock::kubelet 1.22.0
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS": 10'
 assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst": 20'
 
 mock::kubelet 1.26.0-eks-5e0fdde
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS": 10'
 assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst": 20'
 
 mock::kubelet 1.26.0
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS": 10'
 assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst": 20'
 
 mock::kubelet 1.28.0-eks-5e0fdde
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::file-not-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS"'
 assert::file-not-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst"'

--- a/test/integration/cases/local-disks/run.sh
+++ b/test/integration/cases/local-disks/run.sh
@@ -12,6 +12,6 @@ mock::kubelet 1.29.0
 
 mock::setup-local-disks
 
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 
 assert::file-contains /var/log/setup-local-disks.log 'raid0'

--- a/test/integration/cases/pod-infra-container/run.sh
+++ b/test/integration/cases/pod-infra-container/run.sh
@@ -10,9 +10,9 @@ mock::aws
 wait::dbus-ready
 
 mock::kubelet 1.28.0
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::file-contains /etc/eks/kubelet/environment '--pod-infra-container-image=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5'
 
 mock::kubelet 1.29.0
-nodeadm init --skip run,install-validation --config-source file://config.yaml
+nodeadm init --skip run,install-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::file-not-contains /etc/eks/kubelet/environment 'pod-infra-container-image'

--- a/test/integration/cases/uninstall-with-source-none/run.sh
+++ b/test/integration/cases/uninstall-with-source-none/run.sh
@@ -19,7 +19,7 @@ assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 
 # mock iam-ra update service credentials file
 mock::iamra_aws_credentials
-nodeadm init --skip run,node-ip-validation --config-source file://config.yaml
+nodeadm init --skip run,node-ip-validation,aws-auth-validation,k8s-authentication-validation --config-source file://config.yaml
 
 nodeadm uninstall --skip run,node-validation,pod-validation
 
@@ -33,7 +33,7 @@ yq -i '.Artifacts.Containerd = ""' /opt/nodeadm/tracker
 
 # mock iam-ra update service credentials file
 mock::iamra_aws_credentials
-nodeadm init --skip run,node-ip-validation --config-source file://config.yaml
+nodeadm init --skip run,node-ip-validation,aws-auth-validation,k8s-authentication-validation --config-source file://config.yaml
 
 nodeadm uninstall --skip run,node-validation,pod-validation
 

--- a/test/integration/cases/upgrade-with-iam/run.sh
+++ b/test/integration/cases/upgrade-with-iam/run.sh
@@ -49,7 +49,7 @@ assert::file-permission-matches /usr/local/bin/aws-iam-authenticator 755
 
 # mock iam-ra update service credentials file
 mock::iamra_aws_credentials
-nodeadm init --skip run,node-ip-validation --config-source file://config.yaml
+nodeadm init --skip run,node-ip-validation,aws-auth-validation,k8s-authentication-validation --config-source file://config.yaml
 validate-file /etc/systemd/system/aws_signing_helper_update.service 644 expected-aws-signing-helper-systemd-unit
 validate-file /.aws/config 644 expected-aws-config
 # The memory reserved by kubelet is dynamic depending on the host that builts the docker image
@@ -84,7 +84,7 @@ systemctl disable aws_signing_helper_update.service
 systemctl daemon-reload
 systemctl reset-failed
 
-nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation,init-validation,node-ip-validation --config-source file://config.yaml
+nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation,init-validation,node-ip-validation,k8s-authentication-validation --config-source file://config.yaml
 
 # We expect these artifacts to have changed with upgrade, so their stat files would be different now
 assert::birth-not-match /usr/bin/kubelet
@@ -131,7 +131,7 @@ generate::birth-file /usr/bin/kubelet
 generate::birth-file /usr/local/bin/kubectl
 generate::birth-file /etc/eks/image-credential-provider/ecr-credential-provider
 
-nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation,init-validation --config-source file://config.yaml
+nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation,init-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::birth-match /usr/bin/kubelet
 assert::birth-match /usr/local/bin/kubectl
 assert::birth-match /usr/bin/containerd

--- a/test/integration/cases/upgrade-with-source-none/run.sh
+++ b/test/integration/cases/upgrade-with-source-none/run.sh
@@ -33,7 +33,7 @@ assert::birth-match /usr/bin/containerd
 
 # mock iam-ra update service credentials file
 mock::iamra_aws_credentials
-nodeadm init --skip run,node-ip-validation --config-source file://config.yaml
+nodeadm init --skip run,node-ip-validation,aws-auth-validation,k8s-authentication-validation --config-source file://config.yaml
 
 # In integration test environment, the aws_signing_helper_update will run
 # but stuck in a loop of failure which prevents the next nodeadm init call
@@ -43,6 +43,6 @@ systemctl disable aws_signing_helper_update.service
 systemctl daemon-reload
 systemctl reset-failed
 
-nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation,init-validation,node-ip-validation --config-source file://config.yaml
+nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation,init-validation,node-ip-validation,k8s-authentication-validation --config-source file://config.yaml
 
 assert::birth-match /usr/bin/containerd

--- a/test/integration/cases/upgrade-with-ssm/run.sh
+++ b/test/integration/cases/upgrade-with-ssm/run.sh
@@ -45,7 +45,7 @@ assert::file-permission-matches /usr/local/bin/aws-iam-authenticator 755
 assert::file-permission-matches /opt/ssm/ssm-setup-cli 755
 
 mock::ssm
-nodeadm init --skip run,preprocess,node-ip-validation --config-source file://config.yaml
+nodeadm init --skip run,preprocess,node-ip-validation,k8s-authentication-validation --config-source file://config.yaml
 
 # The memory reserved by kubelet is dynamic depending on the host that builts the docker image
 # Remove kubeReserved field before checking its content
@@ -70,7 +70,7 @@ generate::birth-file /usr/bin/amazon-ssm-agent
 # Create dummy cilium-cni to ensure cilium isnt getting replaced
 touch /opt/cni/cilium-cni
 
-nodeadm upgrade $TARGET_VERSION --skip run,preprocess,pod-validation,node-validation,init-validation,node-ip-validation --config-source file://config.yaml
+nodeadm upgrade $TARGET_VERSION --skip run,preprocess,pod-validation,node-validation,init-validation,node-ip-validation,k8s-authentication-validation --config-source file://config.yaml
 
 assert::birth-not-match /usr/bin/kubelet
 assert::birth-not-match /usr/local/bin/kubectl
@@ -114,7 +114,7 @@ generate::birth-file /usr/bin/kubelet
 generate::birth-file /usr/local/bin/kubectl
 generate::birth-file /etc/eks/image-credential-provider/ecr-credential-provider
 
-nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation,init-validation --config-source file://config.yaml
+nodeadm upgrade $TARGET_VERSION --skip run,pod-validation,node-validation,init-validation,k8s-authentication-validation --config-source file://config.yaml
 assert::birth-match /usr/bin/kubelet
 assert::birth-match /usr/local/bin/kubectl
 assert::birth-match /usr/bin/containerd


### PR DESCRIPTION
This PR adds validations for AWS creds and K8s creds to the `nodeadm init` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

