### PR TITLE
Add trailing dash to cluster prefix for cleanup-nodeadm step

### DIFF
--- a/buildspecs/cleanup-nodeadm.yml
+++ b/buildspecs/cleanup-nodeadm.yml
@@ -4,4 +4,4 @@ phases:
   build:
     commands:
     - ARCH="$([ "x86_64" = "$(uname -m)" ] && echo amd64 || echo arm64)"
-    - ./_bin/$ARCH/e2e-test sweeper --cluster-prefix "nodeadm-e2e-tests" --eks-endpoint "${EKS_ENDPOINT:-}"
+    - ./_bin/$ARCH/e2e-test sweeper --cluster-prefix "nodeadm-e2e-tests-" --eks-endpoint "${EKS_ENDPOINT:-}"


### PR DESCRIPTION
## Issue ##
If we have both `nodeadm-e2e-tests` pipeline and `nodeadm-e2e-tests` eks cluster in the same aws account, the pipeline can fail at `Cleanup` stage sometimes. It is because the `Cleanup` stage tries to clean up any stale resources provisioned for `nodeadm-e2e-tests` cluster as well since the cluster-prefix in sweeper command is `nodeadm-e2e-tests`. However it failed to do so as it only has permission to clean up resources with `nodeadm-e2e-tests-` prefix as `testClusterTagKey`. 

## Proposed change ##
Now fix the sweeper command to only clean up resources intended for code pipeline, which uses `nodeadm-e2e-tests-` as prefix in the `testClusterTagKey`.


*Testing (if applicable):*


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

