### PR TITLE
Use static provisioning to validate functionality of S3 csi driver in smoke test

### DIFF
--- a/test/e2e/addon/s3csidriver.go
+++ b/test/e2e/addon/s3csidriver.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"io"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	e2errors "github.com/aws/eks-hybrid/test/e2e/errors"
@@ -18,13 +22,19 @@ import (
 )
 
 const (
-	s3CSIDriverName      = "aws-mountpoint-s3-csi-driver"
-	s3CSIDriverNamespace = "kube-system"
-	s3CSIControllerName  = "s3-csi-controller"
-	s3CSINodeName        = "s3-csi-node"
-	s3CSIDriverSAName    = "s3-csi-driver-sa"
-	s3CSIWaitTimeout     = 5 * time.Minute
+	s3CSIDriver               = "aws-mountpoint-s3-csi-driver"
+	s3CSIDriverNamespace      = "kube-system"
+	s3CSIController           = "s3-csi-controller"
+	s3CSINode                 = "s3-csi-node"
+	s3CSIDriverServiceAccount = "s3-csi-driver-sa"
+	s3CSIWaitTimeout          = 5 * time.Minute
+	s3TestPod                 = "s3-app"
+	s3PathPrefix              = "s3-csi-test"
+	s3TestMsg                 = "Hello from the container!"
 )
+
+//go:embed testdata/s3_csi_static_provisioning.yaml
+var staticProvisioningYaml string
 
 // S3MountpointCSIDriverTest tests the S3 mountpoint CSI driver addon
 type S3MountpointCSIDriverTest struct {
@@ -32,9 +42,11 @@ type S3MountpointCSIDriverTest struct {
 	addon              *Addon
 	K8S                peeredtypes.K8s
 	EKSClient          *eks.Client
+	S3Client           *s3.Client
 	K8SConfig          *rest.Config
 	Logger             logr.Logger
 	PodIdentityRoleArn string
+	Bucket             string
 }
 
 // Create installs the S3 mountpoint CSI driver addon
@@ -42,7 +54,7 @@ func (s *S3MountpointCSIDriverTest) Create(ctx context.Context) error {
 	s.addon = &Addon{
 		Cluster:   s.Cluster,
 		Namespace: s3CSIDriverNamespace,
-		Name:      s3CSIDriverName,
+		Name:      s3CSIDriver,
 		Version:   "v2.0.0-eksbuild.1", // need to specify v2 version explicitly for now since v1 is the default version to install
 	}
 
@@ -57,17 +69,17 @@ func (s *S3MountpointCSIDriverTest) Create(ctx context.Context) error {
 
 	// TODO: remove the following call once the addon is updated to work with hybrid nodes
 	// Remove anti affinity to allow s3-csi-node to be deployed to hybrid nodes
-	if err := kubernetes.RemoveDaemonSetAntiAffinity(ctx, s.Logger, s.K8S, s3CSIDriverNamespace, s3CSINodeName); err != nil {
+	if err := kubernetes.RemoveDaemonSetAntiAffinity(ctx, s.Logger, s.K8S, s3CSIDriverNamespace, s3CSINode); err != nil {
 		return fmt.Errorf("failed to remove anti affinity: %w", err)
 	}
 
 	// Wait for CSI driver controller deployment and node daemonset to be ready
-	if err := kubernetes.DeploymentWaitForReplicas(ctx, s3CSIWaitTimeout, s.K8S, s3CSIDriverNamespace, s3CSIControllerName); err != nil {
-		return fmt.Errorf("controller deployment %s not ready: %w", s3CSIControllerName, err)
+	if err := kubernetes.DeploymentWaitForReplicas(ctx, s3CSIWaitTimeout, s.K8S, s3CSIDriverNamespace, s3CSIController); err != nil {
+		return fmt.Errorf("controller deployment %s not ready: %w", s3CSIController, err)
 	}
 
-	if err := kubernetes.DaemonSetWaitForReady(ctx, s.Logger, s.K8S, s3CSIDriverNamespace, s3CSINodeName); err != nil {
-		return fmt.Errorf("node daemonset %s not ready: %w", s3CSINodeName, err)
+	if err := kubernetes.DaemonSetWaitForReady(ctx, s.Logger, s.K8S, s3CSIDriverNamespace, s3CSINode); err != nil {
+		return fmt.Errorf("node daemonset %s not ready: %w", s3CSINode, err)
 	}
 
 	return nil
@@ -75,7 +87,72 @@ func (s *S3MountpointCSIDriverTest) Create(ctx context.Context) error {
 
 // Validate checks if S3 mountpoint CSI driver is working correctly
 func (s *S3MountpointCSIDriverTest) Validate(ctx context.Context) error {
-	// TODO: add validate later
+	// Replace yaml file placeholder values
+	replacer := strings.NewReplacer(
+		"{{S3_PATH_PREFIX}}", s3PathPrefix,
+		"{{S3_BUCKET}}", s.Bucket,
+		"{{S3_TEST_POD}}", s3TestPod,
+		"{{S3_TEST_MSG}}", s3TestMsg,
+	)
+
+	replacedYaml := replacer.Replace(staticProvisioningYaml)
+	objs, err := kubernetes.YamlToUnstructured([]byte(replacedYaml))
+	if err != nil {
+		return fmt.Errorf("failed to read static provisioning yaml file: %w", err)
+	}
+
+	s.Logger.Info("Applying S3 CSI static provisioning yaml")
+
+	if err := kubernetes.UpsertManifestsWithRetries(ctx, s.K8S, objs); err != nil {
+		return fmt.Errorf("failed to deploy S3 CSI static provisioning yaml: %w", err)
+	}
+
+	podListOptions := metav1.ListOptions{
+		FieldSelector: "metadata.name=" + s3TestPod,
+	}
+
+	if err := kubernetes.WaitForPodsToBeRunning(ctx, s.K8S, podListOptions, namespace, s.Logger); err != nil {
+		return fmt.Errorf("failed to wait for test pod to be running: %w", err)
+	}
+
+	listObjectsOutput, err := s.S3Client.ListObjects(ctx, &s3.ListObjectsInput{
+		Bucket: aws.String(s.Bucket),
+		Prefix: aws.String(s3PathPrefix),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list objects in S3 bucket: %w", err)
+	}
+
+	if len(listObjectsOutput.Contents) != 1 {
+		return fmt.Errorf("there should be only 1 object in the S3 bucket")
+	}
+
+	s.Logger.Info("Validating S3 object contains test message")
+	obj := listObjectsOutput.Contents[0]
+
+	body, err := s.getS3ObjectContent(ctx, s.Bucket, *obj.Key)
+	if err != nil {
+		return fmt.Errorf("failed to get object content from S3 bucket: %w", err)
+	}
+
+	if !strings.Contains(string(body), s3TestMsg) {
+		return fmt.Errorf("S3 object does not contain expected message: %s", s3TestMsg)
+	}
+
+	// Clean up - delete static provisioning yaml
+	if err := kubernetes.DeleteManifestsWithRetries(ctx, s.K8S, objs); err != nil {
+		return fmt.Errorf("failed to delete S3 CSI static provisioning yaml: %w", err)
+	}
+
+	// Clean up S3 object
+	_, err = s.S3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    obj.Key,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete object from S3 bucket: %w", err)
+	}
+
 	return nil
 }
 
@@ -91,13 +168,13 @@ func (s *S3MountpointCSIDriverTest) setupPodIdentity(ctx context.Context) error 
 		ClusterName:    aws.String(s.Cluster),
 		Namespace:      aws.String(s3CSIDriverNamespace),
 		RoleArn:        aws.String(s.PodIdentityRoleArn),
-		ServiceAccount: aws.String(s3CSIDriverSAName),
+		ServiceAccount: aws.String(s3CSIDriverServiceAccount),
 	}
 
 	createAssociationOutput, err := s.EKSClient.CreatePodIdentityAssociation(ctx, createAssociationInput)
 
 	if err != nil && e2errors.IsType(err, &ekstypes.ResourceInUseException{}) {
-		s.Logger.Info("Pod Identity Association already exists for service account: %s", awsPcaServiceAccountName)
+		s.Logger.Info("Pod Identity Association already exists for service account", "serviceAccount", s3CSIDriverServiceAccount)
 		return nil
 	}
 
@@ -107,4 +184,22 @@ func (s *S3MountpointCSIDriverTest) setupPodIdentity(ctx context.Context) error 
 
 	s.Logger.Info("Created Pod Identity Association", "associationID", *createAssociationOutput.Association.AssociationId)
 	return nil
+}
+
+func (s *S3MountpointCSIDriverTest) getS3ObjectContent(ctx context.Context, bucket, key string) ([]byte, error) {
+	getObjectOutput, err := s.S3Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get object [%s] from S3 bucket [%s]: %w", key, bucket, err)
+	}
+
+	defer getObjectOutput.Body.Close()
+	body, err := io.ReadAll(getObjectOutput.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read object body: %w", err)
+	}
+
+	return body, nil
 }

--- a/test/e2e/addon/testdata/s3_csi_static_provisioning.yaml
+++ b/test/e2e/addon/testdata/s3_csi_static_provisioning.yaml
@@ -1,0 +1,59 @@
+---
+# This yaml provides samples for S3 csi static provisioning. 
+# Ref: https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/examples/kubernetes/static_provisioning/static_provisioning.yaml
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: s3-pv
+spec:
+  capacity:
+    storage: 1200Gi # Ignored, required
+  accessModes:
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc # Name of your PVC
+  mountOptions:
+    - allow-delete
+    - region us-west-2
+    - prefix {{S3_PATH_PREFIX}}/
+  csi:
+    driver: s3.csi.aws.com # Required
+    volumeHandle: s3-csi-driver-volume # Must be unique
+    volumeAttributes:
+      bucketName: {{S3_BUCKET}}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  resources:
+    requests:
+      storage: 1200Gi # Ignored, required
+  volumeName: s3-pv # Name of your PV
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{S3_TEST_POD}}
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: ubuntu
+      command: ["/bin/sh"]
+      args: ["-c", "echo '{{S3_TEST_MSG}}' >> /data/$(date -u).txt; tail -f /dev/null"]
+      volumeMounts:
+        - name: persistent-storage
+          mountPath: /data
+  volumes:
+    - name: persistent-storage
+      persistentVolumeClaim:
+        claimName: s3-pvc

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -125,9 +125,11 @@ func (a *AddonEc2Test) NewS3MountpointCSIDriverTest(ctx context.Context) (*addon
 		Cluster:            a.Cluster.Name,
 		K8S:                a.K8sClient,
 		EKSClient:          a.EKSClient,
+		S3Client:           a.S3Client,
 		K8SConfig:          a.K8sClientConfig,
 		Logger:             a.Logger.WithName("S3MountpointCSIDriverTest"),
 		PodIdentityRoleArn: podIdentityRoleArn,
+		Bucket:             a.PodIdentityS3Bucket,
 	}, nil
 }
 

--- a/test/e2e/suite/addons/addons_test.go
+++ b/test/e2e/suite/addons/addons_test.go
@@ -479,9 +479,9 @@ var _ = Describe("Hybrid Nodes", func() {
 						Succeed(), "S3 mountpoint CSI driver should have been created successfully",
 					)
 
-					// Expect(s3MountpointTest.Validate(ctx)).To(
-					// Succeed(), "S3 mountpoint CSI driver should have been validated successfully",
-					// )
+					Expect(s3MountpointTest.Validate(ctx)).To(
+						Succeed(), "S3 mountpoint CSI driver should have been validated successfully",
+					)
 				})
 			}, Label("s3-mountpoint-csi-driver"))
 


### PR DESCRIPTION
## Issue ##
No smoke tests for s3 mountpoint CSI driver addon

## Proposed changes ##
There will be a series of PRs to add smoke test for S3 mountpoint CSI driver addon. This is the third part, which includes the following:
- use static provisioning file from S3 csi driver github repo to create pv, pvc, and test pod
- wait until test pod is in running state
- validate if s3 object contains test message
- misc improvements on naming and logging

First part: #720
Second part: #727 

*Testing (if applicable):*
Tested manually

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

