### PR TITLE
Create pod identity association for external-dns in smoke test

### DIFF
--- a/test/e2e/addon/externaldns.go
+++ b/test/e2e/addon/externaldns.go
@@ -6,29 +6,34 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/rest"
 
+	e2errors "github.com/aws/eks-hybrid/test/e2e/errors"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 	peeredtypes "github.com/aws/eks-hybrid/test/e2e/peered/types"
 )
 
 const (
-	externalDNSName           = "external-dns"
+	externalDNS               = "external-dns"
 	externalDNSNamespace      = "external-dns"
-	externalDNSDeploymentName = "external-dns"
+	externalDNSDeployment     = "external-dns"
+	externalDNSServiceAccount = "external-dns"
 	externalDNSWaitTimeout    = 5 * time.Minute
 )
 
 // ExternalDNSTest tests the external-dns addon
 type ExternalDNSTest struct {
-	Cluster   string
-	addon     *Addon
-	K8S       peeredtypes.K8s
-	EKSClient *eks.Client
-	K8SConfig *rest.Config
-	Logger    logr.Logger
+	Cluster            string
+	addon              *Addon
+	K8S                peeredtypes.K8s
+	EKSClient          *eks.Client
+	K8SConfig          *rest.Config
+	Logger             logr.Logger
+	PodIdentityRoleArn string
 }
 
 // Create installs the external-dns addon
@@ -36,7 +41,12 @@ func (e *ExternalDNSTest) Create(ctx context.Context) error {
 	e.addon = &Addon{
 		Cluster:   e.Cluster,
 		Namespace: externalDNSNamespace,
-		Name:      externalDNSName,
+		Name:      externalDNS,
+	}
+
+	// Create pod identity association for the addon's service account
+	if err := e.setupPodIdentity(ctx); err != nil {
+		return fmt.Errorf("failed to setup Pod Identity for external-dns: %v", err)
 	}
 
 	if err := e.addon.CreateAndWaitForActive(ctx, e.EKSClient, e.K8S, e.Logger); err != nil {
@@ -45,13 +55,13 @@ func (e *ExternalDNSTest) Create(ctx context.Context) error {
 
 	// TODO: remove the following call once the addon is updated to work with hybrid nodes
 	// Remove anti affinity to allow external-dns to be deployed to hybrid nodes
-	if err := kubernetes.RemoveDeploymentAntiAffinity(ctx, e.K8S, externalDNSDeploymentName, externalDNSNamespace, e.Logger); err != nil {
+	if err := kubernetes.RemoveDeploymentAntiAffinity(ctx, e.K8S, externalDNSDeployment, externalDNSNamespace, e.Logger); err != nil {
 		return fmt.Errorf("failed to remove anti affinity: %w", err)
 	}
 
 	// Wait for external-dns deployment to be ready
-	if err := kubernetes.DeploymentWaitForReplicas(ctx, externalDNSWaitTimeout, e.K8S, externalDNSNamespace, externalDNSDeploymentName); err != nil {
-		return fmt.Errorf("deployment %s not ready: %w", externalDNSDeploymentName, err)
+	if err := kubernetes.DeploymentWaitForReplicas(ctx, externalDNSWaitTimeout, e.K8S, externalDNSNamespace, externalDNSDeployment); err != nil {
+		return fmt.Errorf("deployment %s not ready: %w", externalDNSDeployment, err)
 	}
 
 	return nil
@@ -65,4 +75,30 @@ func (e *ExternalDNSTest) Validate(ctx context.Context) error {
 
 func (e *ExternalDNSTest) Delete(ctx context.Context) error {
 	return e.addon.Delete(ctx, e.EKSClient, e.Logger)
+}
+
+func (e *ExternalDNSTest) setupPodIdentity(ctx context.Context) error {
+	e.Logger.Info("Setting up Pod Identity for external-dns")
+
+	// Create Pod Identity Association for the addon's service account
+	createAssociationInput := &eks.CreatePodIdentityAssociationInput{
+		ClusterName:    aws.String(e.Cluster),
+		Namespace:      aws.String(externalDNSNamespace),
+		RoleArn:        aws.String(e.PodIdentityRoleArn),
+		ServiceAccount: aws.String(externalDNSServiceAccount),
+	}
+
+	createAssociationOutput, err := e.EKSClient.CreatePodIdentityAssociation(ctx, createAssociationInput)
+
+	if err != nil && e2errors.IsType(err, &ekstypes.ResourceInUseException{}) {
+		e.Logger.Info("Pod Identity Association already exists for service account", "serviceAccount", externalDNSServiceAccount)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to create Pod Identity Association: %v", err)
+	}
+
+	e.Logger.Info("Created Pod Identity Association", "associationID", *createAssociationOutput.Association.AssociationId)
+	return nil
 }

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -644,6 +644,22 @@ Resources:
                 Resource:
                   - !Sub arn:aws:s3:::${PodIdentityS3Bucket}
                   - !Sub arn:aws:s3:::${PodIdentityS3Bucket}/*
+        - PolicyName: AllowExternalDNSUpdates
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - route53:ChangeResourceRecordSets
+                  - route53:ListResourceRecordSets
+                  - route53:ListTagsForResources
+                Resource:
+                  - arn:aws:route53:::hostedzone/*
+              - Effect: Allow
+                Action:
+                  - route53:ListHostedZones
+                Resource:
+                  - '*'
       Tags:
         - Key: !Ref TestClusterTagKey
           Value: !Ref ClusterName

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -185,12 +185,19 @@ func (a *AddonEc2Test) NewCertManagerTest(ctx context.Context) (*addon.CertManag
 }
 
 // NewExternalDNSTest creates a new ExternalDNSTest
-func (a *AddonEc2Test) NewExternalDNSTest() *addon.ExternalDNSTest {
-	return &addon.ExternalDNSTest{
-		Cluster:   a.Cluster.Name,
-		K8S:       a.K8sClient,
-		EKSClient: a.EKSClient,
-		K8SConfig: a.K8sClientConfig,
-		Logger:    a.Logger.WithName("ExternalDNSTest"),
+func (a *AddonEc2Test) NewExternalDNSTest(ctx context.Context) (*addon.ExternalDNSTest, error) {
+	podIdentityRoleArn, err := addon.PodIdentityRole(ctx, a.IAMClient, a.Cluster.Name)
+	if err != nil {
+		a.Logger.Error(err, "Failed to get pod identity role ARN")
+		return nil, err
 	}
+
+	return &addon.ExternalDNSTest{
+		Cluster:            a.Cluster.Name,
+		K8S:                a.K8sClient,
+		EKSClient:          a.EKSClient,
+		K8SConfig:          a.K8sClientConfig,
+		Logger:             a.Logger.WithName("ExternalDNSTest"),
+		PodIdentityRoleArn: podIdentityRoleArn,
+	}, nil
 }

--- a/test/e2e/suite/addons/addons_test.go
+++ b/test/e2e/suite/addons/addons_test.go
@@ -487,7 +487,8 @@ var _ = Describe("Hybrid Nodes", func() {
 
 			Context("runs external-dns tests", func() {
 				It("uses all OS", func(ctx context.Context) {
-					externalDNSTest := addonEc2Test.NewExternalDNSTest()
+					externalDNSTest, err := addonEc2Test.NewExternalDNSTest(ctx)
+					Expect(err).To(Succeed(), "should have created external-dns test")
 
 					DeferCleanup(func(ctx context.Context) {
 						Expect(externalDNSTest.Delete(ctx)).To(Succeed(), "should cleanup external-dns successfully")


### PR DESCRIPTION
## Issue ##
No smoke tests for external-dns addon

## Proposed changes ##
There will be a series of PRs to add smoke test for external-dns addon. This is the second part, which includes the following:
- Update pod identity IAM role to have permissions for route 53 oeprations
- Create pod identity association for external-dns
- misc improvements on naming and logging

The IAM role ref: 
https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#iam-policy

First part: #725 

*Testing (if applicable):*
Tested manually


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

