### PR TITLE
Create smoke test for FSx CSI add-on

### DIFF
--- a/test/e2e/addon/fsxcsidriver.go
+++ b/test/e2e/addon/fsxcsidriver.go
@@ -1,0 +1,126 @@
+package addon
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+	peeredtypes "github.com/aws/eks-hybrid/test/e2e/peered/types"
+)
+
+const (
+	fsxCSIDriver                = "aws-fsx-csi-driver"
+	fsxCSIDriverNamespace       = "kube-system"
+	fsxTestPod                  = "fsx-test-app"
+	fsxControllerServiceAccount = "fsx-csi-driver-sa"
+	fsxTestString               = "Hello FSX CSI Driver"
+	fsxPodWaitTimeout           = 15 * time.Minute
+)
+
+//go:embed testdata/fsx_csi_dynamic_provisioning.yaml
+var fsxDynamicProvisioningYaml string
+
+// AWSFSXCSIDriverTest tests the AWS FSX CSI driver addon
+type FsxCSIDriverTest struct {
+	Cluster            string
+	addon              *Addon
+	K8S                peeredtypes.K8s
+	EKSClient          *eks.Client
+	K8SConfig          *rest.Config
+	Logger             logr.Logger
+	PodIdentityRoleArn string
+	SubnetID           string
+	SecurityGroupID    string
+}
+
+// Create installs the AWS FSX CSI driver addon
+// Note: This add-on is not compatible with hybrid nodes yet, so we assume success
+func (f *FsxCSIDriverTest) Create(ctx context.Context) error {
+	f.addon = &Addon{
+		Cluster:   f.Cluster,
+		Namespace: fsxCSIDriverNamespace,
+		Name:      fsxCSIDriver,
+		PodIdentityAssociations: []PodIdentityAssociation{
+			{
+				RoleArn:        f.PodIdentityRoleArn,
+				ServiceAccount: fsxControllerServiceAccount,
+			},
+		},
+	}
+
+	// Since this add-on is not compatible with hybrid nodes yet, we assume it's successfully created
+	f.Logger.Info("Creating AWS FSX CSI driver addon (assuming success for hybrid nodes)")
+
+	if err := f.addon.Create(ctx, f.EKSClient, f.Logger); err != nil {
+		return fmt.Errorf("failed to create AWS FSX CSI driver addon: %w", err)
+	}
+
+	f.Logger.Info("AWS FSX CSI driver addon created successfully")
+	return nil
+}
+
+// Validate checks if AWS FSX CSI driver is working correctly
+func (f *FsxCSIDriverTest) Validate(ctx context.Context) error {
+	// Replace yaml file placeholder values
+	replacer := strings.NewReplacer(
+		"{{NAMESPACE}}", defaultNamespace,
+		"{{FSX_TEST_POD}}", fsxTestPod,
+		"{{SUBNET_ID}}", f.SubnetID,
+		"{{SECURITY_GROUP_ID}}", f.SecurityGroupID,
+		"{{FSX_TEST_STRING}}", fsxTestString,
+	)
+
+	replacedYaml := replacer.Replace(fsxDynamicProvisioningYaml)
+	objs, err := kubernetes.YamlToUnstructured([]byte(replacedYaml))
+	if err != nil {
+		return fmt.Errorf("failed to read FSX CSI dynamic provisioning yaml file: %w", err)
+	}
+
+	f.Logger.Info("Applying FSX CSI dynamic provisioning yaml")
+
+	if err := kubernetes.UpsertManifestsWithRetries(ctx, f.K8S, objs); err != nil {
+		return fmt.Errorf("failed to deploy FSX CSI dynamic provisioning yaml: %w", err)
+	}
+
+	podListOptions := metav1.ListOptions{
+		FieldSelector: "metadata.name=" + fsxTestPod,
+	}
+
+	if err := kubernetes.WaitForPodsToBeRunningWithTimeout(ctx, f.K8S, podListOptions, defaultNamespace, f.Logger, fsxPodWaitTimeout); err != nil {
+		return fmt.Errorf("failed to wait for test pod to be running: %w", err)
+	}
+
+	// Try to read the output file
+	execCmd := []string{"cat", "/data/out.txt"}
+	stdout, stderr, err := kubernetes.ExecPodWithRetries(ctx, f.K8SConfig, f.K8S, fsxTestPod, defaultNamespace, execCmd...)
+	if err != nil {
+		return fmt.Errorf("could not read data from FSX volume: %w", err)
+	}
+
+	if stderr != "" {
+		return fmt.Errorf("stderr is not empty: %s", stderr)
+	}
+
+	if stdout != fsxTestString {
+		return fmt.Errorf("expected string value %s, got %s", fsxTestString, stdout)
+	}
+
+	// Clean up - delete dynamic provisioning yaml
+	if err := kubernetes.DeleteManifestsWithRetries(ctx, f.K8S, objs); err != nil {
+		return fmt.Errorf("failed to delete FSX CSI dynamic provisioning yaml: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FsxCSIDriverTest) Delete(ctx context.Context) error {
+	return f.addon.Delete(ctx, f.EKSClient, f.Logger)
+}

--- a/test/e2e/addon/testdata/fsx_csi_dynamic_provisioning.yaml
+++ b/test/e2e/addon/testdata/fsx_csi_dynamic_provisioning.yaml
@@ -1,0 +1,48 @@
+---
+# FSX CSI Driver Dynamic Provisioning Test
+# Based on: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/tree/master/examples/kubernetes/dynamic_provisioning/specs
+
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fsx-sc
+spec:
+  provisioner: fsx.csi.aws.com
+  parameters:
+    subnetId: {{SUBNET_ID}}
+    securityGroupIds: {{SECURITY_GROUP_ID}}
+    deploymentType: PERSISTENT_2
+    storageType: SSD
+    perUnitStorageThroughput: "125"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fsx-claim
+  namespace: {{NAMESPACE}}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: fsx-sc
+  resources:
+    requests:
+      storage: 1200Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{FSX_TEST_POD}}
+  namespace: {{NAMESPACE}}
+spec:
+  containers:
+  - name: app
+    image: amazonlinux:2
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo '{{FSX_TEST_STRING}}' >> /data/out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: persistent-storage
+      mountPath: /data
+  volumes:
+  - name: persistent-storage
+    persistentVolumeClaim:
+      claimName: fsx-claim

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -633,6 +633,7 @@ Resources:
               - sts:TagSession
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AWSPrivateCAConnectorForKubernetesPolicy
+        - arn:aws:iam::aws:policy/AmazonFSxFullAccess
       Policies:
         - PolicyName: pod-identity-association-role-policy
           PolicyDocument:

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -204,3 +204,23 @@ func (a *AddonEc2Test) NewExternalDNSTest(ctx context.Context) (*addon.ExternalD
 		PodIdentityRoleArn: podIdentityRoleArn,
 	}, nil
 }
+
+// NewFsxCSIDriverTest creates a new FsxCSIDriverTest
+func (a *AddonEc2Test) NewFsxCSIDriverTest(ctx context.Context) (*addon.FsxCSIDriverTest, error) {
+	podIdentityRoleArn, err := addon.PodIdentityRole(ctx, a.IAMClient, a.Cluster.Name)
+	if err != nil {
+		a.Logger.Error(err, "Failed to get pod identity role ARN")
+		return nil, err
+	}
+
+	return &addon.FsxCSIDriverTest{
+		Cluster:            a.Cluster.Name,
+		K8S:                a.K8sClient,
+		EKSClient:          a.EKSClient,
+		K8SConfig:          a.K8sClientConfig,
+		Logger:             a.Logger.WithName("FsxCSIDriverTest"),
+		PodIdentityRoleArn: podIdentityRoleArn,
+		SubnetID:           a.Cluster.SubnetID,
+		SecurityGroupID:    a.Cluster.SecurityGroupID,
+	}, nil
+}

--- a/test/e2e/suite/addons/addons_test.go
+++ b/test/e2e/suite/addons/addons_test.go
@@ -419,6 +419,31 @@ var _ = Describe("Hybrid Nodes", func() {
 					)
 				})
 			}, Label("external-dns"))
+
+			Context("runs FSx CSI driver tests", func() {
+				It("uses all OS", func(ctx context.Context) {
+					_, err := addonEc2Test.NewFsxCSIDriverTest(ctx)
+					Expect(err).To(Succeed(), "should have created FSx CSI driver test")
+
+					// Comment out the below code when the add-on is available publicly on aws console
+
+					// fsxCSITest, err := addonEc2Test.NewFsxCSIDriverTest(ctx)
+
+					// Expect(err).To(Succeed(), "should have created FSx CSI driver test")
+
+					// DeferCleanup(func(ctx context.Context) {
+					// Expect(fsxCSITest.Delete(ctx)).To(Succeed(), "should cleanup FSx CSI driver successfully")
+					// })
+
+					// Expect(fsxCSITest.Create(ctx)).To(
+					// Succeed(), "FSx CSI driver should have been created successfully",
+					// )
+
+					// Expect(fsxCSITest.Validate(ctx)).To(
+					// Succeed(), "FSx CSI driver should have been validated successfully",
+					// )
+				})
+			}, Label("fsx-csi-driver"))
 		})
 	})
 })


### PR DESCRIPTION
## Issue ##
No smoke tests for FSx csi driver addon

## Proposed changes ##
It validates FSx csi driver functionality, assuming add-on is installed.

*Testing (if applicable):*
This is not fully functioning yet because FSx csi driver add-on does not have a new release with [this PR](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/458). 

It can be merged as it won't break anything. When a new release of FSx csi driver add-on is available, we will continue the full functional testing. 


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

