### PR TITLE
Add IAM permissions for secrets store csi smoke test

### DIFF
--- a/hybrid-nodes-cdk/lib/nodeadm/policies.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm/policies.ts
@@ -449,6 +449,18 @@ export function createNodeadmTestsCreationCleanupPolicies(
         ],
         resources: ['*'],
       }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'secretsmanager:CreateSecret',
+          'secretsmanager:DeleteSecret',
+          'secretsmanager:DescribeSecret',
+          'secretsmanager:GetSecretValue',
+          'secretsmanager:ListSecrets',
+          'secretsmanager:TagResource',
+        ],
+        resources: ['*'],
+      }),
     ],
   });
 


### PR DESCRIPTION
## Issue ##
No smoke tests for secrets store csi driver addon

## Proposed changes ##
It adds necessary permissions for aws secrets manager. 

*Testing (if applicable):*
Tested manually. This is not fully tested in E2E because secrets store csi driver add-on is not publicly available yet. 


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

