### PR TITLE
Add wait for kubelet systemd service

### DIFF
--- a/internal/node/ec2/daemons.go
+++ b/internal/node/ec2/daemons.go
@@ -25,7 +25,7 @@ func (enp *ec2NodeProvider) GetDaemons() ([]daemon.Daemon, error) {
 	}
 	return []daemon.Daemon{
 		containerd.NewContainerdDaemon(enp.daemonManager, enp.nodeConfig, enp.awsConfig, enp.logger),
-		kubelet.NewKubeletDaemon(enp.daemonManager, enp.nodeConfig, enp.awsConfig, kubelet.CredentialProviderAwsConfig{}, nil, nil),
+		kubelet.NewKubeletDaemon(enp.daemonManager, enp.nodeConfig, enp.awsConfig, kubelet.CredentialProviderAwsConfig{}, enp.logger, nil),
 	}, nil
 }
 


### PR DESCRIPTION
This PR adds wait for kubelet daemon (systemd service) to be in a running state.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

