### PR TITLE
Create misc policy for the rest permission as it can have at most 10 managed policies per role

### DIFF
--- a/hybrid-nodes-cdk/lib/nodeadm/policies.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm/policies.ts
@@ -420,34 +420,20 @@ export function createNodeadmTestsCreationCleanupPolicies(
     ],
   });
 
-  // Tagging Policy
-  const taggingPolicy = new iam.ManagedPolicy(stack, 'nodeadm-e2e-tagging-policy', {
-    managedPolicyName: 'nodeadm-e2e-tagging-policy',
+  // Misc Policy - it can have only 10 managed policies per role thus this policy holds all remaing permissions
+  const miscPolicy = new iam.ManagedPolicy(stack, 'nodeadm-e2e-misc-policy', {
+    managedPolicyName: 'nodeadm-e2e-misc-policy',
     statements: [
       new iam.PolicyStatement({
         actions: ['tag:GetResources'],
         resources: ['*'],
         effect: iam.Effect.ALLOW,
       }),
-    ],
-  });
-
-  // PCA policy
-  const pcaPolicy = new iam.ManagedPolicy(stack, 'nodeadm-e2e-pca-policy', {
-    managedPolicyName: 'nodeadm-e2e-pca-policy',
-    statements: [
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: ['acm-pca:*'],
         resources: [`arn:aws:acm-pca:${stack.region}:${stack.account}:certificate-authority/*`],
       }),
-    ],
-  });
-
-  // Route53 policy
-  const route53Policy = new iam.ManagedPolicy(stack, 'nodeadm-e2e-route53-policy', {
-    managedPolicyName: 'nodeadm-e2e-route53-policy',
-    statements: [
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: [
@@ -474,9 +460,7 @@ export function createNodeadmTestsCreationCleanupPolicies(
     eksPolicy,
     s3SecretsPolicy,
     rolesAnywhereLogsPolicy,
-    taggingPolicy,
-    pcaPolicy,
-    route53Policy,
+    miscPolicy, // Do not create new policy as it can have at most 10 managed policies per role
   ];
 }
 


### PR DESCRIPTION
*Issue #, if available:*
Consolidated three separate IAM policies (tagging, PCA, and Route53) into a single "misc-policy" to avoid exceeding the AWS limit of 10 managed policies per role. The change maintains the same permissions while reducing the total number of managed policies attached to the role.

```
Resource handler returned message: "Cannot exceed quota for PoliciesPerRole: 10 (Service: Iam, Status Code: 409, Request ID: a42eda91-33d6-4a53-976c-2948b84c77b5) (SDK Attempt Count: 1)" (RequestToken: a6dcd513-5b40-32ea-cd39-c272e6373ac5, HandlerErrorCode: ServiceLimitExceeded)
```

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

