### PR TITLE
Fix E2E jumpbox instance availability issues

### DIFF
--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -587,7 +587,9 @@ Resources:
               SubnetId: !Ref HybridNodeVPCPublicSubnet
             - InstanceType: t4g.small
               SubnetId: !Ref HybridNodeVPCPublicSubnet
-            - InstanceType: a1.medium
+            - InstanceType: t4g.large
+              SubnetId: !Ref HybridNodeVPCPublicSubnet
+            - InstanceType: t4g.nano
               SubnetId: !Ref HybridNodeVPCPublicSubnet
       TargetCapacitySpecification:
         TotalTargetCapacity: 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The jumpbox instance will fail create if it falls back to a1 instance type in a region where a1 isn't supported
`Your requested instance type (a1.medium) is not supported in your requested Availability Zone (eu-west-3a)`

This PR removes a1 instance type with the more widely available t4g instance types for better availability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

