### PR TITLE
Create smoke test for secrets store csi driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.21.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.1
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.39.4
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.63.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.38.0
 	github.com/aws/smithy-go v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/ProtonMail/gopenpgp/v3 v3.3.0 h1:N6rHCH5PWwB6zSRMgRj1EbAMQHUAAHxH3Oo4
 github.com/ProtonMail/gopenpgp/v3 v3.3.0/go.mod h1:J+iNPt0/5EO9wRt7Eit9dRUlzyu3hiGX3zId6iuaKOk=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go-v2 v1.38.1 h1:j7sc33amE74Rz0M/PoCpsZQ6OunLqys/m5antM0J+Z8=
-github.com/aws/aws-sdk-go-v2 v1.38.1/go.mod h1:9Q0OoGQoboYIAJyslFyF1f5K1Ryddop8gqMhWx/n4Wg=
 github.com/aws/aws-sdk-go-v2 v1.39.0 h1:xm5WV/2L4emMRmMjHFykqiA4M/ra0DJVSWUkDyBjbg4=
 github.com/aws/aws-sdk-go-v2 v1.39.0/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.0 h1:6GMWV6CNpA/6fbFHnoAjrv4+LGfyTqZz2LtCHnspgDg=
@@ -26,12 +24,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.18.6 h1:AmmvNEYrru7sYNJnp3pf57lGbiar
 github.com/aws/aws-sdk-go-v2/credentials v1.18.6/go.mod h1:/jdQkh1iVPa01xndfECInp1v1Wnp70v3K4MvtlLGVEc=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.4 h1:lpdMwTzmuDLkgW7086jE94HweHCqG+uOJwHf3LZs7T0=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.4/go.mod h1:9xzb8/SV62W6gHQGC/8rrvgNXU6ZoYM3sAIJCIrXJxY=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.4 h1:IdCLsiiIj5YJ3AFevsewURCPV+YWUlOW8JiPhoAy8vg=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.4/go.mod h1:l4bdfCD7XyyZA9BolKBo1eLqgaJxl0/x91PL4Yqe0ao=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.7 h1:UCxq0X9O3xrlENdKf1r9eRJoKz/b0AfGkpp3a7FPlhg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.7/go.mod h1:rHRoJUNUASj5Z/0eqI4w32vKvC7atoWR0jC+IkmVH8k=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.4 h1:j7vjtr1YIssWQOMeOWRbh3z8g2oY/xPjnZH2gLY4sGw=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.4/go.mod h1:yDmJgqOiH4EA8Hndnv4KwAo8jCGTSnM5ASG1nBI+toA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.7 h1:Y6DTZUn7ZUC4th9FMBbo8LVE+1fyq3ofw+tRwkUd3PY=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.7/go.mod h1:x3XE6vMnU9QvHN/Wrx2s44kwzV2o2g5x/siw4ZUJ9g8=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
@@ -72,6 +66,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.58.1 h1:qew9X9TyJrKZSrORLlzNkLiq
 github.com/aws/aws-sdk-go-v2/service/route53 v1.58.1/go.mod h1:py/7C8W37SHqyHk6tkvZKiFDvMA/WkfPv5Qd8dUXYQw=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.87.1 h1:2n6Pd67eJwAb/5KCX62/8RTU0aFAAW7V5XIGSghiHrw=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.87.1/go.mod h1:w5PC+6GHLkvMJKasYGVloB3TduOtROEMqm15HSuIbw4=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.39.4 h1:zWISPZre5hQb3mDMCEl6uni9rJ8K2cmvp64EXF7FXkk=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.39.4/go.mod h1:GrB/4Cn7N41psUAycqnwGDzT7qYJdUm+VnEZpyZAG4I=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.63.2 h1:ciD+LnRj2i9+TwNdbk24Rz1eTrrzVS82FaEZK8B7zyk=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.63.2/go.mod h1:NMCzIcmGKoLNNkZ3/8SZzmp1+jvcU32vyUk5j7BwWI4=
 github.com/aws/aws-sdk-go-v2/service/sso v1.28.2 h1:ve9dYBB8CfJGTFqcQ3ZLAAb/KXWgYlgu/2R2TZL2Ko0=
@@ -80,8 +76,6 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.33.2 h1:pd9G9HQaM6UZAZh19pYOkpKS
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.33.2/go.mod h1:eknndR9rU8UpE/OmFpqU78V1EcXPKFTTm5l/buZYgvM=
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.0 h1:iV1Ko4Em/lkJIsoKyGfc0nQySi+v0Udxr6Igq+y9JZc=
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.0/go.mod h1:bEPcjW7IbolPfK67G1nilqWyoxYMSPrDiIQ3RdIdKgo=
-github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=
-github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/aws/smithy-go v1.23.0 h1:8n6I3gXzWJB2DxBDnfxgBaSX6oe0d/t10qGz7OKqMCE=
 github.com/aws/smithy-go v1.23.0/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/test/e2e/addon/secretsstorecsidriver.go
+++ b/test/e2e/addon/secretsstorecsidriver.go
@@ -1,0 +1,202 @@
+package addon
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/aws/eks-hybrid/test/e2e/constants"
+	"github.com/aws/eks-hybrid/test/e2e/errors"
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+	peeredtypes "github.com/aws/eks-hybrid/test/e2e/peered/types"
+)
+
+const (
+	secretsStoreCSIDriver             = "secrets-provider-aws-secrets-store-csi-driver"
+	secretsStoreCSIDriverNamespace    = "kube-system"
+	secretsStoreCSIDriverProvider     = "secrets-provider-aws-secrets-store-csi-driver-provider-aws"
+	secretsStoreTestPod               = "secrets-store-app"
+	secretsStoreTestPodServiceAccount = "nginx-pod-identity-deployment-sa"
+)
+
+//go:embed testdata/secrets_store_csi_static_provisioning.yaml
+var secretsStoreStaticProvisioningYaml string
+
+// SecretsStoreCSIDriverTest tests the Secrets Store CSI driver addon
+type SecretsStoreCSIDriverTest struct {
+	Cluster              string
+	addon                *Addon
+	K8S                  peeredtypes.K8s
+	EKSClient            *eks.Client
+	SecretsManagerClient *secretsmanager.Client
+	K8SConfig            *rest.Config
+	Logger               logr.Logger
+	PodIdentityRoleArn   string
+
+	secretName  string
+	secretValue string
+}
+
+// Create installs the Secrets Store CSI driver addon
+func (s *SecretsStoreCSIDriverTest) Create(ctx context.Context) error {
+	s.addon = &Addon{
+		Cluster:   s.Cluster,
+		Namespace: secretsStoreCSIDriverNamespace,
+		Name:      secretsStoreCSIDriver,
+	}
+
+	if err := s.addon.CreateAndWaitForActive(ctx, s.EKSClient, s.K8S, s.Logger); err != nil {
+		return err
+	}
+
+	// Wait for CSI driver daemonset to be ready
+	if err := kubernetes.DaemonSetWaitForReady(ctx, s.Logger, s.K8S, secretsStoreCSIDriverNamespace, secretsStoreCSIDriver); err != nil {
+		return fmt.Errorf("daemonset %s not ready: %w", secretsStoreCSIDriver, err)
+	}
+
+	if err := kubernetes.DaemonSetWaitForReady(ctx, s.Logger, s.K8S, secretsStoreCSIDriverNamespace, secretsStoreCSIDriverProvider); err != nil {
+		return fmt.Errorf("daemonset %s not ready: %w", secretsStoreCSIDriverProvider, err)
+	}
+
+	return nil
+}
+
+// Validate checks if Secrets Store CSI driver is working correctly
+func (s *SecretsStoreCSIDriverTest) Validate(ctx context.Context) error {
+	// Set up pod identity association for test pod service account
+	createPodIdentityAssociationInput := &eks.CreatePodIdentityAssociationInput{
+		ClusterName:    &s.Cluster,
+		Namespace:      aws.String(defaultNamespace),
+		RoleArn:        &s.PodIdentityRoleArn,
+		ServiceAccount: aws.String(secretsStoreTestPodServiceAccount),
+	}
+
+	_, err := s.EKSClient.CreatePodIdentityAssociation(ctx, createPodIdentityAssociationInput)
+	if err != nil && !errors.IsType(err, &types.ResourceInUseException{}) {
+		return fmt.Errorf("failed to create pod identity association: %w", err)
+	}
+
+	// Find the test secret by cluster tag
+	if err := s.findTestSecret(ctx); err != nil {
+		return fmt.Errorf("failed to find test secret: %w", err)
+	}
+
+	// Replace yaml file placeholder values
+	replacer := strings.NewReplacer(
+		"{{NAMESPACE}}", defaultNamespace,
+		"{{SECRETS_STORE_TEST_POD}}", secretsStoreTestPod,
+		"{{SECRET_NAME}}", s.secretName,
+		"{{SERVICE_ACCOUNT_NAME}}", secretsStoreTestPodServiceAccount,
+	)
+
+	replacedYaml := replacer.Replace(secretsStoreStaticProvisioningYaml)
+	objs, err := kubernetes.YamlToUnstructured([]byte(replacedYaml))
+	if err != nil {
+		return fmt.Errorf("failed to read secrets store static provisioning yaml file: %w", err)
+	}
+
+	s.Logger.Info("Applying Secrets Store CSI static provisioning yaml")
+
+	if err := kubernetes.UpsertManifestsWithRetries(ctx, s.K8S, objs); err != nil {
+		return fmt.Errorf("failed to deploy Secrets Store CSI static provisioning yaml: %w", err)
+	}
+
+	podListOptions := metav1.ListOptions{
+		FieldSelector: "metadata.name=" + secretsStoreTestPod,
+	}
+
+	if err := kubernetes.WaitForPodsToBeRunning(ctx, s.K8S, podListOptions, defaultNamespace, s.Logger); err != nil {
+		return fmt.Errorf("failed to wait for test pod to be running: %w", err)
+	}
+
+	// Validate that the secret was mounted correctly by checking the pod's mounted file
+	s.Logger.Info("Validating secret was mounted correctly in pod")
+
+	// Try to read the secret content
+	execCmd := []string{"cat", "/mnt/secrets-store/" + s.secretName}
+	stdout, stderr, err := kubernetes.ExecPodWithRetries(ctx, s.K8SConfig, s.K8S, secretsStoreTestPod, defaultNamespace, execCmd...)
+	if err != nil {
+		return fmt.Errorf("could not read secrets from secrets manager: %w", err)
+	}
+
+	if stderr != "" {
+		return fmt.Errorf("stderr is not empty: %s", stderr)
+	}
+
+	if trimAllLineBreaks(stdout) != trimAllLineBreaks(s.secretValue) {
+		return fmt.Errorf("expected secret value %s, got %s", s.secretValue, stdout)
+	}
+
+	s.Logger.Info("Successfully validated Secrets Store CSI driver functionality")
+
+	// Clean up - delete static provisioning yaml
+	if err := kubernetes.DeleteManifestsWithRetries(ctx, s.K8S, objs); err != nil {
+		return fmt.Errorf("failed to delete Secrets Store CSI static provisioning yaml: %w", err)
+	}
+
+	return nil
+}
+
+func (s *SecretsStoreCSIDriverTest) Delete(ctx context.Context) error {
+	return s.addon.Delete(ctx, s.EKSClient, s.Logger)
+}
+
+func (s *SecretsStoreCSIDriverTest) findTestSecret(ctx context.Context) error {
+	s.Logger.Info("Finding test secret by cluster tag")
+
+	// List all secrets
+	listSecretsOutput, err := s.SecretsManagerClient.ListSecrets(ctx, &secretsmanager.ListSecretsInput{})
+	if err != nil {
+		return fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	// Find secret with the cluster tag
+	for _, secret := range listSecretsOutput.SecretList {
+		describeSecretOutput, err := s.SecretsManagerClient.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{
+			SecretId: secret.Name,
+		})
+		if err != nil {
+			s.Logger.Error(err, "Failed to describe secret", "arn", *secret.ARN)
+			continue
+		}
+
+		// Check if this secret has the cluster tag
+		for _, tag := range describeSecretOutput.Tags {
+			if *tag.Key == constants.TestClusterTagKey && *tag.Value == s.Cluster {
+				s.Logger.Info("Found test secret", "name", *secret.Name)
+				// Get the secret value to extract key and value
+				s.secretName = *secret.Name
+				return s.extractSecretValue(ctx, secret.Name)
+			}
+		}
+	}
+
+	return fmt.Errorf("test secret not found for cluster %s", s.Cluster)
+}
+
+func (s *SecretsStoreCSIDriverTest) extractSecretValue(ctx context.Context, secretName *string) error {
+	getSecretValueOutput, err := s.SecretsManagerClient.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: secretName,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get secret value: %w", err)
+	}
+
+	s.secretValue = *getSecretValueOutput.SecretString
+	return nil
+}
+
+func trimAllLineBreaks(s string) string {
+	re := regexp.MustCompile(`[\r\n]+`)
+	return re.ReplaceAllString(s, "")
+}

--- a/test/e2e/addon/testdata/secrets_store_csi_static_provisioning.yaml
+++ b/test/e2e/addon/testdata/secrets_store_csi_static_provisioning.yaml
@@ -1,0 +1,47 @@
+---
+# This yaml provides samples for Secrets Store CSI static provisioning.
+# Ref: https://secrets-store-csi-driver.sigs.k8s.io/getting-started/usage.html
+
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: aws-secrets
+  namespace: {{NAMESPACE}}
+spec:
+  provider: aws
+  parameters:
+    objects: |
+      - objectName: "{{SECRET_NAME}}"
+        objectType: "secretsmanager"
+    usePodIdentity: "true"
+    region: us-west-2
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{SERVICE_ACCOUNT_NAME}}
+  namespace: {{NAMESPACE}}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{SECRETS_STORE_TEST_POD}}
+  namespace: {{NAMESPACE}}
+spec:
+  serviceAccountName: {{SERVICE_ACCOUNT_NAME}}
+  containers:
+    - name: nginx
+      image: nginx
+      ports:
+        - containerPort: 80
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "aws-secrets"

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -660,6 +660,15 @@ Resources:
                   - route53:ListHostedZones
                 Resource:
                   - '*'
+        - PolicyName: AllowSecretsManagerAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:*
+                Resource:
+                  - '*'
       Tags:
         - Key: !Ref TestClusterTagKey
           Value: !Ref ClusterName
@@ -681,7 +690,20 @@ Resources:
           Value: !Ref ClusterName
         - Key: !Ref CreationTimeTagKey
           Value: !Ref CreationTime
-          
+
+  MySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "${ClusterName}-MyTestSecret"
+      SecretString: |
+        {
+          "key": "MyTestSecret"
+        }
+      Tags:
+        - Key: !Ref TestClusterTagKey
+          Value: !Ref ClusterName
+        - Key: !Ref CreationTimeTagKey
+          Value: !Ref CreationTime
 
 Outputs:
   ClusterRole:

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -133,6 +133,25 @@ func (a *AddonEc2Test) NewS3MountpointCSIDriverTest(ctx context.Context) (*addon
 	}, nil
 }
 
+// NewSecretsStoreCSIDriverTest creates a new SecretsStoreCSIDriverTest
+func (a *AddonEc2Test) NewSecretsStoreCSIDriverTest(ctx context.Context) (*addon.SecretsStoreCSIDriverTest, error) {
+	podIdentityRoleArn, err := addon.PodIdentityRole(ctx, a.IAMClient, a.Cluster.Name)
+	if err != nil {
+		a.Logger.Error(err, "Failed to get pod identity role ARN")
+		return nil, err
+	}
+
+	return &addon.SecretsStoreCSIDriverTest{
+		Cluster:              a.Cluster.Name,
+		K8S:                  a.K8sClient,
+		EKSClient:            a.EKSClient,
+		SecretsManagerClient: a.SecretsManagerClient,
+		K8SConfig:            a.K8sClientConfig,
+		Logger:               a.Logger.WithName("SecretsStoreCSIDriverTest"),
+		PodIdentityRoleArn:   podIdentityRoleArn,
+	}, nil
+}
+
 // NewCertManagerTest creates a new CertManagerTest
 func (a *AddonEc2Test) NewCertManagerTest(ctx context.Context) (*addon.CertManagerTest, error) {
 	// Create cert-manager client

--- a/test/e2e/suite/addons/addons_test.go
+++ b/test/e2e/suite/addons/addons_test.go
@@ -401,6 +401,30 @@ var _ = Describe("Hybrid Nodes", func() {
 				})
 			}, Label("s3-mountpoint-csi-driver"))
 
+			Context("runs Secrets Store CSI driver tests", func() {
+				It("uses all OS", func(ctx context.Context) {
+					_, err := addonEc2Test.NewSecretsStoreCSIDriverTest(ctx)
+					Expect(err).To(Succeed(), "should have created secrets store CSI driver test")
+
+					// Comment out the below code when the add-on is available publicly on aws console
+
+					// secretsStoreTest, err := addonEc2Test.NewSecretsStoreCSIDriverTest(ctx)
+					// Expect(err).To(Succeed(), "should have created secrets store CSI driver test")
+
+					// DeferCleanup(func(ctx context.Context) {
+					// Expect(secretsStoreTest.Delete(ctx)).To(Succeed(), "should cleanup Secrets Store CSI driver successfully")
+					// })
+
+					// Expect(secretsStoreTest.Create(ctx)).To(
+					// Succeed(), "Secrets Store CSI driver should have been created successfully",
+					// )
+
+					// Expect(secretsStoreTest.Validate(ctx)).To(
+					//	Succeed(), "Secrets Store CSI driver should have been validated successfully",
+					// )
+				})
+			}, Label("secrets-store-csi-driver"))
+
 			Context("runs external-dns tests", func() {
 				It("uses all OS", func(ctx context.Context) {
 					externalDNSTest, err := addonEc2Test.NewExternalDNSTest(ctx)

--- a/test/e2e/suite/peered_vpc.go
+++ b/test/e2e/suite/peered_vpc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	ssmv2 "github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -59,17 +60,18 @@ type SuiteConfiguration struct {
 }
 
 type PeeredVPCTest struct {
-	aws             aws.Config
-	eksEndpoint     string
-	EKSClient       *eks.Client
-	EC2Client       *ec2v2.Client
-	SSMClient       *ssmv2.Client
-	cfnClient       *cloudformation.Client
-	K8sClient       peeredtypes.K8s
-	K8sClientConfig *rest.Config
-	S3Client        *s3v2.Client
-	IAMClient       *iam.Client
-	Route53Client   *route53.Client
+	aws                  aws.Config
+	eksEndpoint          string
+	EKSClient            *eks.Client
+	EC2Client            *ec2v2.Client
+	SSMClient            *ssmv2.Client
+	cfnClient            *cloudformation.Client
+	K8sClient            peeredtypes.K8s
+	K8sClientConfig      *rest.Config
+	S3Client             *s3v2.Client
+	IAMClient            *iam.Client
+	Route53Client        *route53.Client
+	SecretsManagerClient *secretsmanager.Client
 
 	Logger        logr.Logger
 	loggerControl e2e.PausableLogger
@@ -138,6 +140,7 @@ func BuildPeeredVPCTestForSuite(ctx context.Context, suite *SuiteConfiguration) 
 	test.cfnClient = cloudformation.NewFromConfig(aws)
 	test.IAMClient = iam.NewFromConfig(aws)
 	test.Route53Client = route53.NewFromConfig(aws)
+	test.SecretsManagerClient = secretsmanager.NewFromConfig(aws)
 
 	ca, err := credentials.ParseCertificate(suite.RolesAnywhereCACertPEM, suite.RolesAnywhereCAKeyPEM)
 	if err != nil {


### PR DESCRIPTION
## Issue ##
No smoke tests for secrets store csi driver addon

## Proposed changes ##
It validates secrets store csi driver functionality, assuming add-on is installed.

*Testing (if applicable):*
Tested manually. This is not fully functioning because secrets store csi driver add-on is not publicly available yet. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

