### PR TITLE
Add 1.34 to supported versions for integration tests

### DIFF
--- a/test/integration/test-constants.sh
+++ b/test/integration/test-constants.sh
@@ -4,11 +4,11 @@
 # This file centralizes version definitions used across integration tests
 
 # Supported Kubernetes versions for install/uninstall tests
-declare SUPPORTED_VERSIONS=(1.28 1.29 1.30 1.31 1.32 1.33)
+declare SUPPORTED_VERSIONS=(1.28 1.29 1.30 1.31 1.32 1.33 1.34)
 
 # Default versions for upgrade tests and single-version tests
-declare DEFAULT_INITIAL_VERSION=1.32
-declare CURRENT_VERSION=1.33  # Used for both upgrade target version and single-version tests
+declare DEFAULT_INITIAL_VERSION=1.33
+declare CURRENT_VERSION=1.34  # Used for both upgrade target version and single-version tests
 
 
 # Export arrays and variables for use in test scripts


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds 1.34 to supported EKS versions for integration tests

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

