### PR TITLE
adding guardrails for s3 buckets in different accounts

### DIFF
--- a/test/e2e/addon/podidentityresource.go
+++ b/test/e2e/addon/podidentityresource.go
@@ -53,40 +53,46 @@ type StatementEntry struct {
 var ErrPodIdentityBucketNotFound = errors.New("pod identity bucket not found")
 
 // PodIdentityBucket returns the pod identity bucket for the given cluster.
-func PodIdentityBucket(ctx context.Context, client *s3.Client, cluster string) (string, error) {
+func PodIdentityBucket(ctx context.Context, client *s3.Client, cluster, region string) (string, error) {
 	listBucketsOutput, err := client.ListBuckets(ctx, &s3.ListBucketsInput{
 		Prefix: aws.String(PodIdentityS3BucketPrefix),
 	})
 	if err != nil {
 		return "", fmt.Errorf("listing buckets: %w", err)
 	}
-
 	var foundBuckets []string
 	for _, bucket := range listBucketsOutput.Buckets {
-		getBucketTaggingOutput, err := client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil && (e2eErrors.IsS3BucketNotFound(err) || e2eErrors.IsAwsError(err, "NoSuchTagSet")) {
-			// We have to pull all buckets and then get the tags
-			// the bucket could get deleted between the list and get tags call
+		// listBuckestOutput will go through all of the buckets in the aws account
+		// starting with "podid". We are only concerned with cleaning up the buckets
+		// in the relevant region
+		if *bucket.BucketRegion != region {
 			continue
-		}
-		if err != nil {
-			return "", fmt.Errorf("getting bucket tagging: %w", err)
-		}
-
-		var foundClusterTag, foundPodIdentityTag bool
-		for _, tag := range getBucketTaggingOutput.TagSet {
-			if *tag.Key == constants.TestClusterTagKey && *tag.Value == cluster {
-				foundClusterTag = true
+		} else {
+			getBucketTaggingOutput, err := client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
+				Bucket: bucket.Name,
+			})
+			if err != nil && (e2eErrors.IsS3BucketNotFound(err) || e2eErrors.IsAwsError(err, "NoSuchTagSet")) {
+				// We have to pull all buckets and then get the tags
+				// the bucket could get deleted between the list and get tags call
+				continue
+			}
+			if err != nil {
+				return "", fmt.Errorf("getting bucket tagging: %w", err)
 			}
 
-			if *tag.Key == PodIdentityS3BucketPrefix && *tag.Value == "true" {
-				foundPodIdentityTag = true
-			}
+			var foundClusterTag, foundPodIdentityTag bool
+			for _, tag := range getBucketTaggingOutput.TagSet {
+				if *tag.Key == constants.TestClusterTagKey && *tag.Value == cluster {
+					foundClusterTag = true
+				}
 
-			if foundClusterTag && foundPodIdentityTag {
-				foundBuckets = append(foundBuckets, *bucket.Name)
+				if *tag.Key == PodIdentityS3BucketPrefix && *tag.Value == "true" {
+					foundPodIdentityTag = true
+				}
+
+				if foundClusterTag && foundPodIdentityTag {
+					foundBuckets = append(foundBuckets, *bucket.Name)
+				}
 			}
 		}
 	}

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -86,6 +86,7 @@ func NewCreate(aws aws.Config, logger logr.Logger, endpoint string) Create {
 			ec2Client: ec2.NewFromConfig(aws),
 			logger:    logger,
 			ssmClient: ssm.NewFromConfig(aws),
+			region:    aws.Region,
 		},
 		iam:            iam.NewFromConfig(aws),
 		s3:             s3.NewFromConfig(aws),

--- a/test/e2e/cluster/delete.go
+++ b/test/e2e/cluster/delete.go
@@ -40,6 +40,7 @@ func NewDelete(aws aws.Config, logger logr.Logger, endpoint string) Delete {
 			ec2Client: ec2.NewFromConfig(aws),
 			logger:    logger,
 			s3Client:  s3.NewFromConfig(aws),
+			region:    aws.Region,
 		},
 	}
 }

--- a/test/e2e/cluster/stack.go
+++ b/test/e2e/cluster/stack.go
@@ -65,6 +65,7 @@ type stack struct {
 	ec2Client *ec2.Client
 	s3Client  *s3.Client
 	iamClient *iam.Client
+	region    string
 }
 
 func (s *stack) deploy(ctx context.Context, test TestResources) (*resourcesStackOutput, error) {
@@ -400,7 +401,7 @@ func (s *stack) delete(ctx context.Context, clusterName string) error {
 }
 
 func (s *stack) emptyPodIdentityS3Bucket(ctx context.Context, clusterName string) error {
-	podIdentityBucket, err := addon.PodIdentityBucket(ctx, s.s3Client, clusterName)
+	podIdentityBucket, err := addon.PodIdentityBucket(ctx, s.s3Client, clusterName, s.region)
 	if err != nil {
 		if errors.Is(err, addon.ErrPodIdentityBucketNotFound) {
 			return nil

--- a/test/e2e/suite/peered_vpc.go
+++ b/test/e2e/suite/peered_vpc.go
@@ -129,7 +129,6 @@ func BuildPeeredVPCTestForSuite(ctx context.Context, suite *SuiteConfiguration) 
 	if err != nil {
 		return nil, err
 	}
-
 	test.aws = aws
 	test.EKSClient = e2e.NewEKSClient(aws, suite.TestConfig.Endpoint)
 	test.EC2Client = ec2v2.NewFromConfig(aws)
@@ -177,8 +176,7 @@ func BuildPeeredVPCTestForSuite(ctx context.Context, suite *SuiteConfiguration) 
 		return nil, err
 	}
 	test.nodeadmURLs = *urls
-
-	test.PodIdentityS3Bucket, err = addon.PodIdentityBucket(ctx, test.S3Client, test.Cluster.Name)
+	test.PodIdentityS3Bucket, err = addon.PodIdentityBucket(ctx, test.S3Client, test.Cluster.Name, aws.Region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

If two s3 buckets had the prefix "podid" in different regions, this would cause the tests to fail with the error:
getting bucket tagging: operation error S3: GetBucketTagging, https response error StatusCode: 301, RequestID: WGBQJQFB7Z2KXSVT, HostID: GAVWfFhWLvjhbykCzTgV3mIrOFU4lEAFVitSA8FMMavPLFcSPaVmBjHQ1B6a+ckL+SMvN+S/zHU=, api error PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.

Check if the bucket region is in a different region than the stack user is working on. If so, skip adding this to the list of s3 buckets to be deleted upon cleanup.

*Testing (if applicable):*

Ran make e2e-test ginkgo  && ./_bin/e2e-test run-e2e -f="al23-amd64 && simpleflow && ssm" --skip-cleanup=true --artifacts-dir=e2e-artifacts --logs-bucket=<s3 logs bucket>
saw that error went away and expected infra was deployed in dev account. Was now able to run the tests in us-east-1 and us-west-2

*Documentation added/planned (if applicable):*
n/a

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

