### PR TITLE
Adding Guardrails for s3 buckets in different regions

### DIFF
--- a/test/e2e/addon/addon.go
+++ b/test/e2e/addon/addon.go
@@ -15,16 +15,23 @@ import (
 )
 
 type Addon struct {
-	Name          string
-	Namespace     string
-	Cluster       string
-	Configuration string
-	Version       string
+	Name                    string
+	Namespace               string
+	Cluster                 string
+	Configuration           string
+	Version                 string
+	PodIdentityAssociations []PodIdentityAssociation
+}
+
+type PodIdentityAssociation struct {
+	RoleArn        string
+	ServiceAccount string
 }
 
 const (
 	addonPollInterval = 10 * time.Second
 	addonPollTimeout  = 5 * time.Minute
+	defaultNamespace  = "default"
 )
 
 func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logger) error {
@@ -37,12 +44,21 @@ func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logge
 		}
 	}
 
+	var podIdentityAssociations []types.AddonPodIdentityAssociations
+	for _, association := range a.PodIdentityAssociations {
+		podIdentityAssociations = append(podIdentityAssociations, types.AddonPodIdentityAssociations{
+			RoleArn:        &association.RoleArn,
+			ServiceAccount: &association.ServiceAccount,
+		})
+	}
+
 	params := &eks.CreateAddonInput{
-		ClusterName:         &a.Cluster,
-		AddonName:           &a.Name,
-		ConfigurationValues: &a.Configuration,
-		AddonVersion:        &a.Version,
-		NamespaceConfig:     namespaceConfig,
+		ClusterName:             &a.Cluster,
+		AddonName:               &a.Name,
+		ConfigurationValues:     &a.Configuration,
+		AddonVersion:            &a.Version,
+		NamespaceConfig:         namespaceConfig,
+		PodIdentityAssociations: podIdentityAssociations,
 	}
 
 	_, err := client.CreateAddon(ctx, params)

--- a/test/e2e/addon/cloudwatch.go
+++ b/test/e2e/addon/cloudwatch.go
@@ -113,9 +113,8 @@ func (cw CloudWatchAddon) VerifyWebhookFunctionality(
 	}
 
 	podName := "cloudwatch-webhook-test-hybrid"
-	namespace := "default"
 
-	if err := kubernetes.CreateNginxPodInNode(ctx, k8sClient, hybridNodeName, namespace, clusterRegion, logger, podName, labels); err != nil {
+	if err := kubernetes.CreateNginxPodInNode(ctx, k8sClient, hybridNodeName, defaultNamespace, clusterRegion, logger, podName, labels); err != nil {
 		return fmt.Errorf("creating and running CloudWatch test pod on hybrid node: %w", err)
 	}
 

--- a/test/e2e/addon/externaldns.go
+++ b/test/e2e/addon/externaldns.go
@@ -7,9 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
-	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/go-logr/logr"
@@ -17,7 +15,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/aws/eks-hybrid/test/e2e/constants"
-	e2errors "github.com/aws/eks-hybrid/test/e2e/errors"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 	peeredtypes "github.com/aws/eks-hybrid/test/e2e/peered/types"
 )
@@ -72,11 +69,12 @@ func (e *ExternalDNSTest) Create(ctx context.Context) error {
 		Namespace:     externalDNSNamespace,
 		Name:          externalDNS,
 		Configuration: configuration,
-	}
-
-	// Create pod identity association for the addon's service account
-	if err := e.setupPodIdentity(ctx); err != nil {
-		return fmt.Errorf("failed to setup Pod Identity for external-dns: %v", err)
+		PodIdentityAssociations: []PodIdentityAssociation{
+			{
+				RoleArn:        e.PodIdentityRoleArn,
+				ServiceAccount: externalDNSServiceAccount,
+			},
+		},
 	}
 
 	if err := e.addon.CreateAndWaitForActive(ctx, e.EKSClient, e.K8S, e.Logger); err != nil {
@@ -104,7 +102,7 @@ func (e *ExternalDNSTest) Validate(ctx context.Context) error {
 
 	replacer := strings.NewReplacer(
 		"{{TEST_SERVICE}}", externalDNSTestService,
-		"{{NAMESPACE}}", namespace,
+		"{{NAMESPACE}}", defaultNamespace,
 		"{{HOSTED_ZONE_NAME}}", hostedZoneName,
 	)
 	replacedTestServiceYAML := replacer.Replace(testServiceYAML)
@@ -121,7 +119,7 @@ func (e *ExternalDNSTest) Validate(ctx context.Context) error {
 	}
 
 	// Wait for deployment to be ready
-	if err := kubernetes.DeploymentWaitForReplicas(ctx, externalDNSWaitTimeout, e.K8S, namespace, externalDNSTestService); err != nil {
+	if err := kubernetes.DeploymentWaitForReplicas(ctx, externalDNSWaitTimeout, e.K8S, defaultNamespace, externalDNSTestService); err != nil {
 		return fmt.Errorf("service deployment not ready: %w", err)
 	}
 
@@ -151,32 +149,6 @@ func (e *ExternalDNSTest) Validate(ctx context.Context) error {
 
 func (e *ExternalDNSTest) Delete(ctx context.Context) error {
 	return e.addon.Delete(ctx, e.EKSClient, e.Logger)
-}
-
-func (e *ExternalDNSTest) setupPodIdentity(ctx context.Context) error {
-	e.Logger.Info("Setting up Pod Identity for external-dns")
-
-	// Create Pod Identity Association for the addon's service account
-	createAssociationInput := &eks.CreatePodIdentityAssociationInput{
-		ClusterName:    aws.String(e.Cluster),
-		Namespace:      aws.String(externalDNSNamespace),
-		RoleArn:        aws.String(e.PodIdentityRoleArn),
-		ServiceAccount: aws.String(externalDNSServiceAccount),
-	}
-
-	createAssociationOutput, err := e.EKSClient.CreatePodIdentityAssociation(ctx, createAssociationInput)
-
-	if err != nil && e2errors.IsType(err, &ekstypes.ResourceInUseException{}) {
-		e.Logger.Info("Pod Identity Association already exists for service account", "serviceAccount", externalDNSServiceAccount)
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("failed to create Pod Identity Association: %v", err)
-	}
-
-	e.Logger.Info("Created Pod Identity Association", "associationID", *createAssociationOutput.Association.AssociationId)
-	return nil
 }
 
 func (e *ExternalDNSTest) getHostedZoneId(ctx context.Context) (*string, error) {

--- a/test/e2e/addon/nvidiadeviceplugin.go
+++ b/test/e2e/addon/nvidiadeviceplugin.go
@@ -93,11 +93,11 @@ func (n *NvidiaDevicePluginTest) Validate(ctx context.Context) error {
 		return fmt.Errorf("failed to deploy gpu pod: %w", err)
 	}
 
-	if err := kubernetes.WaitForPodToBeCompleted(ctx, n.K8S, testPodName, namespace); err != nil {
+	if err := kubernetes.WaitForPodToBeCompleted(ctx, n.K8S, testPodName, defaultNamespace); err != nil {
 		return fmt.Errorf("failed to wait for gpu pod to be completed: %w", err)
 	}
 
-	logs, err := kubernetes.FetchLogs(ctx, n.K8S, testPodName, namespace)
+	logs, err := kubernetes.FetchLogs(ctx, n.K8S, testPodName, defaultNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to fetch logs for gpu pod: %w", err)
 	}

--- a/test/e2e/addon/podidentityaddon.go
+++ b/test/e2e/addon/podidentityaddon.go
@@ -22,7 +22,6 @@ type PodIdentityAddon struct {
 
 const (
 	podIdentityServiceAccount = "pod-identity-sa"
-	namespace                 = "default"
 	podIdentityAgent          = "eks-pod-identity-agent"
 	bucketObjectKey           = "test"
 	bucketObjectContent       = "RANDOM-WORD"
@@ -46,13 +45,13 @@ func (p PodIdentityAddon) Create(ctx context.Context, logger logr.Logger, eksCli
 
 	// Provision PodIdentity addon related resources
 	// Create service account in kubernetes
-	if err := kubernetes.NewServiceAccount(ctx, logger, k8sClient, namespace, podIdentityServiceAccount); err != nil {
+	if err := kubernetes.NewServiceAccount(ctx, logger, k8sClient, defaultNamespace, podIdentityServiceAccount); err != nil {
 		return err
 	}
 
 	createPodIdentityAssociationInput := &eks.CreatePodIdentityAssociationInput{
 		ClusterName:    &p.Cluster,
-		Namespace:      aws.String(namespace),
+		Namespace:      aws.String(defaultNamespace),
 		RoleArn:        &p.roleArn,
 		ServiceAccount: aws.String(podIdentityServiceAccount),
 	}

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -70,7 +70,7 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sanitizedPodName,
-			Namespace: namespace,
+			Namespace: defaultNamespace,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -120,7 +120,7 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 	}
 
 	defer func() {
-		if err := kubernetes.DeletePod(ctx, v.K8S, sanitizedPodName, namespace); err != nil {
+		if err := kubernetes.DeletePod(ctx, v.K8S, sanitizedPodName, defaultNamespace); err != nil {
 			// it's okay not fail this operation as the pod would be eventually deleted when the cluster is deleted
 			v.Logger.Info("Fail to delete aws pod", "podName", sanitizedPodName, "error", err)
 		}
@@ -129,7 +129,7 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 	execCommand := []string{
 		"bash", "-c", fmt.Sprintf("aws s3 cp s3://%s/%s . > /dev/null && cat ./%s", v.PodIdentityS3Bucket, bucketObjectKey, bucketObjectKey),
 	}
-	stdout, stdErr, err := kubernetes.ExecPodWithRetries(ctx, v.K8SConfig, v.K8S, sanitizedPodName, namespace, execCommand...)
+	stdout, stdErr, err := kubernetes.ExecPodWithRetries(ctx, v.K8SConfig, v.K8S, sanitizedPodName, defaultNamespace, execCommand...)
 	if err != nil {
 		return fmt.Errorf("exec aws s3 cp command on pod %s: err: %w, stdout: %s, stderr: %s", sanitizedPodName, err, stdout, stdErr)
 	}

--- a/test/e2e/addon/s3csidriver.go
+++ b/test/e2e/addon/s3csidriver.go
@@ -10,13 +10,11 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
-	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
-	e2errors "github.com/aws/eks-hybrid/test/e2e/errors"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 	peeredtypes "github.com/aws/eks-hybrid/test/e2e/peered/types"
 )
@@ -56,11 +54,12 @@ func (s *S3MountpointCSIDriverTest) Create(ctx context.Context) error {
 		Namespace: s3CSIDriverNamespace,
 		Name:      s3CSIDriver,
 		Version:   "v2.0.0-eksbuild.1", // need to specify v2 version explicitly for now since v1 is the default version to install
-	}
-
-	// Create pod identity association for the addon's service account
-	if err := s.setupPodIdentity(ctx); err != nil {
-		return fmt.Errorf("failed to setup Pod Identity for S3 CSI driver: %v", err)
+		PodIdentityAssociations: []PodIdentityAssociation{
+			{
+				RoleArn:        s.PodIdentityRoleArn,
+				ServiceAccount: s3CSIDriverServiceAccount,
+			},
+		},
 	}
 
 	if err := s.addon.CreateAndWaitForActive(ctx, s.EKSClient, s.K8S, s.Logger); err != nil {
@@ -111,7 +110,7 @@ func (s *S3MountpointCSIDriverTest) Validate(ctx context.Context) error {
 		FieldSelector: "metadata.name=" + s3TestPod,
 	}
 
-	if err := kubernetes.WaitForPodsToBeRunning(ctx, s.K8S, podListOptions, namespace, s.Logger); err != nil {
+	if err := kubernetes.WaitForPodsToBeRunning(ctx, s.K8S, podListOptions, defaultNamespace, s.Logger); err != nil {
 		return fmt.Errorf("failed to wait for test pod to be running: %w", err)
 	}
 
@@ -158,32 +157,6 @@ func (s *S3MountpointCSIDriverTest) Validate(ctx context.Context) error {
 
 func (s *S3MountpointCSIDriverTest) Delete(ctx context.Context) error {
 	return s.addon.Delete(ctx, s.EKSClient, s.Logger)
-}
-
-func (s *S3MountpointCSIDriverTest) setupPodIdentity(ctx context.Context) error {
-	s.Logger.Info("Setting up Pod Identity for S3 CSI driver")
-
-	// Create Pod Identity Association for the addon's service account
-	createAssociationInput := &eks.CreatePodIdentityAssociationInput{
-		ClusterName:    aws.String(s.Cluster),
-		Namespace:      aws.String(s3CSIDriverNamespace),
-		RoleArn:        aws.String(s.PodIdentityRoleArn),
-		ServiceAccount: aws.String(s3CSIDriverServiceAccount),
-	}
-
-	createAssociationOutput, err := s.EKSClient.CreatePodIdentityAssociation(ctx, createAssociationInput)
-
-	if err != nil && e2errors.IsType(err, &ekstypes.ResourceInUseException{}) {
-		s.Logger.Info("Pod Identity Association already exists for service account", "serviceAccount", s3CSIDriverServiceAccount)
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("failed to create Pod Identity Association: %v", err)
-	}
-
-	s.Logger.Info("Created Pod Identity Association", "associationID", *createAssociationOutput.Association.AssociationId)
-	return nil
 }
 
 func (s *S3MountpointCSIDriverTest) getS3ObjectContent(ctx context.Context, bucket, key string) ([]byte, error) {

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -86,6 +86,7 @@ func NewCreate(aws aws.Config, logger logr.Logger, endpoint string) Create {
 			ec2Client: ec2.NewFromConfig(aws),
 			logger:    logger,
 			ssmClient: ssm.NewFromConfig(aws),
+			region: aws.Region,
 		},
 		iam:            iam.NewFromConfig(aws),
 		s3:             s3.NewFromConfig(aws),

--- a/test/e2e/cluster/delete.go
+++ b/test/e2e/cluster/delete.go
@@ -40,6 +40,7 @@ func NewDelete(aws aws.Config, logger logr.Logger, endpoint string) Delete {
 			ec2Client: ec2.NewFromConfig(aws),
 			logger:    logger,
 			s3Client:  s3.NewFromConfig(aws),
+			region: aws.Region,
 		},
 	}
 }

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -65,6 +65,7 @@ type stack struct {
 	ec2Client *ec2.Client
 	s3Client  *s3.Client
 	iamClient *iam.Client
+	region string
 }
 
 func (s *stack) deploy(ctx context.Context, test TestResources) (*resourcesStackOutput, error) {
@@ -400,7 +401,7 @@ func (s *stack) delete(ctx context.Context, clusterName string) error {
 }
 
 func (s *stack) emptyPodIdentityS3Bucket(ctx context.Context, clusterName string) error {
-	podIdentityBucket, err := addon.PodIdentityBucket(ctx, s.s3Client, clusterName)
+	podIdentityBucket, err := addon.PodIdentityBucket(ctx, s.s3Client, clusterName, s.region)
 	if err != nil {
 		if errors.Is(err, addon.ErrPodIdentityBucketNotFound) {
 			return nil

--- a/test/e2e/suite/peered_vpc.go
+++ b/test/e2e/suite/peered_vpc.go
@@ -129,7 +129,8 @@ func BuildPeeredVPCTestForSuite(ctx context.Context, suite *SuiteConfiguration) 
 	if err != nil {
 		return nil, err
 	}
-
+	test.Logger.Info("HEREEEE!!!")
+	test.Logger.Info(aws.Region)
 	test.aws = aws
 	test.EKSClient = e2e.NewEKSClient(aws, suite.TestConfig.Endpoint)
 	test.EC2Client = ec2v2.NewFromConfig(aws)
@@ -177,8 +178,7 @@ func BuildPeeredVPCTestForSuite(ctx context.Context, suite *SuiteConfiguration) 
 		return nil, err
 	}
 	test.nodeadmURLs = *urls
-
-	test.PodIdentityS3Bucket, err = addon.PodIdentityBucket(ctx, test.S3Client, test.Cluster.Name)
+	test.PodIdentityS3Bucket, err = addon.PodIdentityBucket(ctx, test.S3Client, test.Cluster.Name, aws.Region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
*Issue #, if available:*
If two s3 buckets had the prefix "podid" in different regions, this would cause the tests to fail with the error: 
`getting bucket tagging: operation error S3: GetBucketTagging, https response error StatusCode: 301, RequestID: WGBQJQFB7Z2KXSVT, HostID: GAVWfFhWLvjhbykCzTgV3mIrOFU4lEAFVitSA8FMMavPLFcSPaVmBjHQ1B6a+ckL+SMvN+S/zHU=, api error PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.`

*Description of changes:*
Check if the bucket region is in a different region than the stack user is working on. If so, skip adding this to the list of s3 buckets to be deleted upon cleanup.

*Testing (if applicable):*
Ran `make e2e-test ginkgo ` && `./_bin/e2e-test run-e2e -f="al23-amd64 && simpleflow && ssm" --skip-cleanup=true --artifacts-dir=e2e-artifacts --logs-bucket=<s3 logs bucket>`
saw that error went away and expected infra was deployed in dev account. Was now able to run the tests in us-east-1 and us-west-2

*Documentation added/planned (if applicable):*
n/a

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

