### PR TITLE
feat: Add E2E test for RHEL10 OS

### DIFF
--- a/cmd/e2e-test/node/create.go
+++ b/cmd/e2e-test/node/create.go
@@ -54,7 +54,7 @@ func NewCreateCommand() cli.Command {
 	createCmd.AddPositionalValue(&cmd.instanceName, "INSTANCE_NAME", 1, true, "Name of the instance to create.")
 	createCmd.String(&cmd.configFile, "f", "config-file", "Path tests config file.")
 	createCmd.String(&cmd.credsProvider, "c", "creds-provider", "Credentials provider to use (iam-ra, ssm).")
-	createCmd.String(&cmd.os, "o", "os", "OS to use (al23, ubuntu2004, ubuntu2204, ubuntu2404, rhel8, rhel9, bottlerocket).")
+	createCmd.String(&cmd.os, "o", "os", "OS to use (al23, ubuntu2004, ubuntu2204, ubuntu2404, rhel8, rhel9, rhel10, bottlerocket).")
 	createCmd.String(&cmd.arch, "a", "arch", "Architecture to use (amd64, arm64).")
 	createCmd.String(&cmd.instanceSize, "s", "instance-size", "Instance size to use (Large, XLarge).")
 	createCmd.String(&cmd.instanceType, "t", "instance-type", "Instance type to use (t3.large, g4dn.xlarge, etc). If provided, instance size would be ignored.")
@@ -279,6 +279,14 @@ var oses = map[string]map[string]func() e2e.NodeadmOS{
 		},
 		"arm64": func() e2e.NodeadmOS {
 			return osystem.NewRedHat9ARM(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD"))
+		},
+	},
+	"rhel10": {
+		"amd64": func() e2e.NodeadmOS {
+			return osystem.NewRedHat10AMD(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD"))
+		},
+		"arm64": func() e2e.NodeadmOS {
+			return osystem.NewRedHat10ARM(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD"))
 		},
 	},
 	"bottlerocket": {

--- a/cmd/e2e-test/rune2e/command.go
+++ b/cmd/e2e-test/rune2e/command.go
@@ -27,7 +27,7 @@ const (
 	defaultNodeadmARMURL     = "https://hybrid-assets.eks.amazonaws.com/releases/latest/bin/linux/arm64/nodeadm"
 	defaultClusterNamePrefix = "nodeadm-e2e-tests"
 	defaultRegion            = "us-west-2"
-	defaultK8sVersion        = "1.31"
+	defaultK8sVersion        = "1.34"
 	defaultCNI               = "cilium"
 	defaultTimeout           = time.Minute * 60
 	defaultTestProcs         = 1

--- a/example/packer/http/rhel/10/ks.cfg
+++ b/example/packer/http/rhel/10/ks.cfg
@@ -1,0 +1,61 @@
+# version=RHEL10
+# Use CDROM installation media
+cdrom
+# Use text install
+text
+# Don't run the Setup Agent on first boot
+firstboot --disabled
+eula --agreed
+# Keyboard layout
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+# Network information
+network --bootproto=dhcp --onboot=on --ipv6=auto --activate --hostname=rhel10
+# Lock Root account
+rootpw --lock
+# Create builder user
+user --name=builder --groups=wheel --password=builder --plaintext --shell=/bin/bash
+# System services
+selinux --permissive
+firewall --disabled
+services --enabled=sshd
+# System timezone
+timezone UTC
+# System bootloader configuration
+bootloader --append="rhgb quiet crashkernel=auto"
+zerombr
+clearpart --all --initlabel
+autopart
+skipx
+%packages --ignoremissing --excludedocs
+# dnf group info minimal-environment
+@^minimal-environment
+@core
+openssh-server
+sed
+sudo
+python3
+open-vm-tools
+# Exclude unnecessary firmwares
+-iwl*firmware
+%end
+%addon com_redhat_kdump --disable
+%end
+reboot
+%post
+echo 'builder ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/builder
+chmod 440 /etc/sudoers.d/builder
+# Disable quiet boot and splash screen
+sed -i 's/ rhgb quiet//' /etc/default/grub
+sed -i 's/ rhgb quiet//' /boot/grub2/grubenv
+# Remove the package cache
+yum -y clean all
+# Disable swap
+swapoff -a
+rm -f /swapfile
+sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+# Ensure on next boot that network devices get assigned unique IDs.
+# Note: RHEL 10 may use NetworkManager instead of network-scripts
+sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-* 2>/dev/null || true
+%end

--- a/example/packer/hybrid-nodes-template.pkr.hcl
+++ b/example/packer/hybrid-nodes-template.pkr.hcl
@@ -103,11 +103,11 @@ variable "format" {
 variable "rhel_version" {
   type        = string
   default     = env("RHEL_VERSION")
-  description = "Rhel version of the input iso and output Qcow2/Raw image. Must be 8 or 9"
+  description = "Rhel version of the input iso and output Qcow2/Raw image. Must be 8, 9, or 10"
 
   validation {
-    condition     = contains(["", "8", "9"], var.rhel_version)
-    error_message = "The 'RHEL_VERSION' environment variable must be set when using the QEMU builder. Set to 8 or 9."
+    condition     = contains(["", "8", "9", "10"], var.rhel_version)
+    error_message = "The 'RHEL_VERSION' environment variable must be set when using the QEMU builder. Set to 8, 9, or 10."
   }
 }
 
@@ -278,6 +278,24 @@ source "amazon-ebs" "rhel9" {
   source_ami_filter {
     filters = {
       name                = "RHEL-9.2.0_HVM-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["309956199498"]
+  }
+}
+
+source "amazon-ebs" "rhel10" {
+  ami_name      = "ami-packer-rhel10-${local.timestamp}"
+  instance_type = "m5.xlarge"
+  region        = "us-west-2"
+  ssh_username  = "ec2-user"
+  profile       = var.aws_profile
+
+  source_ami_filter {
+    filters = {
+      name                = "RHEL-10*_HVM-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }
@@ -505,6 +523,54 @@ source "vsphere-iso" "rhel9" {
 
 }
 
+source "vsphere-iso" "rhel10" {
+  vcenter_server      = var.vsphere_server != "" ? var.vsphere_server : " "
+  username            = var.vsphere_user != "" ? var.vsphere_user : " "
+  password            = var.vsphere_password != "" ? var.vsphere_password : " "
+  insecure_connection = true
+
+  datacenter = var.vsphere_datacenter
+  cluster    = var.vsphere_cluster != "" ? var.vsphere_cluster : " "
+  datastore  = var.vsphere_datastore
+  folder     = var.vsphere_folder
+
+  vm_name              = "iso-packer-rhel10-${local.timestamp}"
+  guest_os_type        = "rhel9_64Guest"  # Using rhel9 as fallback until rhel10_64Guest is available
+  CPUs                 = 4
+  RAM                  = 16384
+  disk_controller_type = ["pvscsi"]
+  storage {
+    disk_size             = 30000
+    disk_thin_provisioned = true
+  }
+
+  network_adapters {
+    network      = var.vsphere_network
+    network_card = "vmxnet3"
+  }
+
+  iso_url      = local.iso_url
+  iso_checksum = local.iso_checksum
+
+  boot_order = "disk,cdrom"
+
+  iso_paths = [
+      "[${var.vsphere_datastore}] packer_cache/rhel10_ks.iso",
+  ]
+
+  boot_command = [
+    "<enter><enter"
+  ]
+
+  communicator = "ssh"
+  ssh_username = "builder"
+  ssh_password = var.pkr_ssh_password # default is "builder" as used in http/rhel/10/ks.cfg, make sure to change in both places
+  ssh_timeout  = "30m"
+
+  convert_to_template = true
+
+}
+
 ######################
 # Ubuntu Raw/Qcow2 sources 
 ######################
@@ -673,8 +739,48 @@ source "qemu" "rhel9" {
   output_directory = "${local.qemu_output_directory}/rhel${local.rhel_os}"
 }
 
+source "qemu" "rhel10" {
+  vm_name          = "qemu-${local.qemu_format}-packer-rhel10-${local.timestamp}"
+  accelerator      = "kvm"
+  disk_size        = "20000"
+  net_device       = "virtio-net"
+  disk_interface   = "virtio"
+  shutdown_command = "echo 'builder' | sudo -S shutdown -P now"
+
+  headless            = true
+
+  format = var.format
+
+  iso_url      = local.iso_url
+  iso_checksum = local.iso_checksum
+
+  boot_wait = "5s"
+  boot_command = [
+    "<up><tab> text inst.ks=",
+    "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+    "/rhel/10/ks.cfg<enter><wait>",
+  ]
+
+  qemuargs = [
+    ["-cpu", "host,+nx"],
+    ["-m", "2048M"],
+    ["-smp", "2"],
+    ["-nographic"],
+    ["-serial", "stdio"],
+    ["-monitor", "none"]
+  ]
+
+  http_directory = "http"
+  communicator   = "ssh"
+  ssh_username   = "builder"
+  ssh_password   = var.pkr_ssh_password # default is "builder" as used in http/rhel/10/ks.cfg, make sure to change in both places
+  ssh_timeout    = "60m"
+
+  output_directory = "${local.qemu_output_directory}/rhel${local.rhel_os}"
+}
+
 ######################
-# Generalized build for Ubuntu 22.04/24.04 and Rhel 8/9 to install nodeadm
+# Generalized build for Ubuntu 22.04/24.04 and Rhel 8/9/10 to install nodeadm
 ######################
 build {
   name = "general-build"
@@ -683,14 +789,17 @@ build {
     "source.amazon-ebs.ubuntu24",
     "source.amazon-ebs.rhel8",
     "source.amazon-ebs.rhel9",
+    "source.amazon-ebs.rhel10",
     "source.vsphere-iso.ubuntu22",
     "source.vsphere-iso.ubuntu24",
     "source.vsphere-iso.rhel8",
     "source.vsphere-iso.rhel9",
+    "source.vsphere-iso.rhel10",
     "source.qemu.ubuntu22",
     "source.qemu.ubuntu24",
     "source.qemu.rhel8", 
-    "source.qemu.rhel9"
+    "source.qemu.rhel9",
+    "source.qemu.rhel10"
   ]
 
 
@@ -715,6 +824,6 @@ build {
       "rhel_version=${var.rhel_version}",
       "k8s_version=${var.k8s_version}"
     ]
-    only = ["amazon-ebs.rhel8", "amazon-ebs.rhel9","qemu.rhel8", "qemu.rhel9", "vsphere-iso.rhel8", "vsphere-iso.rhel9"]
+    only = ["amazon-ebs.rhel8", "amazon-ebs.rhel9", "amazon-ebs.rhel10", "qemu.rhel8", "qemu.rhel9", "qemu.rhel10", "vsphere-iso.rhel8", "vsphere-iso.rhel9", "vsphere-iso.rhel10"]
   }
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -46,9 +46,9 @@ The `run-e2e` subcommand provides a streamlined way to run E2E tests with config
 - `--cni`: CNI plugin to use (default: "cilium")
 - `--logs-bucket`: S3 bucket for uploading test logs
 - `--no-color`: Disable colored output
-- `-n, --name`: Cluster name (default: "nodeadm-e2e-tests-1-31")
+- `-n, --name`: Cluster name (default: "nodeadm-e2e-tests-1-34")
 - `-r, --region`: AWS region (default: "us-west-2")
-- `-k, --kubernetes-version`: Kubernetes version (default: "1.31")
+- `-k, --kubernetes-version`: Kubernetes version (default: "1.34")
 - `-p, --procs`: Number of processes to run (default: 1)
 - `--timeout`: Test timeout (default: "60m")
 - `--setup-config`: Path to YAML file containing cluster.TestResources configuration
@@ -86,7 +86,7 @@ You can run the tests manually using the CLI commands:
 This file defines the infrastructure to be created for testing:
 
 ```yaml
-clusterName: nodeadm-e2e-tests-1-31
+clusterName: nodeadm-e2e-tests-1-34
 clusterRegion: us-west-2
 clusterNetwork:
   vpcCidr: 10.0.0.0/16
@@ -97,7 +97,7 @@ hybridNetwork:
   publicSubnetCidr: 10.1.1.0/24
   privateSubnetCidr: 10.1.2.0/24
   podCidr: 10.2.0.0/16
-kubernetesVersion: "1.31"
+kubernetesVersion: "1.34"
 cni: cilium
 endpoint: ""
 ```
@@ -111,7 +111,7 @@ endpoint: ""
 This file configures the test execution parameters:
 
 ```yaml
-clusterName: nodeadm-e2e-tests-1-31
+clusterName: nodeadm-e2e-tests-1-34
 clusterRegion: us-west-2
 nodeadmUrlAMD: https://hybrid-assets.eks.amazonaws.com/releases/latest/bin/linux/amd64/nodeadm
 nodeadmUrlARM: https://hybrid-assets.eks.amazonaws.com/releases/latest/bin/linux/arm64/nodeadm
@@ -145,7 +145,7 @@ The sweeper command provides more flexible cleanup options:
 
 ```bash
 # Clean up a specific cluster
-./_bin/e2e-test sweeper --cluster-name nodeadm-e2e-tests-1-31
+./_bin/e2e-test sweeper --cluster-name nodeadm-e2e-tests-1-34
 
 # Clean up clusters with a specific prefix
 ./_bin/e2e-test sweeper --cluster-prefix nodeadm-e2e-tests- --age-threshold 12h

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -23,6 +23,9 @@ var rhel8CloudInit []byte
 //go:embed testdata/rhel/9/cloud-init.txt
 var rhel9CloudInit []byte
 
+//go:embed testdata/rhel/10/cloud-init.txt
+var rhel10CloudInit []byte
+
 type rhelCloudInitData struct {
 	e2e.UserDataInput
 	NodeadmUrl        string
@@ -186,6 +189,92 @@ func (r RedHat9) BuildUserData(_ context.Context, userDataInput e2e.UserDataInpu
 	}
 
 	return executeTemplate(rhel9CloudInit, data)
+}
+
+type RedHat10 struct {
+	rhelUsername     string
+	rhelPassword     string
+	amiArchitecture  string
+	architecture     architecture
+	containerdSource string
+}
+
+func NewRedHat10AMD(rhelUsername, rhelPassword string) *RedHat10 {
+	rh10 := new(RedHat10)
+	rh10.rhelUsername = rhelUsername
+	rh10.rhelPassword = rhelPassword
+	rh10.amiArchitecture = x8664Arch
+	rh10.architecture = amd64
+	return rh10
+}
+
+func NewRedHat10ARM(rhelUsername, rhelPassword string) *RedHat10 {
+	rh10 := new(RedHat10)
+	rh10.rhelUsername = rhelUsername
+	rh10.rhelPassword = rhelPassword
+	rh10.amiArchitecture = arm64Arch
+	rh10.architecture = arm64
+	return rh10
+}
+
+func NewRedHat10NoDockerSource(rhelUsername, rhelPassword string) *RedHat10 {
+	rh10 := new(RedHat10)
+	rh10.rhelUsername = rhelUsername
+	rh10.rhelPassword = rhelPassword
+	rh10.amiArchitecture = x8664Arch
+	rh10.architecture = amd64
+	rh10.containerdSource = "none"
+	return rh10
+}
+
+func (r RedHat10) Name() string {
+	name := "rhel10-" + r.architecture.String()
+	if r.containerdSource == "none" {
+		name += "-source-none"
+	}
+	return name
+}
+
+func (r RedHat10) InstanceType(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
+	return getInstanceTypeFromRegionAndArch(region, r.architecture, instanceSize, computeType)
+}
+
+func (r RedHat10) AMIName(ctx context.Context, awsConfig aws.Config, _ string, _ e2e.ComputeType) (string, error) {
+	// RHEL 10 AMIs from Red Hat account 309956199498
+	// aws ec2 describe-images --owners 309956199498 --query 'sort_by(Images, &CreationDate)[-1].[ImageId]' --filters "Name=name,Values=RHEL-10*" "Name=architecture,Values=x86_64" --region us-west-2
+	return findLatestImage(ctx, ec2.NewFromConfig(awsConfig), "RHEL-10*", r.amiArchitecture)
+}
+
+func (r RedHat10) BuildUserData(_ context.Context, userDataInput e2e.UserDataInput) ([]byte, error) {
+	nodeadmConfigYaml, err := generateNodeadmConfigYaml(userDataInput.NodeadmConfig)
+	if err != nil {
+		return nil, err
+	}
+	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
+
+	if err := populateBaseScripts(&userDataInput); err != nil {
+		return nil, err
+	}
+
+	data := rhelCloudInitData{
+		UserDataInput: userDataInput,
+		NodeadmUrl:    userDataInput.NodeadmUrls.AMD,
+		RhelUsername:  r.rhelUsername,
+		RhelPassword:  r.rhelPassword,
+		SSMAgentURL:   rhelSsmAgentAMD,
+	}
+
+	if r.architecture.arm() {
+		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
+		data.SSMAgentURL = rhelSsmAgentARM
+	}
+
+	data.ContainerdSource = "docker"
+	if r.containerdSource == "none" {
+		data.ContainerdSource = "none"
+	}
+
+	return executeTemplate(rhel10CloudInit, data)
 }
 
 // AMI represents an ec2 Image.

--- a/test/e2e/os/testdata/nvidia-driver-install.sh
+++ b/test/e2e/os/testdata/nvidia-driver-install.sh
@@ -105,8 +105,10 @@ case $OS_TYPE in
             RHEL_VERSION="8"
         elif [[ "$VERSION_ID" == "9"* ]]; then
             RHEL_VERSION="9"
+        elif [[ "$VERSION_ID" == "10"* ]]; then
+            RHEL_VERSION="10"
         else
-            echo "Unsupported RHEL version"
+            echo "Unsupported RHEL version: $VERSION_ID"
             exit 1
         fi
 

--- a/test/e2e/os/testdata/rhel/10/cloud-init.txt
+++ b/test/e2e/os/testdata/rhel/10/cloud-init.txt
@@ -1,0 +1,47 @@
+#cloud-config
+users:
+  - name: root
+    lock_passwd: false
+    ssh_authorized_keys:
+      - {{ .PublicKey }}
+{{- if .RootPasswordHash }}
+    hashed_passwd: {{ .RootPasswordHash }}
+{{- end }}
+rh_subscription:
+  username: {{ .RhelUsername }}
+  password: {{ .RhelPassword }}
+{{- if eq .ContainerdSource "none" }}
+yum_repos:
+  docker-ce-stable:
+    name: docker-ce-stable
+    baseurl: https://download.docker.com/linux/rhel/$releasever/$basearch/stable
+    gpgcheck: true
+    gpgkey: https://download.docker.com/linux/rhel/gpg
+{{- end }}
+package_update: true
+write_files:
+  - content: |
+{{ .NodeadmConfigYaml | indent 6 }}
+    path: nodeadm-config.yaml
+{{ range $file := .Files }}
+  - content: |
+{{ $file.Content | indent 6 }}
+    path: {{ $file.Path }}
+{{if $file.Permissions}}
+    permissions: '{{ $file.Permissions }}'
+{{- end }}
+{{- end }}
+
+runcmd:
+{{- if eq .ContainerdSource "none" }}
+  - /tmp/install-containerd.sh
+{{- end }}
+  - ln -sf /run/log/journal /var/log/journal
+  # NOTE: FSx for Lustre addon is NOT supported on RHEL 10
+  # The Lustre client packages for el/10 are not available from AWS
+  # FSx CSI driver will not function until AWS publishes el/10 packages
+  # Tracking: https://fsx-lustre-client-repo.s3.amazonaws.com/el/10/
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}" "--containerd-source {{ .ContainerdSource }}"
+  - /tmp/nvidia-driver-install.sh
+
+final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/suite/peered_vpc.go
+++ b/test/e2e/suite/peered_vpc.go
@@ -486,6 +486,9 @@ func OSProviderList(credentialProviders []e2e.NodeadmCredentialsProvider) []OSPr
 		osystem.NewRedHat9AMD(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
 		osystem.NewRedHat9ARM(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
 		osystem.NewRedHat9NoDockerSource(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
+		osystem.NewRedHat10AMD(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
+		osystem.NewRedHat10ARM(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
+		osystem.NewRedHat10NoDockerSource(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
 	}
 	osProviderList := []OSProvider{}
 	for _, nodeOS := range osList {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*  RHEL10 as a supported operating system for Amazon EKS Hybrid Nodes.

*Testing (if applicable):*
- ✅ RHEL 10 added to `OSProviderList()` in `peered_vpc.go`
- ✅ Will be tested in main E2E suite automatically
- ✅ Will be randomly selected for addon smoke tests
- ✅ Supports manual testing via CLI: `go run ./cmd/e2e-test node create --os rhel10 --arch 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

