### PR TITLE
Create hosted zone for external-dns smoke test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.1
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.63.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.38.0
-	github.com/aws/smithy-go v1.22.5
+	github.com/aws/smithy-go v1.23.0
 	github.com/cert-manager/aws-privateca-issuer v1.7.0
 	github.com/cert-manager/cert-manager v1.18.2
 	github.com/containerd/containerd v1.7.28
@@ -92,13 +92,14 @@ require (
 require (
 	dario.cat/mergo v1.0.2 // direct
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.38.1
+	github.com/aws/aws-sdk-go-v2 v1.39.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.6
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.4 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.4 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.7 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.7 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.58.1
 	github.com/aws/aws-sdk-go-v2/service/sso v1.28.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.33.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go-v2 v1.38.1 h1:j7sc33amE74Rz0M/PoCpsZQ6OunLqys/m5antM0J+Z8=
 github.com/aws/aws-sdk-go-v2 v1.38.1/go.mod h1:9Q0OoGQoboYIAJyslFyF1f5K1Ryddop8gqMhWx/n4Wg=
+github.com/aws/aws-sdk-go-v2 v1.39.0 h1:xm5WV/2L4emMRmMjHFykqiA4M/ra0DJVSWUkDyBjbg4=
+github.com/aws/aws-sdk-go-v2 v1.39.0/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.0 h1:6GMWV6CNpA/6fbFHnoAjrv4+LGfyTqZz2LtCHnspgDg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.0/go.mod h1:/mXlTIVG9jbxkqDnr5UQNQxW1HRYxeGklkM9vAFeabg=
 github.com/aws/aws-sdk-go-v2/config v1.31.2 h1:NOaSZpVGEH2Np/c1toSeW0jooNl+9ALmsUTZ8YvkJR0=
@@ -26,8 +28,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.4 h1:lpdMwTzmuDLkgW7086jE94H
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.4/go.mod h1:9xzb8/SV62W6gHQGC/8rrvgNXU6ZoYM3sAIJCIrXJxY=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.4 h1:IdCLsiiIj5YJ3AFevsewURCPV+YWUlOW8JiPhoAy8vg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.4/go.mod h1:l4bdfCD7XyyZA9BolKBo1eLqgaJxl0/x91PL4Yqe0ao=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.7 h1:UCxq0X9O3xrlENdKf1r9eRJoKz/b0AfGkpp3a7FPlhg=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.7/go.mod h1:rHRoJUNUASj5Z/0eqI4w32vKvC7atoWR0jC+IkmVH8k=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.4 h1:j7vjtr1YIssWQOMeOWRbh3z8g2oY/xPjnZH2gLY4sGw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.4/go.mod h1:yDmJgqOiH4EA8Hndnv4KwAo8jCGTSnM5ASG1nBI+toA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.7 h1:Y6DTZUn7ZUC4th9FMBbo8LVE+1fyq3ofw+tRwkUd3PY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.7/go.mod h1:x3XE6vMnU9QvHN/Wrx2s44kwzV2o2g5x/siw4ZUJ9g8=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.4 h1:BE/MNQ86yzTINrfxPPFS86QCBNQeLKY2A0KhDh47+wI=
@@ -62,6 +68,8 @@ github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.30.0 h1:gEYEoCt
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.30.0/go.mod h1:XsHmCp83S8Lj80JlmWJWNOv3KGxSQRvgQy4miY10z3M=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.21.0 h1:lsV/IEkgM/O/3mL9wu1pKyzwEmYq6Q6D4OBdM9t7Loo=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.21.0/go.mod h1:L61KDM+8S/XSlaWuAwtXUpb0IuB6ufocucP1w1WjPTA=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.58.1 h1:qew9X9TyJrKZSrORLlzNkLiqBGMEZa6eNfr5oL8grOA=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.58.1/go.mod h1:py/7C8W37SHqyHk6tkvZKiFDvMA/WkfPv5Qd8dUXYQw=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.87.1 h1:2n6Pd67eJwAb/5KCX62/8RTU0aFAAW7V5XIGSghiHrw=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.87.1/go.mod h1:w5PC+6GHLkvMJKasYGVloB3TduOtROEMqm15HSuIbw4=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.63.2 h1:ciD+LnRj2i9+TwNdbk24Rz1eTrrzVS82FaEZK8B7zyk=
@@ -74,6 +82,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.38.0 h1:iV1Ko4Em/lkJIsoKyGfc0nQySi+v
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.0/go.mod h1:bEPcjW7IbolPfK67G1nilqWyoxYMSPrDiIQ3RdIdKgo=
 github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=
 github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
+github.com/aws/smithy-go v1.23.0 h1:8n6I3gXzWJB2DxBDnfxgBaSX6oe0d/t10qGz7OKqMCE=
+github.com/aws/smithy-go v1.23.0/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/test/e2e/addon/externaldns.go
+++ b/test/e2e/addon/externaldns.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/rest"
 
+	"github.com/aws/eks-hybrid/test/e2e/constants"
 	e2errors "github.com/aws/eks-hybrid/test/e2e/errors"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 	peeredtypes "github.com/aws/eks-hybrid/test/e2e/peered/types"
@@ -31,6 +35,7 @@ type ExternalDNSTest struct {
 	addon              *Addon
 	K8S                peeredtypes.K8s
 	EKSClient          *eks.Client
+	Route53Client      *route53.Client
 	K8SConfig          *rest.Config
 	Logger             logr.Logger
 	PodIdentityRoleArn string
@@ -38,6 +43,13 @@ type ExternalDNSTest struct {
 
 // Create installs the external-dns addon
 func (e *ExternalDNSTest) Create(ctx context.Context) error {
+	hostedZoneId, err := e.getHostedZoneId(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get hosted zone id: %w", err)
+	}
+
+	e.Logger.Info("Hosted zone", "Id", hostedZoneId)
+
 	e.addon = &Addon{
 		Cluster:   e.Cluster,
 		Namespace: externalDNSNamespace,
@@ -51,12 +63,6 @@ func (e *ExternalDNSTest) Create(ctx context.Context) error {
 
 	if err := e.addon.CreateAndWaitForActive(ctx, e.EKSClient, e.K8S, e.Logger); err != nil {
 		return err
-	}
-
-	// TODO: remove the following call once the addon is updated to work with hybrid nodes
-	// Remove anti affinity to allow external-dns to be deployed to hybrid nodes
-	if err := kubernetes.RemoveDeploymentAntiAffinity(ctx, e.K8S, externalDNSDeployment, externalDNSNamespace, e.Logger); err != nil {
-		return fmt.Errorf("failed to remove anti affinity: %w", err)
 	}
 
 	// Wait for external-dns deployment to be ready
@@ -101,4 +107,37 @@ func (e *ExternalDNSTest) setupPodIdentity(ctx context.Context) error {
 
 	e.Logger.Info("Created Pod Identity Association", "associationID", *createAssociationOutput.Association.AssociationId)
 	return nil
+}
+
+func (e *ExternalDNSTest) getHostedZoneId(ctx context.Context) (*string, error) {
+	output, err := e.Route53Client.ListHostedZones(ctx, &route53.ListHostedZonesInput{
+		HostedZoneType: types.HostedZoneTypePrivateHostedZone,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list hosted zones: %w", err)
+	}
+
+	var hostedZoneIds []string
+
+	for _, hostedZone := range output.HostedZones {
+		hostedZoneIds = append(hostedZoneIds, strings.Split(*hostedZone.Id, "/")[2])
+	}
+
+	listTagsOutput, err := e.Route53Client.ListTagsForResources(ctx, &route53.ListTagsForResourcesInput{
+		ResourceIds:  hostedZoneIds,
+		ResourceType: types.TagResourceTypeHostedzone,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tags for hosted zones: %w", err)
+	}
+
+	for _, resourceTagSet := range listTagsOutput.ResourceTagSets {
+		for _, tag := range resourceTagSet.Tags {
+			if *tag.Key == constants.TestClusterTagKey && *tag.Value == e.Cluster {
+				return resourceTagSet.ResourceId, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("hosted zone not found for cluster %s", e.Cluster)
 }

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -664,6 +664,23 @@ Resources:
         - Key: !Ref TestClusterTagKey
           Value: !Ref ClusterName
       Path: !Ref RolePathPrefix
+
+  HostedZone:
+    Type: AWS::Route53::HostedZone
+    Properties:
+      Name: !Sub "${ClusterName}.local"
+      VPCs:
+        - VPCId: !Ref ClusterVPC
+          VPCRegion: !Ref AWS::Region
+      HostedZoneConfig:
+        Comment: !Sub "Private hosted zone for ${ClusterName} EKS hybrid cluster"
+      HostedZoneTags:
+        - Key: Name
+          Value: !Sub "${ClusterName}-hosted-zone"
+        - Key: !Ref TestClusterTagKey
+          Value: !Ref ClusterName
+        - Key: !Ref CreationTimeTagKey
+          Value: !Ref CreationTime
           
 
 Outputs:

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -198,6 +198,7 @@ func (a *AddonEc2Test) NewExternalDNSTest(ctx context.Context) (*addon.ExternalD
 		Cluster:            a.Cluster.Name,
 		K8S:                a.K8sClient,
 		EKSClient:          a.EKSClient,
+		Route53Client:      a.Route53Client,
 		K8SConfig:          a.K8sClientConfig,
 		Logger:             a.Logger.WithName("ExternalDNSTest"),
 		PodIdentityRoleArn: podIdentityRoleArn,

--- a/test/e2e/suite/peered_vpc.go
+++ b/test/e2e/suite/peered_vpc.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	ssmv2 "github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/go-logr/logr"
@@ -68,6 +69,7 @@ type PeeredVPCTest struct {
 	K8sClientConfig *rest.Config
 	S3Client        *s3v2.Client
 	IAMClient       *iam.Client
+	Route53Client   *route53.Client
 
 	Logger        logr.Logger
 	loggerControl e2e.PausableLogger
@@ -135,6 +137,7 @@ func BuildPeeredVPCTestForSuite(ctx context.Context, suite *SuiteConfiguration) 
 	test.S3Client = s3v2.NewFromConfig(aws)
 	test.cfnClient = cloudformation.NewFromConfig(aws)
 	test.IAMClient = iam.NewFromConfig(aws)
+	test.Route53Client = route53.NewFromConfig(aws)
 
 	ca, err := credentials.ParseCertificate(suite.RolesAnywhereCACertPEM, suite.RolesAnywhereCAKeyPEM)
 	if err != nil {


### PR DESCRIPTION
## Issue ##
No smoke tests for external-dns addon

## Proposed changes ##
There will be a series of PRs to add smoke test for external-dns addon. This is the third part, which includes the following:
- Create private hosted zone in `setup-cfn.yaml`
- Get hosted zone ID in `Create()` method
- Remove method `RemoveDeploymentAntiAffinity` from `Create()` as the anti-affinity rule has been removed

First part: #725 
Second part: #730 

*Testing (if applicable):*
Tested manually

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

