### PR TITLE
Upgrade to Go 1.25

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           check-latest: true
           cache: true
       - name: build application
@@ -31,8 +31,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           check-latest: true
           cache: true
-      - name: build application
+      - name: test application
         run: make test

--- a/.github/workflows/build-e2e-test-binaries.yml
+++ b/.github/workflows/build-e2e-test-binaries.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           check-latest: true
           cache: true
       - name: build e2e test binaries

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,13 +19,13 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           check-latest: true
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.6
+          version: v2.4.0
           # Disable package caching to avoid a double cache with setup-go.
           skip-pkg-cache: true
           args: --timeout 10m

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           check-latest: true
           cache: true
       - name: integration test

--- a/ATTRIBUTION.txt
+++ b/ATTRIBUTION.txt
@@ -1,59 +1,56 @@
 
-** github.com/aws/aws-sdk-go; version v1.55.7 --
-https://github.com/aws/aws-sdk-go
-
-** github.com/aws/aws-sdk-go-v2; version v1.36.3 --
+** github.com/aws/aws-sdk-go-v2; version v1.36.6 --
 https://github.com/aws/aws-sdk-go-v2
 
-** github.com/aws/aws-sdk-go-v2/config; version v1.29.14 --
+** github.com/aws/aws-sdk-go-v2/config; version v1.29.17 --
 https://github.com/aws/aws-sdk-go-v2/config
 
-** github.com/aws/aws-sdk-go-v2/credentials; version v1.17.67 --
+** github.com/aws/aws-sdk-go-v2/credentials; version v1.17.70 --
 https://github.com/aws/aws-sdk-go-v2/credentials
 
-** github.com/aws/aws-sdk-go-v2/feature/ec2/imds; version v1.16.30 --
+** github.com/aws/aws-sdk-go-v2/feature/ec2/imds; version v1.16.32 --
 https://github.com/aws/aws-sdk-go-v2/feature/ec2/imds
 
-** github.com/aws/aws-sdk-go-v2/internal/configsources; version v1.3.34 --
+** github.com/aws/aws-sdk-go-v2/internal/configsources; version v1.3.37 --
 https://github.com/aws/aws-sdk-go-v2/internal/configsources
 
-** github.com/aws/aws-sdk-go-v2/internal/endpoints/v2; version v2.6.34 --
+** github.com/aws/aws-sdk-go-v2/internal/endpoints/v2; version v2.6.37 --
 https://github.com/aws/aws-sdk-go-v2/internal/endpoints/v2
 
 ** github.com/aws/aws-sdk-go-v2/internal/ini; version v1.8.3 --
 https://github.com/aws/aws-sdk-go-v2/internal/ini
 
-** github.com/aws/aws-sdk-go-v2/service/ec2; version v1.224.0 --
+** github.com/aws/aws-sdk-go-v2/service/ec2; version v1.231.0 --
 https://github.com/aws/aws-sdk-go-v2/service/ec2
 
-** github.com/aws/aws-sdk-go-v2/service/ecr; version v1.44.0 --
+** github.com/aws/aws-sdk-go-v2/service/ecr; version v1.45.1 --
 https://github.com/aws/aws-sdk-go-v2/service/ecr
 
-** github.com/aws/aws-sdk-go-v2/service/eks; version v1.64.0 --
+** github.com/aws/aws-sdk-go-v2/service/eks; version v1.66.1 --
 https://github.com/aws/aws-sdk-go-v2/service/eks
 
-** github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding; version v1.12.3 --
+** github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding; version v1.12.4 --
 https://github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding
 
-** github.com/aws/aws-sdk-go-v2/service/internal/presigned-url; version v1.12.15 --
+** github.com/aws/aws-sdk-go-v2/service/internal/presigned-url; version v1.12.17 --
 https://github.com/aws/aws-sdk-go-v2/service/internal/presigned-url
 
-** github.com/aws/aws-sdk-go-v2/service/rolesanywhere; version v1.17.2 --
+** github.com/aws/aws-sdk-go-v2/service/rolesanywhere; version v1.17.5 --
 https://github.com/aws/aws-sdk-go-v2/service/rolesanywhere
 
-** github.com/aws/aws-sdk-go-v2/service/ssm; version v1.59.0 --
+** github.com/aws/aws-sdk-go-v2/service/ssm; version v1.60.0 --
 https://github.com/aws/aws-sdk-go-v2/service/ssm
 
-** github.com/aws/aws-sdk-go-v2/service/sso; version v1.25.3 --
+** github.com/aws/aws-sdk-go-v2/service/sso; version v1.25.5 --
 https://github.com/aws/aws-sdk-go-v2/service/sso
 
-** github.com/aws/aws-sdk-go-v2/service/ssooidc; version v1.30.1 --
+** github.com/aws/aws-sdk-go-v2/service/ssooidc; version v1.30.3 --
 https://github.com/aws/aws-sdk-go-v2/service/ssooidc
 
-** github.com/aws/aws-sdk-go-v2/service/sts; version v1.33.19 --
+** github.com/aws/aws-sdk-go-v2/service/sts; version v1.34.0 --
 https://github.com/aws/aws-sdk-go-v2/service/sts
 
-** github.com/aws/smithy-go; version v1.22.3 --
+** github.com/aws/smithy-go; version v1.22.4 --
 https://github.com/aws/smithy-go
 
 ** github.com/containerd/containerd/integration; version v1.7.27 --
@@ -107,25 +104,28 @@ https://github.com/open-telemetry/opentelemetry-go
 ** go.opentelemetry.io/otel/trace; version v1.34.0 --
 https://github.com/open-telemetry/opentelemetry-go
 
+** go.yaml.in/yaml/v2; version v2.4.2 --
+https://github.com/yaml/go-yaml
+
 ** google.golang.org/genproto/googleapis/rpc/status; version v0.0.0-20250303144028-a0af3efb3deb --
 https://github.com/googleapis/go-genproto
 
 ** google.golang.org/grpc; version v1.71.0 --
 https://github.com/grpc/grpc-go
 
-** k8s.io/api; version v0.33.1 --
+** k8s.io/api; version v0.33.2 --
 https://github.com/kubernetes/api
 
-** k8s.io/apimachinery/pkg; version v0.33.1 --
+** k8s.io/apimachinery/pkg; version v0.33.2 --
 https://github.com/kubernetes/apimachinery
 
-** k8s.io/client-go; version v0.33.1 --
+** k8s.io/client-go; version v0.33.2 --
 https://github.com/kubernetes/client-go
 
-** k8s.io/component-base; version v0.33.1 --
+** k8s.io/component-base; version v0.33.2 --
 https://github.com/kubernetes/component-base
 
-** k8s.io/cri-api/pkg/apis/runtime/v1; version v0.33.1 --
+** k8s.io/cri-api/pkg/apis/runtime/v1; version v0.33.2 --
 https://github.com/kubernetes/cri-api
 
 ** k8s.io/klog/v2; version v2.130.1 --
@@ -137,7 +137,7 @@ https://github.com/kubernetes/kube-openapi
 ** k8s.io/kube-openapi/pkg/validation/spec; version v0.0.0-20250318190949-c8a335a9a2ff --
 https://github.com/kubernetes/kube-openapi
 
-** k8s.io/kubelet/config/v1; version v0.33.1 --
+** k8s.io/kubelet/config/v1; version v0.33.2 --
 https://github.com/kubernetes/kubelet
 
 ** k8s.io/utils; version v0.0.0-20250321185631-1f6e0b77f77e --
@@ -155,10 +155,7 @@ https://github.com/kubernetes-sigs/randfill
 ** sigs.k8s.io/structured-merge-diff/v4; version v4.7.0 --
 https://github.com/kubernetes-sigs/structured-merge-diff
 
-** sigs.k8s.io/yaml; version v1.4.0 --
-https://github.com/kubernetes-sigs/yaml
-
-** sigs.k8s.io/yaml/goyaml.v2; version v1.4.0 --
+** sigs.k8s.io/yaml; version v1.5.0 --
 https://github.com/kubernetes-sigs/yaml
 
 
@@ -443,6 +440,22 @@ This product includes software developed at
 SoundCloud Ltd. (http://soundcloud.com/).
 
 
+* For go.yaml.in/yaml/v2 see also this required NOTICE:
+Copyright 2011-2016 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
 * For sigs.k8s.io/randfill see also this required NOTICE:
 When donating the randfill project to the CNCF, we could not reach all the
 gofuzz contributors to sign the CNCF CLA. As such, according to the CNCF rules
@@ -468,22 +481,6 @@ Submitted on behalf of a third-party: @eclipseo (Robert-André Mauchin)
 Submitted on behalf of a third-party: @yanzhoupan (Andrew Pan)
 Submitted on behalf of a third-party: @STRRL (Zhiqiang ZHOU)
 Submitted on behalf of a third-party: @disconnect3d (Disconnect3d)
-
-
-* For sigs.k8s.io/yaml/goyaml.v2 see also this required NOTICE:
-Copyright 2011-2016 Canonical Ltd.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 
 ------
 
@@ -581,10 +578,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** github.com/aws/aws-sdk-go-v2/internal/sync/singleflight; version v1.36.3 --
+** github.com/aws/aws-sdk-go-v2/internal/sync/singleflight; version v1.36.6 --
 https://github.com/aws/aws-sdk-go-v2
 
-** github.com/aws/smithy-go/internal/sync/singleflight; version v1.22.3 --
+** github.com/aws/smithy-go/internal/sync/singleflight; version v1.22.4 --
 https://github.com/aws/smithy-go
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -618,46 +615,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** github.com/aws/aws-sdk-go/internal/sync/singleflight; version v1.55.7 --
-https://github.com/aws/aws-sdk-go
-
-** github.com/ProtonMail/go-crypto; version v1.3.0 --
-https://github.com/ProtonMail/go-crypto
-
-** k8s.io/apimachinery/third_party/forked/golang; version v0.33.1 --
-https://github.com/kubernetes/apimachinery
-
-Copyright (c) 2009 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-------
-
-** github.com/cloudflare/circl; version v1.6.0 --
+** github.com/cloudflare/circl; version v1.6.1 --
 https://github.com/cloudflare/circl
 
 Copyright (c) 2019 Cloudflare. All rights reserved.
@@ -897,6 +855,42 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
+** github.com/ProtonMail/go-crypto; version v1.3.0 --
+https://github.com/ProtonMail/go-crypto
+
+** k8s.io/apimachinery/third_party/forked/golang; version v0.33.2 --
+https://github.com/kubernetes/apimachinery
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------
+
 ** github.com/spf13/pflag; version v1.0.6 --
 https://github.com/spf13/pflag
 
@@ -931,28 +925,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.24.3 --
+** golang.org/go; version go1.25.0 --
 https://github.com/golang/go
 
-** golang.org/x/crypto; version v0.38.0 --
+** golang.org/x/crypto; version v0.40.0 --
 https://golang.org/x/crypto
 
-** golang.org/x/mod/semver; version v0.24.0 --
+** golang.org/x/mod/semver; version v0.26.0 --
 https://golang.org/x/mod
 
-** golang.org/x/net; version v0.38.0 --
+** golang.org/x/net; version v0.42.0 --
 https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.28.0 --
 https://golang.org/x/oauth2
 
-** golang.org/x/sys; version v0.33.0 --
+** golang.org/x/sys; version v0.34.0 --
 https://golang.org/x/sys
 
-** golang.org/x/term; version v0.32.0 --
+** golang.org/x/term; version v0.33.0 --
 https://golang.org/x/term
 
-** golang.org/x/text; version v0.25.0 --
+** golang.org/x/text; version v0.27.0 --
 https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.10.0 --

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.27.1
 
-GOLANG_VERSION?="1.24"
+GOLANG_VERSION?="1.25"
 GO ?= $(shell source ./scripts/common.sh && get_go_path $(GOLANG_VERSION))/go
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/eks-hybrid
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/ProtonMail/gopenpgp/v3 v3.3.0

--- a/test/integration/infra/Dockerfile
+++ b/test/integration/infra/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/eks-distro-build-tooling/golang:1.24 AS nodeadm-build
+FROM public.ecr.aws/eks-distro-build-tooling/golang:1.25 AS nodeadm-build
 WORKDIR /go/src/github.com/aws/eks-hybrid
 ARG GOPROXY
 RUN go env -w GOPROXY=${GOPROXY}


### PR DESCRIPTION
Upgrading to Go 1.25 everywhere.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

