### PR TITLE
Fix resources for DeletePodIdentityAssociation and DescribePodIdentityAssociation perm

### DIFF
--- a/hybrid-nodes-cdk/lib/nodeadm/policies.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm/policies.ts
@@ -297,11 +297,14 @@ export function createNodeadmTestsCreationCleanupPolicies(
         actions: [
           'eks:CreateAddon',
           'eks:CreatePodIdentityAssociation',
-          'eks:DeletePodIdentityAssociation',
           'eks:ListPodIdentityAssociations',
-          'eks:DescribePodIdentityAssociation',
         ],
         resources: [`arn:aws:eks:${stack.region}:${stack.account}:cluster/*`],
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['eks:DeletePodIdentityAssociation', 'eks:DescribePodIdentityAssociation'],
+        resources: [`arn:aws:eks:${stack.region}:${stack.account}:podidentityassociation/*`],
       }),
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,


### PR DESCRIPTION
## Issue ##
DeletePodIdentityAssociation and DescribePodIdentityAssociation perm are applied to wrong resource. Thus we see the following error in add-on smoke test

```
  2025-09-10T20:32:08.001Z  ERROR   Failed to clean up Pod Identity for AWS PCA Issuer  {"error": "failed to delete Pod Identity Association: operation error EKS: DeletePodIdentityAssociation, https response error StatusCode: 403, RequestID: 0b3f5602-4f26-49ed-a759-a7bd955ef8f1, api error AccessDeniedException: User: arn:aws:sts::654654371076:assumed-role/nodeadm-build-65465437107-nodeadmintegrationtestrol-sfSQqHt0m9M1/AWSCodeBuild-c72fb4b6-44ba-47c1-9429-79dc60393637 is not authorized to perform: eks:DeletePodIdentityAssociation on resource: arn:aws:eks:us-west-2:654654371076:podidentityassociation/nodeadm-e2e-tests-c72fb4b6-44ba-47c1-9429-79dc60393637/a-wchd88wxhg6ydvgyy"}
```

## Proposed changes ##
Fix resource for these perm 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

