### PR TITLE
Upgrade aws-sdk-go/aws to aws-sdk-go-v2/aws

### DIFF
--- a/cmd/e2e-test/ssh/ssh.go
+++ b/cmd/e2e-test/ssh/ssh.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 

--- a/internal/api/status.go
+++ b/internal/api/status.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/aws/aws-sdk-go/aws"
 
 	ec2extra "github.com/aws/eks-hybrid/internal/aws/ec2"
 )
@@ -57,7 +57,7 @@ func getPrivateDNSName(ec2Client *ec2.Client, instanceID string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	privateDNSName := aws.StringValue(out.Reservations[0].Instances[0].PrivateDnsName)
+	privateDNSName := aws.ToString(out.Reservations[0].Instances[0].PrivateDnsName)
 	return privateDNSName, nil
 }
 
@@ -65,5 +65,5 @@ func privateDNSNameAvailable(out *ec2.DescribeInstancesOutput) (bool, error) {
 	if out == nil || len(out.Reservations) != 1 || len(out.Reservations[0].Instances) != 1 {
 		return false, fmt.Errorf("reservation or instance not found")
 	}
-	return aws.StringValue(out.Reservations[0].Instances[0].PrivateDnsName) != "", nil
+	return aws.ToString(out.Reservations[0].Instances[0].PrivateDnsName) != "", nil
 }

--- a/internal/util/ec2_test.go
+++ b/internal/util/ec2_test.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/test/e2e/peered/keypair.go
+++ b/test/e2e/peered/keypair.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/aws/eks-hybrid/test/e2e/constants"
 )


### PR DESCRIPTION
*Issue #, if available:*
`aws-sdk-go` is deprecated

*Description of changes:*
update `aws-sdk-go/aws` to `aws-sdk-go-v2/aws`.

*Testing (if applicable):*
Tested under personal dev stack.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

