### PR TITLE
Ensure stack outputs are non-empty in e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ e2e-config
 **/ca.key
 test/e2e/suite/**/*.test
 _output
+.ignore/


### PR DESCRIPTION
*Description of changes:*
Tests sometimes failing with missing CFN stack outputs
```
Creating access entry	{"ssmRoleArn": ""}
      operation error EKS: CreateAccessEntry, exceeded maximum number of attempts, 40, https response error StatusCode: 400, RequestID: 73a71407-0e38-43f2-b7d2-4947857ba3a6, InvalidParameterException: The principalArn parameter is required.
```
This PR adds retries to ensure all the stack outputs are available and non-empty before consuming them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

