### PR TITLE
Add retries to fix network issues in service connectivity tests

### DIFF
--- a/test/e2e/kubernetes/service.go
+++ b/test/e2e/kubernetes/service.go
@@ -112,7 +112,17 @@ func TestServiceConnectivityWithRetries(ctx context.Context, config *restclient.
 	logger.Info("Testing service connectivity with retries", "from", clientPodName, "service", serviceName, "port", port)
 
 	serviceURL := fmt.Sprintf("http://%s:%d", serviceName, port)
-	cmd := []string{"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", serviceURL, "--connect-timeout", "300", "--max-time", "420"}
+
+	cmd := []string{
+		"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+		serviceURL,
+		"--connect-timeout", "60",
+		"--max-time", "120",
+		"--retry", "5",
+		"--retry-delay", "30",
+		"--retry-max-time", "600",
+		"--retry-all-errors",
+	}
 
 	_, err := ik8s.GetAndWait(ctx, 15*time.Minute, k8s.CoreV1().Pods(namespace), clientPodName, func(pod *corev1.Pod) bool {
 		if pod.Status.Phase != corev1.PodRunning {

--- a/test/e2e/suite/mixed_mode/mixed_mode_test.go
+++ b/test/e2e/suite/mixed_mode/mixed_mode_test.go
@@ -55,7 +55,7 @@ var (
 	webhookPort int32 = 443
 
 	// Timing constants
-	crossVPCPropagationWait = 120 * time.Second
+	crossVPCPropagationWait = 180 * time.Second
 
 	// Node selector constants
 	cloudNodeSelector  = map[string]string{"node.kubernetes.io/instance-type": "m5.large"}


### PR DESCRIPTION
Add retries to fix network issues in service connectivity tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

