### PR TITLE
Add Version field to Addon so we can set it if needed for E2E test

### DIFF
--- a/test/e2e/addon/addon.go
+++ b/test/e2e/addon/addon.go
@@ -19,6 +19,7 @@ type Addon struct {
 	Namespace     string
 	Cluster       string
 	Configuration string
+	Version       string
 }
 
 const (
@@ -33,6 +34,7 @@ func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logge
 		ClusterName:         &a.Cluster,
 		AddonName:           &a.Name,
 		ConfigurationValues: &a.Configuration,
+		AddonVersion:        &a.Version,
 	}
 
 	_, err := client.CreateAddon(ctx, params)


### PR DESCRIPTION
*Issue #, if available:*
We are unable to choose which add-on versions to use during E2E tests. It's okay in most cases. However for S3 mountpoint CSI driver add-on, the default install version is v1. For the testing we want to install v2 version.

*Description of changes:*
Add Version field to Addon so we can set it if needed for E2E test

*Testing (if applicable):*
Manually tested

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

