### PR TITLE
Add retryer to AWS configs in tests

### DIFF
--- a/cmd/e2e-test/rune2e/command.go
+++ b/cmd/e2e-test/rune2e/command.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/go-logr/logr"
 	"github.com/integrii/flaggy"
@@ -106,6 +108,15 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		// We use a custom AppId so the requests show that they were
 		// made by this command in the user-agent
 		config.WithAppID("nodeadm-e2e-test-run-cmd"),
+		config.WithRetryer(func() aws.Retryer {
+			return retry.AddWithMaxBackoffDelay(
+				retry.AddWithMaxAttempts(
+					retry.NewStandard(),
+					10, // Max 10 attempts
+				),
+				10*time.Second, // Max backoff delay
+			)
+		}),
 	)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)

--- a/cmd/e2e-test/setup/setup.go
+++ b/cmd/e2e-test/setup/setup.go
@@ -3,7 +3,10 @@ package setup
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
@@ -53,6 +56,15 @@ func (s *Command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		// We use a custom AppId so the requests show that they were
 		// made by this command in the user-agent
 		config.WithAppID("nodeadm-e2e-test-setup-cmd"),
+		config.WithRetryer(func() aws.Retryer {
+			return retry.AddWithMaxBackoffDelay(
+				retry.AddWithMaxAttempts(
+					retry.NewStandard(),
+					10, // Max 10 attempts
+				),
+				10*time.Second, // Max backoff delay
+			)
+		}),
 	)
 	if err != nil {
 		return fmt.Errorf("reading AWS configuration: %w", err)


### PR DESCRIPTION
*Description of changes:*
This PR enhances the reliability of E2E tests by adding consistent retry configuration to all AWS client initializations across test commands. The change addresses potential transient failures in AWS API calls during test execution.
```
		config.WithRetryer(func() aws.Retryer {
			return retry.AddWithMaxBackoffDelay(
				retry.AddWithMaxAttempts(
					retry.NewStandard(),
					10, // Max 10 attempts
				),
				10*time.Second, // Max backoff delay
			)
		}),
```
__Retry Policy:__

- __Max Attempts:__ 10
- __Max Backoff Delay:__ 10 seconds
- __Strategy:__ Exponential backoff with jitter
- __Total Max Wait Time:__ ~67 seconds



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

