### PR TITLE
Fix namespace issue for bottlerocket PCA test

### DIFF
--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -140,7 +140,7 @@ func (a *AddonEc2Test) NewCertManagerTest(ctx context.Context) (*addon.CertManag
 	// Create PCA Issuer test
 	pcaIssuer := &addon.PCAIssuerTest{
 		Cluster:            a.Cluster.Name,
-		Namespace:          "cert-test",
+		Namespace:          defaultCertNamespace,
 		K8S:                a.K8sClient,
 		EKSClient:          a.EKSClient,
 		CertClient:         certClient,

--- a/test/e2e/suite/addons/addons_test.go
+++ b/test/e2e/suite/addons/addons_test.go
@@ -438,6 +438,7 @@ var _ = Describe("Hybrid Nodes", func() {
 					certManager.CertNamespace = "bottlerocket-cert-test"
 					certManager.CertSecretName = "bottlerocket-selfsigned-cert-tls"
 					certManager.IssuerName = "bottlerocket-selfsigned-issuer"
+					certManager.PCAIssuer.Namespace = "bottlerocket-cert-test"
 
 					DeferCleanup(func(ctx context.Context) {
 						Expect(certManager.Delete(ctx)).To(Succeed(), "should cleanup cert manager successfully")


### PR DESCRIPTION
## Issue ##
We are seeing the following issue in E2E:

```
    [FAILED] uses Bottlerocket OS
        Expected cert manager should have been validated successfully
            Expected success, but got an error:
                <*fmt.wrapError | 0xc000e80400>: 
                AWS PCA Issuer validation failed: failed to create AWS PCA Issuer: timed out waiting for the condition while retrying: namespaces "cert-test" not found
                {
                    msg: "AWS PCA Issuer validation failed: failed to create AWS PCA Issuer: timed out waiting for the condition while retrying: namespaces \"cert-test\" not found",
                    err: <*errors.errorString | 0xc000d1dd00>{
                        s: "failed to create AWS PCA Issuer: timed out waiting for the condition while retrying: namespaces \"cert-test\" not found",
                    },
                }
        In [It] at: /codebuild/output/src3047699039/src/test/e2e/suite/addons/addons_test.go:462 @ 2025-08-12 03:57:39

```

In bottlerocket, it uses a different namespace for cert test. However it is hardcoded to `cert-test` in PCA. That's why it can't find the namespace.

## Proposed Change ##
Fix PCA namespace to match cert manager namespace

*Testing (if applicable):*
Tested under my personal dev stack for add-on


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

