### PR TITLE
Fix addon namespace issue for addon test

### DIFF
--- a/test/e2e/addon/addon.go
+++ b/test/e2e/addon/addon.go
@@ -30,11 +30,19 @@ const (
 func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logger) error {
 	logger.Info("Create cluster add-on", "ClusterAddon", a.Name)
 
+	var namespaceConfig *types.AddonNamespaceConfigRequest
+	if a.Namespace != "" {
+		namespaceConfig = &types.AddonNamespaceConfigRequest{
+			Namespace: &a.Namespace,
+		}
+	}
+
 	params := &eks.CreateAddonInput{
 		ClusterName:         &a.Cluster,
 		AddonName:           &a.Name,
 		ConfigurationValues: &a.Configuration,
 		AddonVersion:        &a.Version,
+		NamespaceConfig:     namespaceConfig,
 	}
 
 	_, err := client.CreateAddon(ctx, params)


### PR DESCRIPTION
*Issue #, if available:*

Add-on was not created in the namespace that it sets in `Addon.Namespace`. We don't see any issue before because luckily all the namespace we set for add-on matches the default namespace it uses in add-on manifest files.

*Description of changes:*
Now it creates add-on to the namespace that it needs.


*Testing (if applicable):*
Tested in my personal dev stack for add-on pipeline

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

