### PR TITLE
Validate cloudwatch observability agent addon  in mixed mode

### DIFF
--- a/hybrid-nodes-cdk/lib/nodeadm/policies.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm/policies.ts
@@ -7,7 +7,7 @@ export function createNodeadmTestsCreationCleanupPolicy(
   testClusterPrefix: string,
   binaryBucketArn: string,
   podIdentityS3BucketPrefix: string,
-) {
+): iam.ManagedPolicy[] {
   const requestTagCondition = {
     StringLike: {
       [`aws:RequestTag/${testClusterTagKey}`]: `${testClusterPrefix}-*`,
@@ -18,7 +18,9 @@ export function createNodeadmTestsCreationCleanupPolicy(
       [`aws:ResourceTag/${testClusterTagKey}`]: `${testClusterPrefix}-*`,
     },
   };
-  return new iam.Policy(stack, 'nodeadm-e2e-tests-runner-policy', {
+
+ 
+  const iamPolicy = new iam.ManagedPolicy(stack, 'nodeadm-e2e-tests-iam-policy', {
     statements: [
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
@@ -77,14 +79,57 @@ export function createNodeadmTestsCreationCleanupPolicy(
         conditions: requestTagCondition,
       }),
       new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
         actions: [
-          'cloudformation:ListStacks',
-          'cloudformation:DescribeStacks',
-          'ec2:AcceptVpcPeeringConnection',
-          'ec2:AssociateRouteTable',
-          'ec2:AssociateTransitGatewayRouteTable',
-          'ec2:AttachInternetGateway',
-          'ec2:AuthorizeSecurityGroupIngress',
+          'iam:ListOpenIDConnectProviders',
+          'iam:CreateOpenIDConnectProvider',
+          'iam:UpdateAssumeRolePolicy',
+        ],
+        resources: [
+          `arn:aws:iam::${stack.account}:oidc-provider/*`,
+          `arn:aws:iam::${stack.account}:role/*CloudWatch*`,
+        ],
+      }),
+    ],
+  });
+
+  const ec2Policy = new iam.ManagedPolicy(stack, 'nodeadm-e2e-tests-ec2-policy', {
+    statements: [
+      new iam.PolicyStatement({
+        actions: [
+          'ec2:DescribeInstances',
+          'ec2:DescribeInstanceTypes',
+          'ec2:DescribeInstanceAttribute',
+          'ec2:DescribeInstanceStatus',
+          'ec2:DescribeSecurityGroups',
+          'ec2:DescribeSubnets',
+          'ec2:DescribeVpcs',
+          'ec2:DescribeRouteTables',
+          'ec2:DescribeRoutes',
+          'ec2:DescribeTransitGateways',
+          'ec2:DescribeTransitGatewayAttachments',
+          'ec2:DescribeTransitGatewayRouteTables',
+          'ec2:DescribeTransitGatewayVpcAttachments',
+          'ec2:DescribeVpcPeeringConnections',
+          'ec2:DescribeLaunchTemplates',
+          'ec2:DescribeLaunchTemplateVersions',
+          'ec2:DescribeFleets',
+          'ec2:DescribeNetworkInterfaces',
+          'ec2:DescribeSnapshots',
+          'ec2:DescribeImages',
+          'ec2:DescribeKeyPairs',
+          'ec2:DescribeAvailabilityZones',
+          'ec2:DescribeRegions',
+          'ec2:DescribeInternetGateways',
+          'ec2:DescribeNatGateways',
+          'ec2:DescribeVpcEndpoints',
+          'ec2:DescribeTags',
+        ],
+        resources: ['*'],
+        effect: iam.Effect.ALLOW,
+      }),
+      new iam.PolicyStatement({
+        actions: [
           'ec2:CreateFleet',
           'ec2:CreateLaunchTemplate',
           'ec2:CreateLaunchTemplateVersion',
@@ -96,35 +141,75 @@ export function createNodeadmTestsCreationCleanupPolicy(
           'ec2:CreateTransitGatewayRouteTable',
           'ec2:CreateTransitGatewayVpcAttachment',
           'ec2:CreateVpcPeeringConnection',
-          'ec2:DeleteFleets',
-          'ec2:DeleteKeyPair',
-          'ec2:DeleteLaunchTemplate',
-          'ec2:DeleteNetworkInterface',
-          'ec2:DeleteRouteTable',
+          'ec2:CreateSecurityGroup',
+          'ec2:CreateNetworkInterface',
+          'ec2:CreateSnapshot',
+          'ec2:CreateImage',
+          'ec2:CreateNatGateway',
+          'ec2:CreateVpcEndpoint',
+        ],
+        resources: ['*'],
+        effect: iam.Effect.ALLOW,
+      }),
+      new iam.PolicyStatement({
+        actions: [
           'ec2:DeleteSecurityGroup',
+          'ec2:DeleteRoute',
+          'ec2:DeleteRouteTable',
+          'ec2:DeleteSubnet',
           'ec2:DeleteTransitGateway',
           'ec2:DeleteTransitGatewayRoute',
           'ec2:DeleteTransitGatewayRouteTable',
           'ec2:DeleteTransitGatewayVpcAttachment',
-          'ec2:DescribeAvailabilityZones',
-          'ec2:DescribeFleets',
-          'ec2:DescribeImages',
-          'ec2:DescribeInstances',
-          'ec2:DescribeInstanceStatus',
-          'ec2:DescribeInternetGateways',
-          'ec2:DescribeKeyPairs',
-          'ec2:DescribeLaunchTemplates',
-          'ec2:DescribeLaunchTemplateVersions',
-          'ec2:DescribeNetworkInterfaces',
-          'ec2:DescribeRouteTables',
-          'ec2:DescribeSecurityGroups',
-          'ec2:DescribeSubnets',
-          'ec2:DescribeTransitGateways',
-          'ec2:DescribeTransitGatewayAttachments',
-          'ec2:DescribeTransitGatewayRouteTables',
-          'ec2:DescribeTransitGatewayVpcAttachments',
-          'ec2:DescribeVpcPeeringConnections',
-          'ec2:DescribeVpcs',
+          'ec2:DeleteVpcPeeringConnection',
+          'ec2:DeleteLaunchTemplate',
+          'ec2:DeleteLaunchTemplateVersion',
+          'ec2:DeleteFleets',
+          'ec2:DeleteKeyPair',
+          'ec2:DeleteNetworkInterface',
+          'ec2:DeleteSnapshot',
+          'ec2:DeleteImage',
+          'ec2:DeleteInternetGateway',
+          'ec2:DeleteVpc',
+          'ec2:DeleteNatGateway',
+          'ec2:DeleteVpcEndpoint',
+        ],
+        resources: ['*'],
+        effect: iam.Effect.ALLOW,
+      }),
+      new iam.PolicyStatement({
+        actions: ['ec2:CreateInternetGateway', 'ec2:CreateKeyPair', 'ec2:CreateTags', 'ec2:CreateVpc'],
+        resources: ['*'],
+        effect: iam.Effect.ALLOW,
+        conditions: requestTagCondition,
+      }),
+      new iam.PolicyStatement({
+        actions: [
+          'ec2:DetachInternetGateway',
+          'ec2:DisassociateRouteTable',
+          'ec2:RebootInstances',
+          'ec2:StopInstances',
+          'ec2:TerminateInstances',
+          'ec2-instance-connect:SendSerialConsoleSSHPublicKey',
+        ],
+        resources: ['*'],
+        effect: iam.Effect.ALLOW,
+        conditions: resourceTagCondition,
+      }),
+    ],
+  });
+
+  const servicesPolicy = new iam.ManagedPolicy(stack, 'nodeadm-e2e-tests-services-policy', {
+    statements: [
+      new iam.PolicyStatement({
+        actions: [
+          'cloudformation:ListStacks',
+          'cloudformation:DescribeStacks',
+          'ec2:AcceptVpcPeeringConnection',
+          'ec2:AssociateRouteTable',
+          'ec2:AssociateTransitGatewayRouteTable',
+          'ec2:AttachInternetGateway',
+          'ec2:AuthorizeSecurityGroupIngress',
           'ec2:DisassociateTransitGatewayRouteTable',
           'ec2:GetLaunchTemplateData',
           'ec2:GetTransitGatewayRouteTableAssociations',
@@ -154,28 +239,58 @@ export function createNodeadmTestsCreationCleanupPolicy(
         effect: iam.Effect.ALLOW,
       }),
       new iam.PolicyStatement({
-        actions: ['ec2:CreateInternetGateway', 'ec2:CreateKeyPair', 'ec2:CreateTags', 'ec2:CreateVpc'],
-        resources: ['*'],
         effect: iam.Effect.ALLOW,
+        actions: ['s3:GetObject', 's3:ListBucket'],
+        resources: [binaryBucketArn, `${binaryBucketArn}/*`],
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          's3:CreateBucket',
+          's3:DeleteBucket',
+          's3:PutBucketTagging',
+          's3:GetBucketTagging',
+          's3:ListBucket',
+          's3:PutObject*',
+          's3:DeleteObject',
+          's3:ListAllMyBuckets',
+        ],
+        resources: [`arn:aws:s3:::${podIdentityS3BucketPrefix}*`],
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['eks:CreateAccessEntry', 'eks:DescribeCluster', 'eks:ListClusters', 'eks:TagResource'],
+        resources: [
+          `arn:aws:eks:${stack.region}:${stack.account}:cluster/*`,
+          `arn:aws:eks:${stack.region}:${stack.account}:access-entry/*`,
+        ],
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['eks:CreateCluster'],
+        resources: [`arn:aws:eks:${stack.region}:${stack.account}:cluster/*`],
         conditions: requestTagCondition,
       }),
       new iam.PolicyStatement({
-        actions: [
-          'ec2:DeleteInternetGateway',
-          'ec2:DeleteRoute',
-          'ec2:DeleteSubnet',
-          'ec2:DeleteVpc',
-          'ec2:DeleteVpcPeeringConnection',
-          'ec2:DetachInternetGateway',
-          'ec2:DisassociateRouteTable',
-          'ec2:RebootInstances',
-          'ec2:StopInstances',
-          'ec2:TerminateInstances',
-          'ec2-instance-connect:SendSerialConsoleSSHPublicKey',
-        ],
-        resources: ['*'],
         effect: iam.Effect.ALLOW,
+        actions: ['eks:DeleteCluster', 'eks:ListUpdates', 'eks:DescribeUpdate'],
+        resources: [`arn:aws:eks:${stack.region}:${stack.account}:cluster/*`],
         conditions: resourceTagCondition,
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['eks:DeleteAccessEntry', 'eks:DescribeAccessEntry', 'eks:ListAssociatedAccessPolicies'],
+        resources: [`arn:aws:eks:${stack.region}:${stack.account}:access-entry/*`],
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['eks:CreateAddon', 'eks:CreatePodIdentityAssociation'],
+        resources: [`arn:aws:eks:${stack.region}:${stack.account}:cluster/*`],
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['eks:DeleteAddon', 'eks:DescribeAddon'],
+        resources: [`arn:aws:eks:${stack.region}:${stack.account}:addon/*`],
       }),
       new iam.PolicyStatement({
         actions: ['ssm:SendCommand'],
@@ -215,59 +330,12 @@ export function createNodeadmTestsCreationCleanupPolicy(
         actions: ['secretsmanager:GetSecretValue'],
         resources: [`arn:aws:secretsmanager:${stack.region}:${stack.account}:secret:*`],
       }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['s3:GetObject', 's3:ListBucket'],
-        resources: [binaryBucketArn, `${binaryBucketArn}/*`],
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: [
-          's3:CreateBucket',
-          's3:DeleteBucket',
-          's3:PutBucketTagging',
-          's3:GetBucketTagging',
-          's3:ListBucket',
-          's3:PutObject*',
-          's3:DeleteObject',
-        ],
-        resources: [`arn:aws:s3:::${podIdentityS3BucketPrefix}*`],
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['eks:CreateAccessEntry', 'eks:DescribeCluster', 'eks:ListClusters', 'eks:TagResource'],
-        resources: [
-          `arn:aws:eks:${stack.region}:${stack.account}:cluster/*`,
-          `arn:aws:eks:${stack.region}:${stack.account}:access-entry/*`,
-        ],
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['eks:CreateCluster'],
-        resources: [`arn:aws:eks:${stack.region}:${stack.account}:cluster/*`],
-        conditions: requestTagCondition,
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['eks:DeleteCluster', 'eks:ListUpdates', 'eks:DescribeUpdate'],
-        resources: [`arn:aws:eks:${stack.region}:${stack.account}:cluster/*`],
-        conditions: resourceTagCondition,
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['eks:DeleteAccessEntry', 'eks:DescribeAccessEntry', 'eks:ListAssociatedAccessPolicies'],
-        resources: [`arn:aws:eks:${stack.region}:${stack.account}:access-entry/*`],
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['eks:CreateAddon', 'eks:CreatePodIdentityAssociation'],
-        resources: [`arn:aws:eks:${stack.region}:${stack.account}:cluster/*`],
-      }),
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['eks:DeleteAddon', 'eks:DescribeAddon'],
-        resources: [`arn:aws:eks:${stack.region}:${stack.account}:addon/*`],
-      }),
+    ],
+  });
+
+
+  const additionalPolicy = new iam.ManagedPolicy(stack, 'nodeadm-e2e-tests-additional-policy', {
+    statements: [
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: [
@@ -354,4 +422,6 @@ export function createNodeadmTestsCreationCleanupPolicy(
       }),
     ],
   });
+
+  return [iamPolicy, ec2Policy, servicesPolicy, additionalPolicy];
 }

--- a/internal/system/os.go
+++ b/internal/system/os.go
@@ -1,6 +1,12 @@
 package system
 
-import "github.com/go-ini/ini"
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-ini/ini"
+	"go.uber.org/zap"
+)
 
 const (
 	UbuntuOsName = "ubuntu"
@@ -22,4 +28,29 @@ func GetOsName() string {
 func GetVersionCodeName() string {
 	cfg, _ := ini.Load("/etc/os-release")
 	return cfg.Section("").Key("VERSION_CODENAME").String()
+}
+
+// SetupRHELJournalCompatibility creates a symlink from /var/log/journal to /run/log/journal
+// on RHEL nodes to ensure compatibility with systemd-journald logging.
+func SetupRHELJournalCompatibility(logger *zap.Logger) error {
+	if GetOsName() == RhelOsName {
+		symlinkPath := "/var/log/journal"
+		targetPath := "/run/log/journal"
+
+		// Check if symlink already exists
+		if _, err := os.Lstat(symlinkPath); os.IsNotExist(err) {
+			if err := os.MkdirAll("/var/log", 0o755); err != nil {
+				return fmt.Errorf("failed to create /var/log directory: %w", err)
+			}
+
+			if err := os.Symlink(targetPath, symlinkPath); err != nil {
+				return fmt.Errorf("failed to create journal symlink: %w", err)
+			}
+
+			logger.Info("Created RHEL journal compatibility symlink",
+				zap.String("symlink", symlinkPath),
+				zap.String("target", targetPath))
+		}
+	}
+	return nil
 }

--- a/test/e2e/addon/cloudwatch.go
+++ b/test/e2e/addon/cloudwatch.go
@@ -3,10 +3,18 @@ package addon
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	clientgo "k8s.io/client-go/kubernetes"
 
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
@@ -14,124 +22,468 @@ import (
 
 type CloudWatchAddon struct {
 	Addon
+	roleArn string
 }
 
 const (
 	cloudwatchAddonName        = "amazon-cloudwatch-observability"
 	cloudwatchNamespace        = "amazon-cloudwatch"
+	cloudwatchServiceAccount   = "cloudwatch-agent"
 	cloudwatchComponentTimeout = 10 * time.Minute
 	cloudwatchCheckInterval    = 15 * time.Second
+	logCollectionWaitTime      = 10 * time.Minute
 )
 
 // NewCloudWatchAddon creates a new CloudWatch Observability addon instance
-func NewCloudWatchAddon(cluster string) CloudWatchAddon {
+func NewCloudWatchAddon(cluster, roleArn string) CloudWatchAddon {
 	return CloudWatchAddon{
 		Addon: Addon{
 			Cluster: cluster,
 			Name:    cloudwatchAddonName,
 		},
+		roleArn: roleArn,
 	}
 }
 
-// WaitForComponents waits for CloudWatch components to be ready
-func (cw CloudWatchAddon) WaitForComponents(ctx context.Context, k8sClient clientgo.Interface, logger logr.Logger) error {
-	timeout := time.After(cloudwatchComponentTimeout)
-	ticker := time.NewTicker(cloudwatchCheckInterval)
-	defer ticker.Stop()
+// SetupIRSA sets up complete IRSA configuration for CloudWatch observability addon
+func (cw *CloudWatchAddon) SetupIRSA(ctx context.Context, iamClient *iam.Client, eksClient *eks.Client, k8sClient clientgo.Interface, dynamicClient dynamic.Interface, logger logr.Logger) error {
+	logger.Info("Setting up complete IRSA configuration for CloudWatch Observabilty agent ")
 
-	logger.Info("Waiting for CloudWatch components to be ready")
-
-	for {
-		select {
-		case <-timeout:
-			return fmt.Errorf("timeout waiting for CloudWatch components to be ready")
-		case <-ticker.C:
-			// Check if namespace exists
-			err := kubernetes.CheckNamespaceExists(ctx, k8sClient, cloudwatchNamespace)
-			if err != nil {
-				logger.Info("Waiting for CloudWatch namespace to be created")
-				continue
-			}
-
-			// Check for operator deployment
-			operators, err := kubernetes.ListDeploymentsWithLabels(ctx, k8sClient, cloudwatchNamespace, "control-plane=controller-manager")
-			if err != nil || len(operators.Items) == 0 {
-				logger.Info("Waiting for CloudWatch operator deployment")
-				continue
-			}
-
-			operator := operators.Items[0]
-			if operator.Status.ReadyReplicas != operator.Status.Replicas || operator.Status.ReadyReplicas == 0 {
-				logger.Info("Waiting for operator pods to be ready", "ready", operator.Status.ReadyReplicas, "desired", operator.Status.Replicas)
-				continue
-			}
-
-			logger.Info("CloudWatch webhook components are ready", "operator-ready", operator.Status.ReadyReplicas)
-			return nil
-		}
-	}
-}
-
-// VerifyWebhookFunctionality tests CloudWatch webhook functionality in mixed mode
-func (cw CloudWatchAddon) VerifyWebhookFunctionality(
-	ctx context.Context,
-	eksClient *eks.Client,
-	k8sClient clientgo.Interface,
-	clusterRegion string,
-	hybridNodeSelector map[string]string,
-	labels map[string]string,
-	logger logr.Logger,
-) error {
-	logger.Info("Testing CloudWatch Observability webhook functionality")
-
-	// Install and wait for CloudWatch addon
-	if err := cw.Create(ctx, eksClient, logger); err != nil {
-		return fmt.Errorf("installing CloudWatch Observability addon: %w", err)
+	// Get cluster information to extract OIDC issuer
+	cluster, err := eksClient.DescribeCluster(ctx, &eks.DescribeClusterInput{
+		Name: aws.String(cw.Cluster),
+	})
+	if err != nil {
+		return fmt.Errorf("describing cluster: %w", err)
 	}
 
-	if err := cw.WaitUntilActive(ctx, eksClient, logger); err != nil {
-		return fmt.Errorf("waiting for addon to become active: %w", err)
+	oidcURL := *cluster.Cluster.Identity.Oidc.Issuer
+	logger.Info("Found cluster OIDC issuer", "url", oidcURL)
+
+	// Create OIDC provider if required
+	if err := cw.createOIDCProvider(ctx, iamClient, oidcURL, logger); err != nil {
+		return fmt.Errorf("creating OIDC provider: %w", err)
 	}
 
-	if err := cw.WaitForComponents(ctx, k8sClient, logger); err != nil {
-		return fmt.Errorf("waiting for CloudWatch components: %w", err)
+	// Apply the trust policy for IRSA
+	if err := cw.applyTrustPolicyForIRSA(ctx, iamClient, oidcURL, logger); err != nil {
+		return fmt.Errorf("applying trust policy for IRSA: %w", err)
 	}
 
-	// Find a hybrid node to test on
-	hybridNodeName := ""
-	for labelKey, labelValue := range hybridNodeSelector {
-		nodeName, err := kubernetes.FindNodeWithLabel(ctx, k8sClient, labelKey, labelValue, logger)
-		if err != nil {
-			return fmt.Errorf("finding hybrid node with selector %s=%s: %w", labelKey, labelValue, err)
-		}
-		hybridNodeName = nodeName
-		break
+	logger.Info("Using  CloudWatch role ", "roleArn", cw.roleArn)
+
+	// Annotate service account with IRSA role ARN
+	if err := cw.annotateServiceAccount(ctx, k8sClient, logger); err != nil {
+		return fmt.Errorf("annotating service account: %w", err)
 	}
 
-	if hybridNodeName == "" {
-		return fmt.Errorf("no hybrid node found matching selector")
+	// Patch FluentBit DaemonSet with IRSA environment variables
+	if err := cw.patchFluentBitForIRSA(ctx, k8sClient, logger); err != nil {
+		return fmt.Errorf("patching FluentBit DaemonSet for IRSA: %w", err)
 	}
 
-	podName := "cloudwatch-webhook-test-hybrid"
-	namespace := "default"
-
-	if err := kubernetes.CreateNginxPodInNode(ctx, k8sClient, hybridNodeName, namespace, clusterRegion, logger, podName, labels); err != nil {
-		return fmt.Errorf("creating and running CloudWatch test pod on hybrid node: %w", err)
+	// Patch AmazonCloudWatchAgent CRD for IRSA support
+	if err := kubernetes.PatchCloudWatchAgentCRD(ctx, dynamicClient, logger, cloudwatchNamespace); err != nil {
+		return fmt.Errorf("patching CRD: %w", err)
 	}
 
-	logger.Info("CloudWatch Observability Addon test successful - cross-VPC webhook communication confirmed")
+	logger.Info("Complete IRSA configuration for mixed mode completed successfully")
 	return nil
 }
 
-// Cleanup performs CloudWatch-specific cleanup operations
-func (cw CloudWatchAddon) Cleanup(ctx context.Context, k8sClient clientgo.Interface, namespace string, labels map[string]string, logger logr.Logger) error {
-	// Clean up CloudWatch test pods using label selector
-	labelSelector := fmt.Sprintf("test-suite=%s,app=cloudwatch-webhook-test-hybrid", labels["test-suite"])
+// createOIDCProvider creates OIDC identity provider using IAM client
+func (cw *CloudWatchAddon) createOIDCProvider(ctx context.Context, iamClient *iam.Client, oidcURL string, logger logr.Logger) error {
+	logger.Info("Creating OIDC provider", "url", oidcURL)
 
-	err := kubernetes.DeletePodsWithLabels(ctx, k8sClient, namespace, labelSelector, logger)
+	providers, err := iamClient.ListOpenIDConnectProviders(ctx, &iam.ListOpenIDConnectProvidersInput{})
 	if err != nil {
-		logger.Info("Failed to delete CloudWatch test pods", "error", err.Error())
+		return fmt.Errorf("listing OIDC providers: %w", err)
 	}
 
+	for _, provider := range providers.OpenIDConnectProviderList {
+		if strings.Contains(*provider.Arn, oidcURL) {
+			logger.Info("OIDC provider already exists", "arn", *provider.Arn)
+			return nil
+		}
+	}
+
+	// Create OIDC provider with EKS OIDC root CA thumbprint
+	_, err = iamClient.CreateOpenIDConnectProvider(ctx, &iam.CreateOpenIDConnectProviderInput{
+		Url:            aws.String(oidcURL),
+		ClientIDList:   []string{"sts.amazonaws.com"},
+		ThumbprintList: []string{"9e99a48a9960b14926bb7f3b02e22da2b0ab7280"}, // EKS OIDC root CA thumbprint
+	})
+	if err != nil {
+		// Check if it already exists
+		if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "EntityAlreadyExists") {
+			logger.Info("OIDC provider already exists")
+			return nil
+		}
+		return fmt.Errorf("creating OIDC provider: %w", err)
+	}
+
+	logger.Info("Created OIDC provider successfully")
+	return nil
+}
+
+// applyTrustPolicyForIRSA updates the IAM role trust policy with correct IRSA conditions
+func (cw *CloudWatchAddon) applyTrustPolicyForIRSA(ctx context.Context, iamClient *iam.Client, oidcURL string, logger logr.Logger) error {
+	logger.Info("Applying IAM role trust policy for proper IRSA authentication", "roleArn", cw.roleArn, "oidcURL", oidcURL)
+
+	// Extract role name from ARN
+	roleName := cw.extractRoleNameFromArn()
+	if roleName == "" {
+		return fmt.Errorf("could not extract role name from ARN: %s", cw.roleArn)
+	}
+
+	// Extract cluster ID from OIDC URL
+	clusterID := cw.extractClusterIDFromOIDC(oidcURL)
+	if clusterID == "" {
+		return fmt.Errorf("could not extract cluster ID from OIDC URL: %s", oidcURL)
+	}
+
+	// Extract AWS account ID from ARN
+	accountID := cw.getAccountIDFromArn()
+	if accountID == "" {
+		return fmt.Errorf("could not extract account ID from ARN: %s", cw.roleArn)
+	}
+
+	// Build correct trust policy document
+	trustPolicyDoc := fmt.Sprintf(`{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::%s:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/%s"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/%s:sub": "system:serviceaccount:amazon-cloudwatch:cloudwatch-agent",
+						"oidc.eks.us-west-2.amazonaws.com/id/%s:aud": "sts.amazonaws.com"
+					}
+				}
+			}
+		]
+	}`, accountID, clusterID, clusterID, clusterID)
+
+	// Update the role's trust policy
+	_, err := iamClient.UpdateAssumeRolePolicy(ctx, &iam.UpdateAssumeRolePolicyInput{
+		RoleName:       aws.String(roleName),
+		PolicyDocument: aws.String(trustPolicyDoc),
+	})
+	if err != nil {
+		return fmt.Errorf("updating assume role policy: %w", err)
+	}
+
+	logger.Info("Successfully updated IAM role trust policy for IRSA", "roleName", roleName, "clusterID", clusterID)
+	return nil
+}
+
+// extractRoleNameFromArn extracts the role name from an ARN
+func (cw *CloudWatchAddon) extractRoleNameFromArn() string {
+	parts := strings.Split(cw.roleArn, "/")
+	if len(parts) >= 2 {
+		return parts[len(parts)-1]
+	}
+	return ""
+}
+
+// extractClusterIDFromOIDC extracts cluster ID from OIDC issuer URL
+func (cw *CloudWatchAddon) extractClusterIDFromOIDC(oidcURL string) string {
+	parts := strings.Split(oidcURL, "/id/")
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return ""
+}
+
+// getAccountIDFromArn extracts AWS account ID from role ARN
+func (cw *CloudWatchAddon) getAccountIDFromArn() string {
+	parts := strings.Split(cw.roleArn, ":")
+	if len(parts) >= 5 {
+		return parts[4]
+	}
+	return ""
+}
+
+// annotateServiceAccount annotates the CloudWatch service account with IRSA role ARN
+func (cw *CloudWatchAddon) annotateServiceAccount(ctx context.Context, k8sClient clientgo.Interface, logger logr.Logger) error {
+	logger.Info("Annotating CloudWatch service account for IRSA", "roleArn", cw.roleArn)
+
+	sa, err := k8sClient.CoreV1().ServiceAccounts(cloudwatchNamespace).Get(ctx, cloudwatchServiceAccount, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting service account: %w", err)
+	}
+
+	if sa.Annotations == nil {
+		sa.Annotations = make(map[string]string)
+	}
+	sa.Annotations["eks.amazonaws.com/role-arn"] = cw.roleArn
+
+	_, err = k8sClient.CoreV1().ServiceAccounts(cloudwatchNamespace).Update(ctx, sa, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating service account with annotation: %w", err)
+	}
+
+	logger.Info("Service account annotated for IRSA successfully")
+	return nil
+}
+
+// patchFluentBitForIRSA patches FluentBit DaemonSet with essential IRSA environment variables
+func (cw *CloudWatchAddon) patchFluentBitForIRSA(ctx context.Context, k8s clientgo.Interface, logger logr.Logger) error {
+	logger.Info("Patching FluentBit DaemonSet with essential IRSA environment variables", "roleArn", cw.roleArn)
+
+	envVars := map[string]string{
+		"AWS_REGION":                  "us-west-2",
+		"AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
+		"AWS_ROLE_ARN":                cw.roleArn,
+		"AWS_EC2_METADATA_DISABLED":   "true",
+	}
+
+	if err := kubernetes.PatchDaemonSetWithEnvVars(ctx, logger, k8s, cloudwatchNamespace, "fluent-bit", "fluent-bit", envVars); err != nil {
+		return fmt.Errorf("patching FluentBit DaemonSet with IRSA: %w", err)
+	}
+
+	logger.Info("FluentBit DaemonSet patched successfully with essential IRSA configuration")
+
+	return kubernetes.RestartDaemonSetAndWait(ctx, logger, k8s, cloudwatchNamespace, "fluent-bit")
+}
+
+// VerifyCwAddon verifies CloudWatch webhook functionality and log groups for mixed mode.
+func (cw CloudWatchAddon) VerifyCwAddon(ctx context.Context, k8sClient clientgo.Interface, dynamicClient dynamic.Interface, awsConfig aws.Config, logger logr.Logger) error {
+	logger.Info("Verifying CloudWatch webhook functionality and log groups for mixed mode")
+
+	// Test webhook validation by attempting to create CRD with invalid resource specifications
+	if err := cw.testWebhookValidation(ctx, dynamicClient, logger); err != nil {
+		return fmt.Errorf("webhook validation test failed: %w", err)
+	}
+
+	logger.Info("CloudWatch mixed-mode webhook validated successfully")
+
+	logger.Info("Waiting for CloudWatch DaemonSet to be ready before checking log groups")
+	if err := kubernetes.DaemonSetWaitForReady(ctx, logger, k8sClient, cloudwatchNamespace, "cloudwatch-agent"); err != nil {
+		return fmt.Errorf("CloudWatch DaemonSet not ready: %w", err)
+	}
+
+	logger.Info("CloudWatch DaemonSet is ready - all agent pods are ready")
+
+	// Wait for CloudWatch agents to start collecting and shipping logs
+	logger.Info("Waiting for CloudWatch agents to collect and ship logs to CloudWatch",
+		"waitTime", logCollectionWaitTime.String())
+	time.Sleep(logCollectionWaitTime)
+
+	cwLogsClient := cloudwatchlogs.NewFromConfig(awsConfig)
+	if err := cw.VerifyCloudWatchLogGroups(ctx, cwLogsClient, logger); err != nil {
+		logger.Info("CloudWatch log groups verification had issues but will continue", "error", err.Error())
+	} else {
+		logger.Info("CloudWatch log groups verification successful ")
+	}
+
+	return nil
+}
+
+// VerifyCloudWatchLogGroups verifies that CloudWatch log groups exist and have streams
+func (cw *CloudWatchAddon) VerifyCloudWatchLogGroups(ctx context.Context, cwLogsClient *cloudwatchlogs.Client, logger logr.Logger) error {
+	logger.Info("Verifying CloudWatch log groups exist and have streams")
+
+	logGroups := []string{
+		"/aws/containerinsights/" + cw.Cluster + "/application",
+		"/aws/containerinsights/" + cw.Cluster + "/dataplane",
+		"/aws/containerinsights/" + cw.Cluster + "/performance",
+		"/aws/containerinsights/" + cw.Cluster + "/host",
+	}
+
+	foundLogGroups := 0
+	for _, logGroupName := range logGroups {
+		response, err := cwLogsClient.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+			LogGroupNamePrefix: aws.String(logGroupName),
+			Limit:              aws.Int32(10),
+		})
+		if err != nil {
+			logger.Info("Could not check log group", "logGroup", logGroupName, "error", err.Error())
+			continue
+		}
+
+		for _, logGroup := range response.LogGroups {
+			if logGroup.LogGroupName == nil || *logGroup.LogGroupName != logGroupName {
+				continue
+			}
+
+			foundLogGroups++
+			logger.Info("Found CloudWatch log group - addon is working", "logGroup", logGroupName)
+
+			// Check for log streams (indicates activity)
+			if streams, err := cwLogsClient.DescribeLogStreams(ctx, &cloudwatchlogs.DescribeLogStreamsInput{
+				LogGroupName: aws.String(logGroupName),
+				Limit:        aws.Int32(5),
+			}); err == nil && len(streams.LogStreams) > 0 {
+				logger.Info("Log group has active streams - CloudWatch receiving logs", "logGroup", logGroupName, "streamCount", len(streams.LogStreams))
+			}
+			break
+		}
+	}
+
+	if foundLogGroups > 0 {
+		logger.Info("CloudWatch log groups verification successful - found log groups", "foundGroups", foundLogGroups, "expectedGroups", len(logGroups))
+		return nil
+	} else {
+		return fmt.Errorf("no CloudWatch log groups found - expected %d log groups but found %d", len(logGroups), foundLogGroups)
+	}
+}
+
+// testWebhookValidation verifies webhook rejects invalid resource specifications using Kubernetes API
+func (cw *CloudWatchAddon) testWebhookValidation(ctx context.Context, dynamicClient dynamic.Interface, logger logr.Logger) error {
+	logger.Info("Testing CloudWatch webhook validation functionality using Kubernetes API")
+
+	testName := fmt.Sprintf("webhook-validation-test-%d", time.Now().Unix())
+
+	invalidCRD := fmt.Sprintf(`
+apiVersion: cloudwatch.aws.amazon.com/v1alpha1
+kind: AmazonCloudWatchAgent
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  resources:
+    requests:
+      memory: "invalid-memory-format"
+      cpu: "999cores"`, testName, cloudwatchNamespace)
+
+	// Apply invalid CRD - should FAIL due to webhook validation
+	_, err := kubernetes.CreateCRDFromYAML(ctx, logger, dynamicClient, invalidCRD)
+
+	if err == nil {
+		logger.Error(nil, "Webhook validation test FAILED - invalid CRD was accepted")
+
+		gvr := schema.GroupVersionResource{
+			Group:    "cloudwatch.aws.amazon.com",
+			Version:  "v1alpha1",
+			Resource: "amazoncloudwatchagents",
+		}
+		_ = kubernetes.DeleteCRD(ctx, logger, dynamicClient, gvr, cloudwatchNamespace, testName)
+
+		return fmt.Errorf("webhook validation failed - invalid resource quantities were accepted")
+	}
+
+	errorOutput := err.Error()
+	if strings.Contains(errorOutput, "admission webhook") && strings.Contains(errorOutput, "denied the request") {
+		logger.Info("CloudWatch webhook validation test successful - webhook correctly rejected invalid CRD", "expectedWebhookError", errorOutput)
+		return nil
+	} else {
+		return fmt.Errorf("unexpected validation error (not webhook): %s", errorOutput)
+	}
+}
+
+// cleanupLogGroups deletes existing CloudWatch addon log groups to ensure clean test environment
+func (cw *CloudWatchAddon) cleanupLogGroups(ctx context.Context, cwLogsClient *cloudwatchlogs.Client, logger logr.Logger) error {
+	logger.Info("Cleaning up existing CloudWatch addon log groups for clean test environment")
+
+	logGroups := []string{
+		"/aws/containerinsights/" + cw.Cluster + "/application",
+		"/aws/containerinsights/" + cw.Cluster + "/dataplane",
+		"/aws/containerinsights/" + cw.Cluster + "/host",
+		"/aws/containerinsights/" + cw.Cluster + "/performance",
+	}
+
+	deletedGroups := []string{}
+
+	for _, logGroupName := range logGroups {
+		logger.Info("Attempting to delete log group", "logGroup", logGroupName)
+		_, err := cwLogsClient.DeleteLogGroup(ctx, &cloudwatchlogs.DeleteLogGroupInput{
+			LogGroupName: aws.String(logGroupName),
+		})
+		if err != nil {
+			if strings.Contains(err.Error(), "ResourceNotFoundException") {
+				logger.Info("Log group does not exist (already clean)", "logGroup", logGroupName)
+			} else {
+				logger.Info("Could not delete log group", "logGroup", logGroupName, "error", err.Error())
+			}
+		} else {
+			logger.Info("Successfully initiated deletion of log group", "logGroup", logGroupName)
+			deletedGroups = append(deletedGroups, logGroupName)
+		}
+	}
+
+	if len(deletedGroups) > 0 {
+		logger.Info("Waiting for log group deletions to complete to avoid conflicts", "deletedCount", len(deletedGroups))
+		if err := cw.waitForLogGroupDeletions(ctx, cwLogsClient, deletedGroups, logger); err != nil {
+			logger.Info("Some log group deletions may still be in progress", "error", err.Error())
+		}
+
+		time.Sleep(30 * time.Second)
+	}
+
+	logger.Info("Log group cleanup completed - environment is clean for fresh test")
+	return nil
+}
+
+// waitForLogGroupDeletions waits for log group deletions to complete using wait.PollUntilContextTimeout
+func (cw *CloudWatchAddon) waitForLogGroupDeletions(ctx context.Context, cwLogsClient *cloudwatchlogs.Client, logGroups []string, logger logr.Logger) error {
+	remainingGroups := make(map[string]bool)
+	for _, lg := range logGroups {
+		remainingGroups[lg] = true
+	}
+
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+		for logGroup := range remainingGroups {
+			response, err := cwLogsClient.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+				LogGroupNamePrefix: aws.String(logGroup),
+				Limit:              aws.Int32(1),
+			})
+			if err != nil {
+				logger.Info("Error checking log group deletion", "logGroup", logGroup, "error", err.Error())
+				continue
+			}
+
+			exists := false
+			for _, lg := range response.LogGroups {
+				if lg.LogGroupName != nil && *lg.LogGroupName == logGroup {
+					exists = true
+					break
+				}
+			}
+
+			if !exists {
+				logger.Info("Log group deleted", "logGroup", logGroup)
+				delete(remainingGroups, logGroup)
+			}
+		}
+
+		if len(remainingGroups) == 0 {
+			logger.Info("All log group deletions completed")
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+// SetupCwAddon handles complete CloudWatch addon setup for mixed mode with IRSA
+func (cw *CloudWatchAddon) SetupCwAddon(ctx context.Context, eksClient *eks.Client, iamClient *iam.Client, k8sClient clientgo.Interface, dynamicClient dynamic.Interface, awsConfig aws.Config, logger logr.Logger) error {
+	logger.Info("Setting up CloudWatch addon for mixed mode with IRSA", "cluster", cw.Cluster)
+
+	//  Clean up existing log groups for fresh test environment
+	cwLogsClient := cloudwatchlogs.NewFromConfig(awsConfig)
+	if err := cw.cleanupLogGroups(ctx, cwLogsClient, logger); err != nil {
+		logger.Info("Failed to cleanup old log groups - continuing", "error", err.Error())
+	}
+
+	// 1. Create EKS addon
+	if err := cw.Create(ctx, eksClient, logger); err != nil {
+		return fmt.Errorf("creating CloudWatch addon: %w", err)
+	}
+
+	// 2. Wait for addon to be active
+	if err := cw.WaitUntilActive(ctx, eksClient, logger); err != nil {
+		return fmt.Errorf("waiting for addon to be active: %w", err)
+	}
+
+	// 4. Setup complete IRSA configuration
+	if err := cw.SetupIRSA(ctx, iamClient, eksClient, k8sClient, dynamicClient, logger); err != nil {
+		return fmt.Errorf("setting up IRSA: %w", err)
+	}
+
+	logger.Info("CloudWatch Observabilty addon is working in mixed mode setup ")
 	return nil
 }

--- a/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
+++ b/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
@@ -25,6 +25,12 @@ Parameters:
   ManagedNodeRolePrefix:
     Type: String
     Default: 'mng'
+  CloudWatchRolePrefix:
+    Type: String
+    Default: 'cw'
+  ClusterOIDCIssuerURL:
+    Type: String
+    Description: The OIDC issuer URL for the EKS cluster
     
 Resources:
   SSMRole:
@@ -203,6 +209,37 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
       Path: !Ref rolePathPrefix
 
+  # Create IAM Role for CloudWatch Observability
+  CloudWatchObservabilityRole:
+    Type: AWS::IAM::Role
+    Properties:
+      # use a predictable prefix for CloudWatch role while maintaining uniqueness requirement for CloudWatch role name
+      RoleName:
+        !Sub
+          - '${RolePrefix}-${TrimmedRegion}${UUID}'
+          - RolePrefix: !Ref CloudWatchRolePrefix
+            TrimmedRegion: !Join ['', !Split ['-', !Ref AWS::Region]]
+            UUID: !Join ['', !Split ['-', !Select [2, !Split [/, !Ref AWS::StackId]]]]
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub 
+                - "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDCProvider}"
+                - OIDCProvider: !Select [2, !Split ['/', !Ref ClusterOIDCIssuerURL]]
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                "aws:RequestedRegion": !Ref "AWS::Region"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}'
+      Path: !Ref rolePathPrefix
+
 Outputs:
   EC2Role:
     Description: The name of the IAM Role for EC2.
@@ -219,6 +256,10 @@ Outputs:
   ManagedNodeRoleArn:
     Description: The ARN of the IAM Role for EKS Managed Node Groups.
     Value: !GetAtt ManagedNodeInstanceRole.Arn
+
+  CloudWatchObservabilityRoleArn:
+    Description: The ARN of the IAM Role for CloudWatch Observability.
+    Value: !GetAtt CloudWatchObservabilityRole.Arn
 {{- if .IncludeRolesAnywhere}}
   IRANodeRoleName:
     Description: IAM Role for IAM Roles Anywhere

--- a/test/e2e/kubernetes/crd.go
+++ b/test/e2e/kubernetes/crd.go
@@ -1,0 +1,148 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/yaml"
+)
+
+// PatchCRDWithMerge patches a Custom Resource using strategic merge patch
+func PatchCRDWithMerge(ctx context.Context, logger logr.Logger, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespace, name string, patchData map[string]interface{}) error {
+	logger.Info("Patching CRD with merge patch", "name", name, "namespace", namespace, "gvr", gvr)
+
+	patchBytes, err := json.Marshal(patchData)
+	if err != nil {
+		return fmt.Errorf("marshaling patch data: %w", err)
+	}
+
+	_, err = dynamicClient.Resource(gvr).Namespace(namespace).Patch(
+		ctx,
+		name,
+		types.MergePatchType,
+		patchBytes,
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("patching CRD %s/%s: %w", namespace, name, err)
+	}
+
+	logger.Info("Successfully patched CRD", "name", name, "namespace", namespace)
+	return nil
+}
+
+// CreateCRDFromYAML creates a Custom Resource from YAML content
+func CreateCRDFromYAML(ctx context.Context, logger logr.Logger, dynamicClient dynamic.Interface, yamlContent string) (*unstructured.Unstructured, error) {
+	logger.Info("Creating CRD from YAML")
+
+	// Convert YAML to unstructured object
+	obj := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal([]byte(yamlContent), &obj.Object); err != nil {
+		return nil, fmt.Errorf("unmarshaling YAML: %w", err)
+	}
+
+	// Get GVR from the object
+	gvk := obj.GroupVersionKind()
+	gvr := schema.GroupVersionResource{
+		Group:    gvk.Group,
+		Version:  gvk.Version,
+		Resource: fmt.Sprintf("%ss", gvk.Kind),
+	}
+
+	if gvk.Kind == "AmazonCloudWatchAgent" {
+		gvr.Resource = "amazoncloudwatchagents"
+	}
+
+	logger.Info("Creating CRD", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", gvk.Kind)
+
+	// Create the resource
+	created, err := dynamicClient.Resource(gvr).Namespace(obj.GetNamespace()).Create(
+		ctx,
+		obj,
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating CRD %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	logger.Info("Successfully created CRD", "name", created.GetName(), "namespace", created.GetNamespace())
+	return created, nil
+}
+
+// DeleteCRD deletes a Custom Resource
+func DeleteCRD(ctx context.Context, logger logr.Logger, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespace, name string) error {
+	logger.Info("Deleting CRD", "name", name, "namespace", namespace, "gvr", gvr)
+
+	err := dynamicClient.Resource(gvr).Namespace(namespace).Delete(
+		ctx,
+		name,
+		metav1.DeleteOptions{},
+	)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting CRD %s/%s: %w", namespace, name, err)
+	}
+
+	logger.Info("Successfully deleted CRD", "name", name, "namespace", namespace)
+	return nil
+}
+
+// PatchCloudWatchAgentCRD patches the AmazonCloudWatchAgent CRD with IRSA environment variables
+func PatchCloudWatchAgentCRD(ctx context.Context, dynamicClient dynamic.Interface, logger logr.Logger, namespace string) error {
+	logger.Info("Patching AmazonCloudWatchAgent CRD")
+
+	// Patch data structure for adding environment variables to the CRD
+	patchData := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"env": []map[string]interface{}{
+				{
+					"name":  "RUN_WITH_IRSA",
+					"value": "True",
+				},
+				{
+					"name": "HOST_IP",
+					"valueFrom": map[string]interface{}{
+						"fieldRef": map[string]interface{}{
+							"fieldPath": "status.hostIP",
+						},
+					},
+				},
+				{
+					"name": "HOST_NAME",
+					"valueFrom": map[string]interface{}{
+						"fieldRef": map[string]interface{}{
+							"fieldPath": "spec.nodeName",
+						},
+					},
+				},
+				{
+					"name": "K8S_NAMESPACE",
+					"valueFrom": map[string]interface{}{
+						"fieldRef": map[string]interface{}{
+							"fieldPath": "metadata.namespace",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "cloudwatch.aws.amazon.com",
+		Version:  "v1alpha1",
+		Resource: "amazoncloudwatchagents",
+	}
+	if err := PatchCRDWithMerge(ctx, logger, dynamicClient, gvr, namespace, "cloudwatch-agent", patchData); err != nil {
+		return fmt.Errorf("patching AmazonCloudWatchAgent CRD: %w", err)
+	}
+
+	logger.Info("CloudWatch mutating webhook is working - successfully processed and allowed valid CRD patch operation")
+	return nil
+}

--- a/test/e2e/kubernetes/daemonset.go
+++ b/test/e2e/kubernetes/daemonset.go
@@ -2,11 +2,14 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	ik8s "github.com/aws/eks-hybrid/internal/kubernetes"
@@ -35,5 +38,73 @@ func DaemonSetWaitForReady(ctx context.Context, logger logr.Logger, k8s kubernet
 	}); err != nil {
 		return fmt.Errorf("daemonset %s replicas never became ready: %v", name, err)
 	}
+	return nil
+}
+
+// RestartDaemonSetAndWait restarts a DaemonSet and waits for rollout completion using Kubernetes API
+func RestartDaemonSetAndWait(ctx context.Context, logger logr.Logger, k8s kubernetes.Interface, namespace, name string) error {
+	logger.Info("Restarting DaemonSet ", "name", name, "namespace", namespace)
+
+	// Patch DaemonSet to trigger restart
+	now := time.Now().Format(time.RFC3339)
+	patch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"%s"}}}}}`, now)
+
+	_, err := k8s.AppsV1().DaemonSets(namespace).Patch(ctx, name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to restart DaemonSet %s: %w", name, err)
+	}
+
+	logger.Info("DaemonSet restart initiated - waiting for rollout to complete", "name", name)
+
+	if err := DaemonSetWaitForReady(ctx, logger, k8s, namespace, name); err != nil {
+		return fmt.Errorf("waiting for DaemonSet rollout: %w", err)
+	}
+
+	logger.Info("DaemonSet rollout completed successfully", "name", name, "namespace", namespace)
+	return nil
+}
+
+// PatchDaemonSetWithEnvVars patches a DaemonSet container with environment variables using Kubernetes API
+func PatchDaemonSetWithEnvVars(ctx context.Context, logger logr.Logger, k8s kubernetes.Interface, namespace, name, containerName string, envVars map[string]string) error {
+	logger.Info("Patching DaemonSet with environment variables", "name", name, "namespace", namespace, "container", containerName)
+
+	// Build environment variables array as JSON-compatible structure
+	var envArray []map[string]interface{}
+	for key, value := range envVars {
+		envArray = append(envArray, map[string]interface{}{
+			"name":  key,
+			"value": value,
+		})
+	}
+
+	// Create patch data structure
+	patchData := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []map[string]interface{}{
+						{
+							"name": containerName,
+							"env":  envArray,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Convert to JSON
+	patchBytes, err := json.Marshal(patchData)
+	if err != nil {
+		return fmt.Errorf("marshaling patch data: %w", err)
+	}
+
+	// Apply the patch
+	_, err = k8s.AppsV1().DaemonSets(namespace).Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("patching DaemonSet %s with environment variables: %w", name, err)
+	}
+
+	logger.Info("Successfully patched DaemonSet with environment variables", "name", name, "namespace", namespace)
 	return nil
 }

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -128,7 +128,7 @@ func (a *AddonEc2Test) NewCertManagerTest(ctx context.Context) (*addon.CertManag
 	}
 
 	// Create PCA service client
-	pcaClient := acmpca.NewFromConfig(a.aws)
+	pcaClient := acmpca.NewFromConfig(a.AWS)
 
 	// Get pod identity role ARN
 	podIdentityRoleArn, err := addon.PodIdentityRole(ctx, a.IAMClient, a.Cluster.Name)

--- a/test/e2e/suite/peered_vpc.go
+++ b/test/e2e/suite/peered_vpc.go
@@ -57,7 +57,7 @@ type SuiteConfiguration struct {
 }
 
 type PeeredVPCTest struct {
-	aws             aws.Config
+	AWS             aws.Config
 	eksEndpoint     string
 	EKSClient       *eks.Client
 	EC2Client       *ec2v2.Client
@@ -118,7 +118,7 @@ func BuildPeeredVPCTestForSuite(ctx context.Context, suite *SuiteConfiguration) 
 		return nil, err
 	}
 
-	test.aws = aws
+	test.AWS = aws
 	test.EKSClient = e2e.NewEKSClient(aws, suite.TestConfig.Endpoint)
 	test.EC2Client = ec2v2.NewFromConfig(aws)
 	test.SSMClient = ssmv2.NewFromConfig(aws)
@@ -182,7 +182,7 @@ func (t *PeeredVPCTest) NewPeeredNode(logger logr.Logger) *peered.Node {
 	remoteCommandRunner := ssm.NewStandardLinuxSSHOnSSMCommandRunner(t.SSMClient, t.JumpboxInstanceId, t.Logger)
 	return &peered.Node{
 		NodeCreate: peered.NodeCreate{
-			AWS:                 t.aws,
+			AWS:                 t.AWS,
 			EC2:                 t.EC2Client,
 			SSM:                 t.SSMClient,
 			K8sClientConfig:     t.K8sClientConfig,


### PR DESCRIPTION
Added timeout to prevent from hanging indefinitely and reaching Global timeout when waiting for addon to reach active/degraded state.

Validating functionality of Cloud Watch Observability addon in mixed mode environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

