### PR TITLE
Create pod identity association for s3 csi driver in smoke test

### DIFF
--- a/test/e2e/addon/s3csidriver.go
+++ b/test/e2e/addon/s3csidriver.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/rest"
 
+	e2errors "github.com/aws/eks-hybrid/test/e2e/errors"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 	peeredtypes "github.com/aws/eks-hybrid/test/e2e/peered/types"
 )
@@ -19,17 +22,19 @@ const (
 	s3CSIDriverNamespace = "kube-system"
 	s3CSIControllerName  = "s3-csi-controller"
 	s3CSINodeName        = "s3-csi-node"
+	s3CSIDriverSAName    = "s3-csi-driver-sa"
 	s3CSIWaitTimeout     = 5 * time.Minute
 )
 
 // S3MountpointCSIDriverTest tests the S3 mountpoint CSI driver addon
 type S3MountpointCSIDriverTest struct {
-	Cluster   string
-	addon     *Addon
-	K8S       peeredtypes.K8s
-	EKSClient *eks.Client
-	K8SConfig *rest.Config
-	Logger    logr.Logger
+	Cluster            string
+	addon              *Addon
+	K8S                peeredtypes.K8s
+	EKSClient          *eks.Client
+	K8SConfig          *rest.Config
+	Logger             logr.Logger
+	PodIdentityRoleArn string
 }
 
 // Create installs the S3 mountpoint CSI driver addon
@@ -39,6 +44,11 @@ func (s *S3MountpointCSIDriverTest) Create(ctx context.Context) error {
 		Namespace: s3CSIDriverNamespace,
 		Name:      s3CSIDriverName,
 		Version:   "v2.0.0-eksbuild.1", // need to specify v2 version explicitly for now since v1 is the default version to install
+	}
+
+	// Create pod identity association for the addon's service account
+	if err := s.setupPodIdentity(ctx); err != nil {
+		return fmt.Errorf("failed to setup Pod Identity for S3 CSI driver: %v", err)
 	}
 
 	if err := s.addon.CreateAndWaitForActive(ctx, s.EKSClient, s.K8S, s.Logger); err != nil {
@@ -71,4 +81,30 @@ func (s *S3MountpointCSIDriverTest) Validate(ctx context.Context) error {
 
 func (s *S3MountpointCSIDriverTest) Delete(ctx context.Context) error {
 	return s.addon.Delete(ctx, s.EKSClient, s.Logger)
+}
+
+func (s *S3MountpointCSIDriverTest) setupPodIdentity(ctx context.Context) error {
+	s.Logger.Info("Setting up Pod Identity for S3 CSI driver")
+
+	// Create Pod Identity Association for the addon's service account
+	createAssociationInput := &eks.CreatePodIdentityAssociationInput{
+		ClusterName:    aws.String(s.Cluster),
+		Namespace:      aws.String(s3CSIDriverNamespace),
+		RoleArn:        aws.String(s.PodIdentityRoleArn),
+		ServiceAccount: aws.String(s3CSIDriverSAName),
+	}
+
+	createAssociationOutput, err := s.EKSClient.CreatePodIdentityAssociation(ctx, createAssociationInput)
+
+	if err != nil && e2errors.IsType(err, &ekstypes.ResourceInUseException{}) {
+		s.Logger.Info("Pod Identity Association already exists for service account: %s", awsPcaServiceAccountName)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to create Pod Identity Association: %v", err)
+	}
+
+	s.Logger.Info("Created Pod Identity Association", "associationID", *createAssociationOutput.Association.AssociationId)
+	return nil
 }

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -640,8 +640,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - s3:Get*
-                  - s3:List*
+                  - s3:*
                 Resource:
                   - !Sub arn:aws:s3:::${PodIdentityS3Bucket}
                   - !Sub arn:aws:s3:::${PodIdentityS3Bucket}/*

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -114,14 +114,21 @@ func (a *AddonEc2Test) NewNvidiaDevicePluginTest(nodeName string) *addon.NvidiaD
 }
 
 // NewS3MountpointCSIDriverTest creates a new S3MountpointCSIDriverTest
-func (a *AddonEc2Test) NewS3MountpointCSIDriverTest() *addon.S3MountpointCSIDriverTest {
-	return &addon.S3MountpointCSIDriverTest{
-		Cluster:   a.Cluster.Name,
-		K8S:       a.K8sClient,
-		EKSClient: a.EKSClient,
-		K8SConfig: a.K8sClientConfig,
-		Logger:    a.Logger.WithName("S3MountpointCSIDriverTest"),
+func (a *AddonEc2Test) NewS3MountpointCSIDriverTest(ctx context.Context) (*addon.S3MountpointCSIDriverTest, error) {
+	podIdentityRoleArn, err := addon.PodIdentityRole(ctx, a.IAMClient, a.Cluster.Name)
+	if err != nil {
+		a.Logger.Error(err, "Failed to get pod identity role ARN")
+		return nil, err
 	}
+
+	return &addon.S3MountpointCSIDriverTest{
+		Cluster:            a.Cluster.Name,
+		K8S:                a.K8sClient,
+		EKSClient:          a.EKSClient,
+		K8SConfig:          a.K8sClientConfig,
+		Logger:             a.Logger.WithName("S3MountpointCSIDriverTest"),
+		PodIdentityRoleArn: podIdentityRoleArn,
+	}, nil
 }
 
 // NewCertManagerTest creates a new CertManagerTest

--- a/test/e2e/suite/addons/addons_test.go
+++ b/test/e2e/suite/addons/addons_test.go
@@ -468,7 +468,8 @@ var _ = Describe("Hybrid Nodes", func() {
 
 			Context("runs S3 mountpoint CSI driver tests", func() {
 				It("uses all OS", func(ctx context.Context) {
-					s3MountpointTest := addonEc2Test.NewS3MountpointCSIDriverTest()
+					s3MountpointTest, err := addonEc2Test.NewS3MountpointCSIDriverTest(ctx)
+					Expect(err).To(Succeed(), "should have created s3 mountpoint test")
 
 					DeferCleanup(func(ctx context.Context) {
 						Expect(s3MountpointTest.Delete(ctx)).To(Succeed(), "should cleanup S3 mountpoint CSI driver successfully")


### PR DESCRIPTION
## Issue ##
No smoke tests for s3 mountpoint CSI driver addon

## Proposed changes ##
There will be a series of PRs to add smoke test for S3 mountpoint CSI driver addon. This is the second part, which includes the following:
- Update pod identity IAM role to have full access on pod identity S3 bucket
- Create pod identity association for S3 mountpoint CSI driver

First part: #720 

*Testing (if applicable):*
Tested manually


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

