### PR TITLE
Allow containerd 2.x for k8s versions >= 1.30

### DIFF
--- a/internal/containerd/install_test.go
+++ b/internal/containerd/install_test.go
@@ -1,0 +1,70 @@
+package containerd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetermineContainerdVersionConstraint(t *testing.T) {
+	tests := []struct {
+		name               string
+		kubernetesVersion  string
+		expectedConstraint string
+	}{
+		{
+			name:               "K8s 1.28 should use containerd 1.* constraint",
+			kubernetesVersion:  "1.28.0",
+			expectedConstraint: "1.*",
+		},
+		{
+			name:               "K8s 1.29.0 should use containerd 1.* constraint",
+			kubernetesVersion:  "1.29.0",
+			expectedConstraint: "1.*",
+		},
+		{
+			name:               "K8s 1.29.5 should use containerd 1.* constraint",
+			kubernetesVersion:  "1.29.5",
+			expectedConstraint: "1.*",
+		},
+		{
+			name:               "K8s 1.30.0 should use no constraint (allows 2.x)",
+			kubernetesVersion:  "1.30.0",
+			expectedConstraint: "",
+		},
+		{
+			name:               "K8s 1.30.1 should use no constraint (allows 2.x)",
+			kubernetesVersion:  "1.30.1",
+			expectedConstraint: "",
+		},
+		{
+			name:               "K8s 1.30.5 should use no constraint (allows 2.x)",
+			kubernetesVersion:  "1.30.5",
+			expectedConstraint: "",
+		},
+		{
+			name:               "K8s 1.31.0 should use no constraint (allows 2.x)",
+			kubernetesVersion:  "1.31.0",
+			expectedConstraint: "",
+		},
+		{
+			name:               "K8s 1.32.0 should use no constraint (allows 2.x)",
+			kubernetesVersion:  "1.32.0",
+			expectedConstraint: "",
+		},
+		{
+			name:               "K8s 2.0.0 should use no constraint (allows 2.x)",
+			kubernetesVersion:  "2.0.0",
+			expectedConstraint: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineContainerdVersionConstraint(tt.kubernetesVersion)
+			assert.Equal(t, tt.expectedConstraint, got,
+				"determineContainerdVersionConstraint(%q) returned %q, expected %q",
+				tt.kubernetesVersion, got, tt.expectedConstraint)
+		})
+	}
+}

--- a/internal/containerd/sandbox_test.go
+++ b/internal/containerd/sandbox_test.go
@@ -6,7 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const containerdConfigDumpFragment = `
+const (
+	containerdConfigDumpFragment = `
 [plugins]
 
   [plugins."io.containerd.gc.v1.scheduler"]
@@ -47,11 +48,82 @@ const containerdConfigDumpFragment = `
     unset_seccomp_profile = ""
 `
 
-func TestSandboxImageRegex(t *testing.T) {
-	matches := containerdSandboxImageRegex.FindStringSubmatch(containerdConfigDumpFragment)
+	// Test data for parseConfigVersion function
+	containerdConfigV2 = `version = 2
+[plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.8"`
+
+	containerdConfigV3 = `version = 3
+[plugins."io.containerd.grpc.v1.cri"]
+    sandbox = "registry.k8s.io/pause:3.8"`
+
+	containerdConfigNoVersion = `[plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.8"`
+
+	containerdConfigInvalidVersion = `version = invalid
+[plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.8"`
+)
+
+func TestSandboxImageV2Regex(t *testing.T) {
+	matches := containerdSandboxImageV2Regex.FindStringSubmatch(containerdConfigDumpFragment)
 	if matches == nil {
 		t.Errorf("sandbox image could not be found in containerd config")
 	}
 	sandboxImage := matches[1]
 	assert.Equal(t, sandboxImage, "registry.k8s.io/pause:3.8")
+}
+
+func TestParseConfigVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    int
+		expectError bool
+	}{
+		{
+			name:        "valid v2 config",
+			input:       containerdConfigV2,
+			expected:    2,
+			expectError: false,
+		},
+		{
+			name:        "valid v3 config",
+			input:       containerdConfigV3,
+			expected:    3,
+			expectError: false,
+		},
+		{
+			name:        "config without version",
+			input:       containerdConfigNoVersion,
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "config with invalid version",
+			input:       containerdConfigInvalidVersion,
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "empty input",
+			input:       "",
+			expected:    0,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseConfigVersion([]byte(tt.input))
+
+			if tt.expectError {
+				assert.Error(t, err, "expected error for test case: %s", tt.name)
+				assert.Equal(t, tt.expected, result, "expected result should be 0 for error cases")
+			} else {
+				assert.NoError(t, err, "unexpected error for test case: %s", tt.name)
+				assert.Equal(t, tt.expected, result, "incorrect version parsed for test case: %s", tt.name)
+			}
+		})
+	}
 }

--- a/internal/containerd/version.go
+++ b/internal/containerd/version.go
@@ -1,0 +1,27 @@
+package containerd
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	"go.uber.org/zap"
+)
+
+func GetContainerdVersion() (string, error) {
+	rawVersion, err := GetContainerdVersionRaw()
+	if err != nil {
+		return "", err
+	}
+	semVerRegex := regexp.MustCompile(`[0-9]+\.[0-9]+.[0-9]+`)
+	return semVerRegex.FindString(string(rawVersion)), nil
+}
+
+func GetContainerdVersionRaw() ([]byte, error) {
+	zap.L().Info("Reading containerd version from executable")
+	output, err := exec.Command("containerd", "--version").Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get containerd version: %w", err)
+	}
+	return output, nil
+}

--- a/internal/flows/install.go
+++ b/internal/flows/install.go
@@ -63,8 +63,14 @@ func (i *Installer) Run(ctx context.Context) error {
 
 func (i *Installer) installDistroPackages(ctx context.Context) error {
 	i.Logger.Info("Installing containerd...")
-	if err := containerd.Install(ctx, i.Tracker, i.PackageManager, i.ContainerdSource); err != nil {
+	if err := containerd.Install(ctx, i.Tracker, i.PackageManager, i.ContainerdSource, i.AwsSource.Eks.Version); err != nil {
 		return err
+	}
+	if containerdVersion, err := containerd.GetContainerdVersion(); err == nil {
+		i.Logger.Info("Containerd installation completed",
+			zap.String("containerdVersion", containerdVersion))
+	} else {
+		i.Logger.Warn("Could not determine installed containerd version", zap.Error(err))
 	}
 
 	i.Logger.Info("Installing iptables...")

--- a/internal/flows/upgrade.go
+++ b/internal/flows/upgrade.go
@@ -70,7 +70,7 @@ func (u *Upgrader) upgradeDistroPackages(ctx context.Context) error {
 	}
 	if u.Artifacts.Containerd != tracker.ContainerdSourceNone {
 		u.Logger.Info("Upgrading containerd...")
-		if err := containerd.Upgrade(ctx, u.PackageManager); err != nil {
+		if err := containerd.Upgrade(ctx, u.PackageManager, u.AwsSource.Eks.Version); err != nil {
 			return err
 		}
 	}

--- a/internal/packagemanager/packagemanager.go
+++ b/internal/packagemanager/packagemanager.go
@@ -208,7 +208,7 @@ func (pm *DistroPackageManager) appendPackageVersion(packageName, version string
 	}
 }
 
-func (pm *DistroPackageManager) getContainerdPackageNameWithVersion(version string) string {
+func (pm *DistroPackageManager) getContainerdPackageNameWithVersionConstraint(version string) string {
 	containerdPkgName := containerdDistroPkgName
 	if pm.dockerRepo != "" {
 		containerdPkgName = containerdDockerPkgName
@@ -227,8 +227,8 @@ func (pm *DistroPackageManager) refreshMetadataCacheCommand(ctx context.Context)
 
 // GetContainerd gets the Package
 // Satisfies the containerd source interface
-func (pm *DistroPackageManager) GetContainerd(version string) artifact.Package {
-	packageName := pm.getContainerdPackageNameWithVersion(version)
+func (pm *DistroPackageManager) GetContainerd(versionConstraint string) artifact.Package {
+	packageName := pm.getContainerdPackageNameWithVersionConstraint(versionConstraint)
 	return artifact.NewPackageSource(
 		artifact.NewCmd(pm.manager, pm.installVerb, packageName, "-y"),
 		artifact.NewCmd(pm.manager, pm.deleteVerb, packageName, "-y"),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Enables containerd `2.x` when available in the OS's package manager and K8s version is 1.30 or greater (the versions that have been tested for containerd 2.x - https://containerd.io/releases/). For now this is expected to the be AL2023 while RHEL 8/9 and Ubuntu 20/22/24 will remain on `1.7.x`. 

Containerd major version upgrading is enabled - customers previously on containerd `1.7.x` will also be upgraded to containerd `2.x` if available at upgrade time and compatible with the Kubernetes version.

There was a change in containerd config version from 2 to 3 as part of the containerd `2.x`. However the old config v2 is still compatible with containerd `2.x` (https://containerd.io/releases/#daemon-configuration), and the config will be automatically migrated in-memory at startup by containerd. In the future we would like to use the `containerd config migrate` command to automatically migrate the v2 config to v3 for the customer to improve containerd start time, however this does not currently support drop-in configs and is only a minor improvement so it's been omitted.

*Testing (if applicable):*

E2E tests on AL2023/Ubuntu with K8s versions1.33 and 1.29.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

