### PR TITLE
Modify S3 upload scripts by removing explicit public-read ACL flags

### DIFF
--- a/hack/release-nodeadm.sh
+++ b/hack/release-nodeadm.sh
@@ -6,20 +6,14 @@ set -o pipefail
 # Required arguments
 PROD_BUCKET=$1
 VERSION=$2
-PUBLIC_READ_ACL="${3:-true}"
-
-PUBLIC_READ_ACL_ARG=""  
-if [ "$PUBLIC_READ_ACL" = "true" ]; then
-  PUBLIC_READ_ACL_ARG="--acl public-read"
-fi
 
 echo "Starting nodeadm release process..."
 
 # Upload to production
 echo "Uploading artifacts to production..."
-aws s3 sync --no-progress --exclude "*nodeadm.gz" latest/ s3://${PROD_BUCKET}/releases/${VERSION}/ ${PUBLIC_READ_ACL_ARG}
+aws s3 sync --no-progress --exclude "*nodeadm.gz" latest/ s3://${PROD_BUCKET}/releases/${VERSION}/
 # uploading nodeadm.gz files separately to ensure the content-encoding/disposition is applied
-aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip --content-disposition "attachment; filename=\"nodeadm\"" latest/ s3://${PROD_BUCKET}/releases/${VERSION}/ ${PUBLIC_READ_ACL_ARG}
+aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip --content-disposition "attachment; filename=\"nodeadm\"" latest/ s3://${PROD_BUCKET}/releases/${VERSION}/
 
 # Update latest symlinks
 echo "Updating latest symlinks for nodeadm..."

--- a/hack/upload-dev-release-artifacts.sh
+++ b/hack/upload-dev-release-artifacts.sh
@@ -4,12 +4,6 @@ set -o nounset
 set -o pipefail
 
 ARTIFACTS_BUCKET="$1"
-PUBLIC_READ_ACL="${2:-true}"
-
-PUBLIC_READ_ACL_ARG=""  
-if [ "$PUBLIC_READ_ACL" = "true" ]; then
-  PUBLIC_READ_ACL_ARG="--acl public-read"
-fi
 
 # only uploading nodeadm, ATTRIBUTION.txt, and GIT_VERSION, skipping ginkgo/e2e-test/nodeadm.test
 mkdir -p _bin/latest/bin/linux/{amd64,arm64}
@@ -18,5 +12,5 @@ cp _bin/amd64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/bi
 cp _bin/arm64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/bin/linux/arm64/
 
 # uploading nodeadm.gz files separately to ensure the content-encoding/disposition is applied
-aws s3 sync --no-progress --exclude "*nodeadm.gz" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/ ${PUBLIC_READ_ACL_ARG}
-aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip --content-disposition "attachment; filename=\"nodeadm\"" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/ ${PUBLIC_READ_ACL_ARG}
+aws s3 sync --no-progress --exclude "*nodeadm.gz" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/
+aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip --content-disposition "attachment; filename=\"nodeadm\"" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/


### PR DESCRIPTION


*Description of changes:*
Modify S3 upload scripts by removing explicit public-read ACL flags  as CloudFront distribution provides public access, making object ACLs unnecessary



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

