### PR TITLE
Add functions to remove nodeAffinity rules from deployment and daemonset for E2E

### DIFF
--- a/test/e2e/kubernetes/daemonset.go
+++ b/test/e2e/kubernetes/daemonset.go
@@ -2,11 +2,14 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	ik8s "github.com/aws/eks-hybrid/internal/kubernetes"
@@ -35,5 +38,51 @@ func DaemonSetWaitForReady(ctx context.Context, logger logr.Logger, k8s kubernet
 	}); err != nil {
 		return fmt.Errorf("daemonset %s replicas never became ready: %v", name, err)
 	}
+	return nil
+}
+
+// RemoveDaemonSetAntiAffinity removes node affinity rules from a daemonset that would prevent pods from being scheduled on hybrid nodes.
+// This is useful to test EKS add-on before anti-affinity rule for hybrid nodes is removed.
+// Once anti-affinity rule is removed, then caller no longer needs to call this method.
+func RemoveDaemonSetAntiAffinity(ctx context.Context, logger logr.Logger, k8s kubernetes.Interface, namespace, name string) error {
+	logger.Info("Removing node affinity rules to allow scheduling on hybrid nodes", "daemonset", name, "namespace", namespace)
+
+	// Get the current daemonset to check if it has affinity rules
+	daemonset, err := k8s.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting daemonset %s in namespace %s: %w", name, namespace, err)
+	}
+
+	if daemonset.Spec.Template.Spec.Affinity == nil {
+		logger.Info("DaemonSet has no affinity rules, nothing to remove", "daemonset", name)
+		return nil
+	}
+
+	if daemonset.Spec.Template.Spec.Affinity.NodeAffinity == nil {
+		logger.Info("DaemonSet has no node affinity rules", "daemonset", name)
+		return nil
+	}
+
+	// Create a JSON patch to remove the nodeAffinity field
+	// For now we remove all nodeAffinity rules, which should be okay for our e2e tests
+	patchJSON := []map[string]interface{}{
+		{
+			"op":   "remove",
+			"path": "/spec/template/spec/affinity/nodeAffinity",
+		},
+	}
+
+	patchBytes, err := json.Marshal(patchJSON)
+	if err != nil {
+		return fmt.Errorf("marshaling daemonset patch: %w", err)
+	}
+
+	// Apply the JSON patch
+	_, err = k8s.AppsV1().DaemonSets(namespace).Patch(ctx, name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("patching daemonset %s to remove node affinity rules: %w", name, err)
+	}
+
+	logger.Info("Successfully removed node affinity rules from daemonset", "daemonset", name)
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*
We can't test add-on in our E2E if the anti-affinity rule for add-on is not updated for hybrid nodes

*Description of changes:*
For new add-on that are not updated to be compatible with hybrid nodes yet, we can remove the anti-affinity rule in our E2E tests to allow the add-on to be provisioned on hybrid nodes.

*Testing (if applicable):*
Tested manually

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

