### PR TITLE
Deregister ssm instance when running node delete command

### DIFF
--- a/cmd/e2e-test/node/delete.go
+++ b/cmd/e2e-test/node/delete.go
@@ -135,6 +135,7 @@ func (d *Delete) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	node := peered.NodeCleanup{
 		EC2:          ec2Client,
 		S3:           s3Client,
+		SSM:          ssmClient,
 		K8s:          k8s,
 		LogCollector: logCollector,
 		Logger:       logger,
@@ -150,6 +151,10 @@ func (d *Delete) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		},
 		Name: d.instanceName,
 	}); err != nil {
+		return err
+	}
+
+	if err := node.CleanupSSMActivation(ctx, d.instanceName, config.ClusterName); err != nil {
 		return err
 	}
 

--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -253,7 +253,8 @@ func (c *NodeCleanup) CleanupSSMActivation(ctx context.Context, nodeName, cluste
 		return fmt.Errorf("listing activations: %w", err)
 	}
 	if len(activationIDs) == 0 {
-		return fmt.Errorf("no activation found for node %s", nodeName)
+		// if no activationID found, then cleanup is not needed
+		return nil
 	}
 
 	instanceIDs, err := cleaner.ListManagedInstancesByActivationID(ctx, activationIDs...)


### PR DESCRIPTION
## Issue ##
When running `node delete` to delete instances that are created by `node create`, it only deletes EC2 instance, leaving ssm instance orphaned. 

## Proposed changes ##
Now it deregisters ssm instance when the ec2 instance is deleted via `node delete`.


*Testing (if applicable):*
Tested manually

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

