### PR TITLE
Reduce SSM credential retry backoff interval to 60 seconds

### DIFF
--- a/test/integration/cases/install-with-ssm/expected-ssm-agent-config.json
+++ b/test/integration/cases/install-with-ssm/expected-ssm-agent-config.json
@@ -1,0 +1,11 @@
+{
+    "Identity": {
+        "ConsumptionOrder": [
+            "OnPrem"
+        ],
+        "CustomIdentities": null
+    },
+    "Ssm": {
+        "CredentialRetryMaxSleepSeconds": 60
+    }
+}

--- a/test/integration/cases/install-with-ssm/run.sh
+++ b/test/integration/cases/install-with-ssm/run.sh
@@ -30,6 +30,8 @@ do
     assert::path-exists /opt/ssm/ssm-setup-cli
     assert::path-exists /usr/bin/amazon-ssm-agent
 
+    validate-json-file /etc/amazon/ssm/amazon-ssm-agent.json 600 expected-ssm-agent-config.json
+
     assert::files-equal /opt/nodeadm/tracker expected-nodeadm-tracker
 
     nodeadm uninstall --skip node-validation,pod-validation
@@ -44,5 +46,7 @@ do
     assert::path-not-exist /usr/bin/containerd
     assert::path-not-exist /opt/ssm/ssm-setup-cli
     assert::path-not-exist /usr/bin/amazon-ssm-agent
+    assert::path-not-exist /etc/amazon/ssm/amazon-ssm-agent.json
+    assert::path-not-exist /etc/amazon
     assert::path-not-exist /opt/nodeadm/tracker
 done


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Reduces SSM agent credential retry backoff from 1800 seconds  to 60 seconds. Fixes delay in credential rotation caused by excessive backoff time when SSM agent cannot reach endpoints.

```javascript
When network disconnections occur due to networking issues and the SSM agent cannot reach
SSM endpoints, it enters an exponential backoff retry mechanism with a maximum delay of up to
30 minutes between retry attempts. After network connectivity is restored, the SSM agent can
still be in the backoff state and won't attempt to refresh expired credentials for up to 30 minutes,
leaving the nodes unable to authenticate with the EKS control plane during this period.

This change improve the responsiveness of credential rotation failure during backoff time. 
```

Fix applied to SSM-AGENT (Release 3.3.3050.0)
https://github.com/aws/amazon-ssm-agent/commit/2619f4c36fc15192c93e40e7352c6103f4242ad2


*Testing (if applicable):*

1. Unit test
2. Integration tests 
3. Test nodeadm to beta Hybrid node 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

