### PR TITLE
Create external-dns addon in smoke test

### DIFF
--- a/test/e2e/addon/externaldns.go
+++ b/test/e2e/addon/externaldns.go
@@ -1,0 +1,68 @@
+package addon
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/rest"
+
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+	peeredtypes "github.com/aws/eks-hybrid/test/e2e/peered/types"
+)
+
+const (
+	externalDNSName           = "external-dns"
+	externalDNSNamespace      = "external-dns"
+	externalDNSDeploymentName = "external-dns"
+	externalDNSWaitTimeout    = 5 * time.Minute
+)
+
+// ExternalDNSTest tests the external-dns addon
+type ExternalDNSTest struct {
+	Cluster   string
+	addon     *Addon
+	K8S       peeredtypes.K8s
+	EKSClient *eks.Client
+	K8SConfig *rest.Config
+	Logger    logr.Logger
+}
+
+// Create installs the external-dns addon
+func (e *ExternalDNSTest) Create(ctx context.Context) error {
+	e.addon = &Addon{
+		Cluster:   e.Cluster,
+		Namespace: externalDNSNamespace,
+		Name:      externalDNSName,
+	}
+
+	if err := e.addon.CreateAndWaitForActive(ctx, e.EKSClient, e.K8S, e.Logger); err != nil {
+		return err
+	}
+
+	// TODO: remove the following call once the addon is updated to work with hybrid nodes
+	// Remove anti affinity to allow external-dns to be deployed to hybrid nodes
+	if err := kubernetes.RemoveDeploymentAntiAffinity(ctx, e.K8S, externalDNSDeploymentName, externalDNSNamespace, e.Logger); err != nil {
+		return fmt.Errorf("failed to remove anti affinity: %w", err)
+	}
+
+	// Wait for external-dns deployment to be ready
+	if err := kubernetes.DeploymentWaitForReplicas(ctx, externalDNSWaitTimeout, e.K8S, externalDNSNamespace, externalDNSDeploymentName); err != nil {
+		return fmt.Errorf("deployment %s not ready: %w", externalDNSDeploymentName, err)
+	}
+
+	return nil
+}
+
+// Validate checks if external-dns is working correctly
+func (e *ExternalDNSTest) Validate(ctx context.Context) error {
+	// TODO: add validate later
+	return nil
+}
+
+func (e *ExternalDNSTest) Delete(ctx context.Context) error {
+	return e.addon.Delete(ctx, e.EKSClient, e.Logger)
+}

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -176,3 +176,14 @@ func (a *AddonEc2Test) NewCertManagerTest(ctx context.Context) (*addon.CertManag
 		IssuerName:     defaultIssuerName,
 	}, nil
 }
+
+// NewExternalDNSTest creates a new ExternalDNSTest
+func (a *AddonEc2Test) NewExternalDNSTest() *addon.ExternalDNSTest {
+	return &addon.ExternalDNSTest{
+		Cluster:   a.Cluster.Name,
+		K8S:       a.K8sClient,
+		EKSClient: a.EKSClient,
+		K8SConfig: a.K8sClientConfig,
+		Logger:    a.Logger.WithName("ExternalDNSTest"),
+	}
+}

--- a/test/e2e/suite/addons/addons_test.go
+++ b/test/e2e/suite/addons/addons_test.go
@@ -483,6 +483,24 @@ var _ = Describe("Hybrid Nodes", func() {
 					// )
 				})
 			}, Label("s3-mountpoint-csi-driver"))
+
+			Context("runs external-dns tests", func() {
+				It("uses all OS", func(ctx context.Context) {
+					externalDNSTest := addonEc2Test.NewExternalDNSTest()
+
+					DeferCleanup(func(ctx context.Context) {
+						Expect(externalDNSTest.Delete(ctx)).To(Succeed(), "should cleanup external-dns successfully")
+					})
+
+					Expect(externalDNSTest.Create(ctx)).To(
+						Succeed(), "external-dns should have been created successfully",
+					)
+
+					// Expect(externalDNSTest.Validate(ctx)).To(
+					// Succeed(), "external-dns should have been validated successfully",
+					// )
+				})
+			}, Label("external-dns"))
 		})
 	})
 })


### PR DESCRIPTION
## Issue ##
No smoke tests for external-dns addon

## Proposed changes ##
There will be a series of PRs to add smoke test for external-dns addon. This is the first part, which includes the following:
1. Create `external-dns` addon
2. Remove anti-affinity from `external-dns` daemonset
3. Wait for `external-dns` to be ready

*Testing (if applicable):*
Tested manually

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

