### PR TITLE
chore: Move pod identity association logic to addon.go

### DIFF
--- a/test/e2e/addon/addon.go
+++ b/test/e2e/addon/addon.go
@@ -15,11 +15,17 @@ import (
 )
 
 type Addon struct {
-	Name          string
-	Namespace     string
-	Cluster       string
-	Configuration string
-	Version       string
+	Name                    string
+	Namespace               string
+	Cluster                 string
+	Configuration           string
+	Version                 string
+	PodIdentityAssociations []PodIdentityAssociation
+}
+
+type PodIdentityAssociation struct {
+	RoleArn        string
+	ServiceAccount string
 }
 
 const (
@@ -37,12 +43,21 @@ func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logge
 		}
 	}
 
+	var podIdentityAssociations []types.AddonPodIdentityAssociations
+	for _, association := range a.PodIdentityAssociations {
+		podIdentityAssociations = append(podIdentityAssociations, types.AddonPodIdentityAssociations{
+			RoleArn:        &association.RoleArn,
+			ServiceAccount: &association.ServiceAccount,
+		})
+	}
+
 	params := &eks.CreateAddonInput{
-		ClusterName:         &a.Cluster,
-		AddonName:           &a.Name,
-		ConfigurationValues: &a.Configuration,
-		AddonVersion:        &a.Version,
-		NamespaceConfig:     namespaceConfig,
+		ClusterName:             &a.Cluster,
+		AddonName:               &a.Name,
+		ConfigurationValues:     &a.Configuration,
+		AddonVersion:            &a.Version,
+		NamespaceConfig:         namespaceConfig,
+		PodIdentityAssociations: podIdentityAssociations,
 	}
 
 	_, err := client.CreateAddon(ctx, params)


### PR DESCRIPTION
*Issue #, if available:*
Currently, we create pod identity association in each add-on and then delete the association when the add-on is deleted. That means every new add-on needs to have the same logic if it plans to use pod identity, resulting duplicate code.

*Description of changes:*
Now we will handle pod identity association in `eks.CreateAddon` method. When `DeleteAddon` is called, the association will be removed as part of add-on deletion.

*Testing (if applicable):*
Tested with personal dev stack.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

