### PR TITLE
Validate dns are synced to hosted zone for external-dns smoke test

### DIFF
--- a/test/e2e/addon/externaldns.go
+++ b/test/e2e/addon/externaldns.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 
 	"github.com/aws/eks-hybrid/test/e2e/constants"
@@ -21,12 +22,17 @@ import (
 	peeredtypes "github.com/aws/eks-hybrid/test/e2e/peered/types"
 )
 
+//go:embed testdata/nginx-external-dns.yaml
+var testServiceYAML string
+
 const (
 	externalDNS               = "external-dns"
 	externalDNSNamespace      = "external-dns"
 	externalDNSDeployment     = "external-dns"
 	externalDNSServiceAccount = "external-dns"
+	externalDNSTestService    = "nginx"
 	externalDNSWaitTimeout    = 5 * time.Minute
+	externalDNSPollInterval   = 20 * time.Second
 )
 
 // ExternalDNSTest tests the external-dns addon
@@ -39,6 +45,9 @@ type ExternalDNSTest struct {
 	K8SConfig          *rest.Config
 	Logger             logr.Logger
 	PodIdentityRoleArn string
+
+	hostedZoneId   *string
+	hostedZoneName *string
 }
 
 // Create installs the external-dns addon
@@ -48,12 +57,21 @@ func (e *ExternalDNSTest) Create(ctx context.Context) error {
 		return fmt.Errorf("failed to get hosted zone id: %w", err)
 	}
 
-	e.Logger.Info("Hosted zone", "Id", hostedZoneId)
+	hostedZoneName, err := e.getHostedZoneName(ctx, hostedZoneId)
+	if err != nil {
+		return fmt.Errorf("failed to get hosted zone name: %w", err)
+	}
 
+	e.hostedZoneId = hostedZoneId
+	e.hostedZoneName = hostedZoneName
+	e.Logger.Info("Hosted zone", "Id", hostedZoneId, "Name", hostedZoneName)
+
+	configuration := fmt.Sprintf(`{"domainFilters": ["%s"], "policy": "sync"}`, *hostedZoneName)
 	e.addon = &Addon{
-		Cluster:   e.Cluster,
-		Namespace: externalDNSNamespace,
-		Name:      externalDNS,
+		Cluster:       e.Cluster,
+		Namespace:     externalDNSNamespace,
+		Name:          externalDNS,
+		Configuration: configuration,
 	}
 
 	// Create pod identity association for the addon's service account
@@ -75,7 +93,59 @@ func (e *ExternalDNSTest) Create(ctx context.Context) error {
 
 // Validate checks if external-dns is working correctly
 func (e *ExternalDNSTest) Validate(ctx context.Context) error {
-	// TODO: add validate later
+	if e.hostedZoneName == nil {
+		return fmt.Errorf("hosted zone name is not set, ensure Create() was called first")
+	}
+
+	e.Logger.Info("Deploying test service for external-dns validation")
+
+	// Remove the trailing dot from the hosted zone name if present
+	hostedZoneName := strings.TrimSuffix(*e.hostedZoneName, ".")
+
+	replacer := strings.NewReplacer(
+		"{{TEST_SERVICE}}", externalDNSTestService,
+		"{{NAMESPACE}}", namespace,
+		"{{HOSTED_ZONE_NAME}}", hostedZoneName,
+	)
+	replacedTestServiceYAML := replacer.Replace(testServiceYAML)
+
+	// Deploy the test service with external-dns annotation
+	objs, err := kubernetes.YamlToUnstructured([]byte(replacedTestServiceYAML))
+	if err != nil {
+		return fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	e.Logger.Info("Applying test service YAML")
+	if err := kubernetes.UpsertManifestsWithRetries(ctx, e.K8S, objs); err != nil {
+		return fmt.Errorf("failed to deploy test service: %w", err)
+	}
+
+	// Wait for deployment to be ready
+	if err := kubernetes.DeploymentWaitForReplicas(ctx, externalDNSWaitTimeout, e.K8S, namespace, externalDNSTestService); err != nil {
+		return fmt.Errorf("service deployment not ready: %w", err)
+	}
+
+	// Wait for external-dns to create the DNS record
+	expectedDNSName := fmt.Sprintf("%s.%s", externalDNSTestService, hostedZoneName)
+	e.Logger.Info("Waiting for external-dns to create DNS record", "dnsName", expectedDNSName)
+
+	if err := e.waitForDNSRecord(ctx, expectedDNSName); err != nil {
+		return fmt.Errorf("DNS record not created by external-dns: %w", err)
+	}
+
+	// Clean up - delete test service
+	e.Logger.Info("Cleaning up test service")
+	if err := kubernetes.DeleteManifestsWithRetries(ctx, e.K8S, objs); err != nil {
+		return fmt.Errorf("failed to delete test service: %w", err)
+	}
+
+	// Wait for external-dns to clean up the DNS record
+	e.Logger.Info("Waiting for external-dns to clean up DNS record", "dnsName", expectedDNSName)
+	if err := e.waitForDNSRecordDeletion(ctx, expectedDNSName); err != nil {
+		return fmt.Errorf("DNS record not cleaned up by external-dns: %w", err)
+	}
+
+	e.Logger.Info("Successfully validated external-dns functionality", "dnsName", expectedDNSName)
 	return nil
 }
 
@@ -140,4 +210,96 @@ func (e *ExternalDNSTest) getHostedZoneId(ctx context.Context) (*string, error) 
 	}
 
 	return nil, fmt.Errorf("hosted zone not found for cluster %s", e.Cluster)
+}
+
+func (e *ExternalDNSTest) getHostedZoneName(ctx context.Context, hostedZoneId *string) (*string, error) {
+	zoneOutput, err := e.Route53Client.GetHostedZone(ctx, &route53.GetHostedZoneInput{
+		Id: hostedZoneId,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hosted zone: %w", err)
+	}
+
+	return zoneOutput.HostedZone.Name, nil
+}
+
+func (e *ExternalDNSTest) waitForDNSRecord(ctx context.Context, expectedDNSName string) error {
+	if e.hostedZoneId == nil {
+		return fmt.Errorf("hosted zone id is not set, ensure Create() was called first")
+	}
+
+	e.Logger.Info("Polling for DNS record creation", "dnsName", expectedDNSName)
+
+	err := wait.PollUntilContextTimeout(ctx, externalDNSPollInterval, externalDNSWaitTimeout, true, func(ctx context.Context) (bool, error) {
+		found, err := e.checkDNSRecordExists(ctx, e.hostedZoneId, expectedDNSName)
+		if err != nil {
+			e.Logger.Error(err, "Error checking DNS record", "dnsName", expectedDNSName)
+			return false, nil // Continue polling on error
+		}
+		if found {
+			e.Logger.Info("DNS record found in hosted zone", "dnsName", expectedDNSName)
+			return true, nil
+		}
+		e.Logger.Info("DNS record not found yet, waiting...", "dnsName", expectedDNSName)
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timeout waiting for DNS record %s to be created: %w", expectedDNSName, err)
+	}
+
+	return nil
+}
+
+func (e *ExternalDNSTest) waitForDNSRecordDeletion(ctx context.Context, expectedDNSName string) error {
+	if e.hostedZoneId == nil {
+		return fmt.Errorf("hosted zone id is not set, ensure Create() was called first")
+	}
+
+	e.Logger.Info("Polling for DNS record deletion", "dnsName", expectedDNSName)
+
+	err := wait.PollUntilContextTimeout(ctx, externalDNSPollInterval, externalDNSWaitTimeout, true, func(ctx context.Context) (bool, error) {
+		found, err := e.checkDNSRecordExists(ctx, e.hostedZoneId, expectedDNSName)
+		if err != nil {
+			e.Logger.Error(err, "Error checking DNS record", "dnsName", expectedDNSName)
+			return false, nil // Continue polling on error
+		}
+		if !found {
+			e.Logger.Info("DNS record successfully deleted from hosted zone", "dnsName", expectedDNSName)
+			return true, nil
+		}
+		e.Logger.Info("DNS record still exists, waiting for deletion...", "dnsName", expectedDNSName)
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timeout waiting for DNS record %s to be deleted: %w", expectedDNSName, err)
+	}
+
+	return nil
+}
+
+func (e *ExternalDNSTest) checkDNSRecordExists(ctx context.Context, hostedZoneId *string, dnsName string) (bool, error) {
+	// Ensure DNS name ends with a dot for Route53 API
+	if !strings.HasSuffix(dnsName, ".") {
+		dnsName = dnsName + "."
+	}
+
+	listInput := &route53.ListResourceRecordSetsInput{
+		HostedZoneId: hostedZoneId,
+	}
+
+	output, err := e.Route53Client.ListResourceRecordSets(ctx, listInput)
+	if err != nil {
+		return false, fmt.Errorf("failed to list resource record sets: %w", err)
+	}
+
+	for _, recordSet := range output.ResourceRecordSets {
+		if recordSet.Name != nil && *recordSet.Name == dnsName {
+			// Found the DNS record, check if it's an A record (LoadBalancer creates A records)
+			if recordSet.Type == types.RRTypeA {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }

--- a/test/e2e/addon/testdata/nginx-external-dns.yaml
+++ b/test/e2e/addon/testdata/nginx-external-dns.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{TEST_SERVICE}}
+  namespace: {{NAMESPACE}}
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: {{TEST_SERVICE}}.{{HOSTED_ZONE_NAME}}
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    name: http
+    targetPort: 80
+  selector:
+    app: {{TEST_SERVICE}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{TEST_SERVICE}}
+  namespace: {{NAMESPACE}}
+spec:
+  selector:
+    matchLabels:
+      app: {{TEST_SERVICE}}
+  template:
+    metadata:
+      labels:
+        app: {{TEST_SERVICE}}
+    spec:
+      containers:
+      - image: nginx
+        name: {{TEST_SERVICE}}
+        ports:
+        - containerPort: 80
+          name: http

--- a/test/e2e/suite/addons/addons_test.go
+++ b/test/e2e/suite/addons/addons_test.go
@@ -414,9 +414,9 @@ var _ = Describe("Hybrid Nodes", func() {
 						Succeed(), "external-dns should have been created successfully",
 					)
 
-					// Expect(externalDNSTest.Validate(ctx)).To(
-					// Succeed(), "external-dns should have been validated successfully",
-					// )
+					Expect(externalDNSTest.Validate(ctx)).To(
+						Succeed(), "external-dns should have been validated successfully",
+					)
 				})
 			}, Label("external-dns"))
 		})


### PR DESCRIPTION
## Issue ##
No smoke tests for external-dns addon

## Proposed changes ##
There will be a series of PRs to add smoke test for external-dns addon. This is the fifth part, which includes the following:
- Update add-on configuration to have domain filter and policy
- Find hosted zone id and name based on cluster name we set in tags 
- Replace hosted zone name in test service yaml 
- Deploy test service yaml
- Wait for the test service to be ready
- Validate the dns in test service are synced to route 53 hosted zone
- Delete test service
- Validate the dns in test service are deleted when the test service is deleted


First part: #725 
Second part: #730 
Third part: #738 
Fourth part: #739 

*Testing (if applicable):*
Tested manually and also tested with my dev stack

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

