### PR TITLE
update mirror-cilium.sh to point to public ecr

### DIFF
--- a/test/e2e/cni/testdata/cilium/mirror-cilium.sh
+++ b/test/e2e/cni/testdata/cilium/mirror-cilium.sh
@@ -28,6 +28,6 @@ for region in "us-west-2" "us-west-1"; do
 		# inspecting the image, which returns the manifest/digests
 		# will trigger the pull through cache if the image does not already exist in the repo.
 		# using inspect instead of pull since we do not need the image locally
-		docker buildx imagetools inspect "${registry}/quay.io/${repo}:${CILIUM_VERSION}"
+		docker buildx imagetools inspect "public.ecr.aws/eks/${repo}:${CILIUM_VERSION}"
 	done
 done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update mirror-cilium script to use public ecr rather than quay.io when inspecting cilium images
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

