### PR TITLE
update buildspecs for cases where github can't be used as source

### DIFF
--- a/buildspecs/dev-release-nodeadm.yml
+++ b/buildspecs/dev-release-nodeadm.yml
@@ -7,4 +7,7 @@ phases:
 
   post_build:
     commands:
-    - ./hack/validate-release-artifacts.sh $ARTIFACTS_BUCKET latest
+    - |
+      if [ "${SKIP_LATEST_UPLOAD:-false}" != "true" ]; then
+        ./hack/validate-release-artifacts.sh $ARTIFACTS_BUCKET latest
+      fi

--- a/buildspecs/test-nodeadm.yml
+++ b/buildspecs/test-nodeadm.yml
@@ -17,6 +17,21 @@ phases:
         fi
       - export BUILD_NUMBER=${CODEBUILD_BUILD_NUMBER:-1}
       - export VERSION="build-${BUILD_NUMBER}"
+      
+      - |
+        if [ "${USE_S3_TEST_BINARIES:-false}" = "true" ]; then
+          echo "Downloading test artifacts from S3 (China region workflow)..."
+          
+          # Download artifacts.zip created by upload-dev-release-artifacts.sh
+          aws s3 cp --no-progress s3://$ARTIFACTS_BUCKET/${S3_TEST_BINARIES_PATH:-test-release/latest}/artifacts.zip ./artifacts.zip
+          
+          # Extract to get _bin/ structure directly
+          unzip -q artifacts.zip
+          
+          echo "Test artifacts downloaded and extracted from S3"
+        else
+          echo "Using locally built test binaries from previous build phase (commercial region workflow)"
+        fi
 
   build:
     commands:

--- a/cmd/e2e-test/rune2e/command.go
+++ b/cmd/e2e-test/rune2e/command.go
@@ -61,6 +61,7 @@ func NewCommand() *command {
 		clusterName:       fmt.Sprintf("%s-%s", defaultClusterNamePrefix, strings.ReplaceAll(defaultK8sVersion, ".", "-")),
 		cni:               defaultCNI,
 		k8sVersion:        defaultK8sVersion,
+		region:            defaultRegion,
 		nodeadmAMDURL:     defaultNodeadmAMDURL,
 		nodeadmARMURL:     defaultNodeadmARMURL,
 		skipCleanup:       false,
@@ -103,8 +104,15 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	ctx := context.Background()
 	logger := e2e.NewLogger(e2e.LoggerConfig{NoColor: c.noColor})
 
+	// Load test resources first to get the correct region from config file
+	testResources, err := c.loadSetupConfig(logger)
+	if err != nil {
+		return fmt.Errorf("loading test resources configuration: %w", err)
+	}
+
+	// Use the region from test resources (which may come from config file)
 	awsCfg, err := e2e.NewAWSConfig(ctx,
-		config.WithRegion(c.region),
+		config.WithRegion(testResources.ClusterRegion),
 		// We use a custom AppId so the requests show that they were
 		// made by this command in the user-agent
 		config.WithAppID("nodeadm-e2e-test-run-cmd"),
@@ -123,11 +131,6 @@ func (c *command) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 	if c.region == "" {
 		c.region = awsCfg.Region
-	}
-
-	testResources, err := c.loadSetupConfig(logger)
-	if err != nil {
-		return fmt.Errorf("loading test resources configuration: %w", err)
 	}
 
 	testConfig, err := c.loadTestConfig(&testResources, logger)
@@ -215,6 +218,8 @@ func (c *command) loadSetupConfig(logger logr.Logger) (cluster.TestResources, er
 			c.region != defaultRegion ||
 			c.k8sVersion != defaultK8sVersion ||
 			c.cni != defaultCNI {
+			logger.Info("setup config", "clusterName", c.clusterName, "region", c.region, "k8sVersion", c.k8sVersion, "CNI", c.cni)
+			logger.Info("defaults", "clusterName", defaultClusterName, "region", defaultRegion, "k8sVersion", defaultK8sVersion, "CNI", defaultCNI)
 			return testResources, fmt.Errorf("cannot specify both setup-config file and individual cluster resource flags (name, region, kubernetes-version, cni, eks-endpoint)")
 		}
 

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -27,8 +27,8 @@ KUBERNETES_VERSION="${3?Please specify the Kubernetes version}"
 CNI="${4?Please specify the cni}"
 NODEADM_AMD_URL="${5?Please specify the nodeadm amd url}"
 NODEADM_ARM_URL="${6?Please specify the nodeadm arm url}"
-LOGS_BUCKET="${7-?Please specify the bucket for logs}"
-ARTIFACTS_FOLDER="${8-?Please specify the folder for artifacts}"
+LOGS_BUCKET="${7:?Please specify the bucket for logs}"
+ARTIFACTS_FOLDER="${8:?Please specify the folder for artifacts}"
 
 PARALLEL_TEST_PROCESSES=64
 

--- a/hack/upload-dev-release-artifacts.sh
+++ b/hack/upload-dev-release-artifacts.sh
@@ -5,12 +5,34 @@ set -o pipefail
 
 ARTIFACTS_BUCKET="$1"
 
-# only uploading nodeadm, ATTRIBUTION.txt, and GIT_VERSION, skipping ginkgo/e2e-test/nodeadm.test
-mkdir -p _bin/latest/bin/linux/{amd64,arm64}
-cp _bin/{ATTRIBUTION.txt,GIT_VERSION} _bin/latest/
-cp _bin/amd64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/bin/linux/amd64/
-cp _bin/arm64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/bin/linux/arm64/
+if [ "${SKIP_LATEST_UPLOAD:-false}" != "true" ]; then
+  mkdir -p _bin/latest/bin/linux/{amd64,arm64}
+  cp _bin/{ATTRIBUTION.txt,GIT_VERSION} _bin/latest/
+  cp _bin/amd64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/bin/linux/amd64/
+  cp _bin/arm64/nodeadm{,.gz,.sha256,.sha512,.gz.sha256,.gz.sha512} _bin/latest/bin/linux/arm64/
 
-# uploading nodeadm.gz files separately to ensure the content-encoding/disposition is applied
-aws s3 sync --no-progress --exclude "*nodeadm.gz" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/
-aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip --content-disposition "attachment; filename=\"nodeadm\"" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/
+  # uploading nodeadm.gz files separately to ensure the content-encoding/disposition is applied
+  aws s3 sync --no-progress --exclude "*nodeadm.gz" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/
+  aws s3 sync --no-progress --include "*nodeadm.gz" --content-encoding gzip --content-disposition "attachment; filename=\"nodeadm\"" _bin/latest/ s3://${ARTIFACTS_BUCKET}/latest/
+fi
+
+# create artifacts zip for CodePipeline S3 source 
+ARTIFACT_KEY="${ARTIFACT_KEY:-artifacts.zip}"
+echo "Creating ${ARTIFACT_KEY} for CodePipeline S3 source..."
+mkdir -p _bin/artifacts/_bin/{amd64,arm64}
+
+# copy ALL binaries (nodeadm + test binaries) - same structure as build output
+cp _bin/amd64/* _bin/artifacts/_bin/amd64/
+cp _bin/arm64/* _bin/artifacts/_bin/arm64/
+
+# copy buildspecs and scripts needed to run tests
+mkdir -p _bin/artifacts/buildspecs _bin/artifacts/hack _bin/artifacts/test/e2e/cni/testdata
+cp -r buildspecs/* _bin/artifacts/buildspecs/
+cp -r hack/* _bin/artifacts/hack/
+cp -r test/e2e/cni/testdata/* _bin/artifacts/test/e2e/cni/testdata/
+
+# zip and upload to bucket root
+(cd _bin/artifacts && zip -r ../${ARTIFACT_KEY} .)
+aws s3 cp --no-progress _bin/${ARTIFACT_KEY} s3://${ARTIFACTS_BUCKET}/${ARTIFACT_KEY}
+rm -rf _bin/artifacts _bin/${ARTIFACT_KEY}
+echo "${ARTIFACT_KEY} uploaded successfully to s3://${ARTIFACTS_BUCKET}/${ARTIFACT_KEY}"

--- a/internal/aws/manifest.go
+++ b/internal/aws/manifest.go
@@ -14,6 +14,27 @@ import (
 // set build time
 var manifestUrl string
 
+// getManifestURL returns the appropriate manifest URL based on the region/partition
+// If the region is in aws-cn partition, it uses a China-specific URL
+// Otherwise, it defaults to the embedded manifestUrl
+func getManifestURL(region string) string {
+	if region == "" {
+		// No region provided, use default embedded URL
+		return manifestUrl
+	}
+
+	// Detect partition from region
+	partition := GetPartitionFromRegionFallback(region)
+
+	// For aws-cn partition, use China-specific manifest host
+	if partition == "aws-cn" {
+		return "https://eks-hybrid-assets.awsstatic.cn/manifest.yaml"
+	}
+
+	// For all other partitions, use the embedded default URL
+	return manifestUrl
+}
+
 type Manifest struct {
 	SupportedEksReleases     []SupportedEksRelease     `json:"supported_eks_releases"`
 	IamRolesAnywhereReleases []IamRolesAnywhereRelease `json:"iam_roles_anywhere_releases"`
@@ -65,8 +86,10 @@ type Artifact struct {
 }
 
 // Read from the manifest file on s3 and parse into Manifest struct
-func getReleaseManifest(ctx context.Context) (*Manifest, error) {
-	yamlFileData, err := util.GetHttpFile(ctx, manifestUrl)
+// region is used to determine the appropriate manifest URL for different partitions (e.g., aws-cn)
+func getReleaseManifest(ctx context.Context, region string) (*Manifest, error) {
+	manifestURL := getManifestURL(region)
+	yamlFileData, err := util.GetHttpFile(ctx, manifestURL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/aws/manifest_url_test.go
+++ b/internal/aws/manifest_url_test.go
@@ -1,0 +1,101 @@
+package aws
+
+import (
+	"testing"
+)
+
+func TestGetManifestURL(t *testing.T) {
+	// Set a default embedded manifest URL for testing
+	originalManifestUrl := manifestUrl
+	manifestUrl = "https://hybrid-assets.eks.amazonaws.com/manifest.yaml"
+	defer func() { manifestUrl = originalManifestUrl }()
+
+	tests := []struct {
+		name     string
+		region   string
+		expected string
+	}{
+		{
+			name:     "Empty region uses default embedded URL",
+			region:   "",
+			expected: "https://hybrid-assets.eks.amazonaws.com/manifest.yaml",
+		},
+		{
+			name:     "Standard AWS region uses default embedded URL",
+			region:   "us-east-1",
+			expected: "https://hybrid-assets.eks.amazonaws.com/manifest.yaml",
+		},
+		{
+			name:     "Another standard AWS region uses default embedded URL",
+			region:   "eu-west-1",
+			expected: "https://hybrid-assets.eks.amazonaws.com/manifest.yaml",
+		},
+		{
+			name:     "AWS China region uses China-specific URL",
+			region:   "cn-north-1",
+			expected: "https://eks-hybrid-assets.awsstatic.cn/manifest.yaml",
+		},
+		{
+			name:     "AWS China northwest region uses China-specific URL",
+			region:   "cn-northwest-1",
+			expected: "https://eks-hybrid-assets.awsstatic.cn/manifest.yaml",
+		},
+		{
+			name:     "AWS GovCloud region uses default embedded URL",
+			region:   "us-gov-west-1",
+			expected: "https://hybrid-assets.eks.amazonaws.com/manifest.yaml",
+		},
+		{
+			name:     "AWS ISO region uses default embedded URL",
+			region:   "us-iso-east-1",
+			expected: "https://hybrid-assets.eks.amazonaws.com/manifest.yaml",
+		},
+		{
+			name:     "AWS ISOB region uses default embedded URL",
+			region:   "us-isob-east-1",
+			expected: "https://hybrid-assets.eks.amazonaws.com/manifest.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getManifestURL(tt.region)
+			if result != tt.expected {
+				t.Errorf("getManifestURL(%q) = %q, want %q", tt.region, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetManifestURLWithDifferentEmbeddedDefault(t *testing.T) {
+	// Test that the function respects the embedded manifest URL
+	originalManifestUrl := manifestUrl
+	manifestUrl = "https://custom-host.example.com/manifest.yaml"
+	defer func() { manifestUrl = originalManifestUrl }()
+
+	tests := []struct {
+		name     string
+		region   string
+		expected string
+	}{
+		{
+			name:     "Standard region uses custom embedded URL",
+			region:   "us-west-2",
+			expected: "https://custom-host.example.com/manifest.yaml",
+		},
+		{
+			name:     "China region constructs URL based on partition",
+			region:   "cn-north-1",
+			expected: "https://eks-hybrid-assets.awsstatic.cn/manifest.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getManifestURL(tt.region)
+			if result != tt.expected {
+				t.Errorf("getManifestURL(%q) = %q, want %q", tt.region, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/aws/source.go
+++ b/internal/aws/source.go
@@ -25,7 +25,7 @@ type Source struct {
 // GetLatestSource gets the source for latest version of aws provided artifacts from the
 // hybrid nodes CDN manifest https://hybrid-assets.eks.amazonaws.com/manifest.yaml
 func GetLatestSource(ctx context.Context, eksVersion, region string) (Source, error) {
-	manifest, err := getReleaseManifest(ctx)
+	manifest, err := getReleaseManifest(ctx, region)
 	if err != nil {
 		return Source{}, err
 	}
@@ -161,7 +161,7 @@ func getLatestDateEksPatchRelease(patchReleases []EksPatchRelease) (EksPatchRele
 }
 
 func GetRegionConfig(ctx context.Context, region string) (*RegionData, error) {
-	manifest, err := getReleaseManifest(ctx)
+	manifest, err := getReleaseManifest(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/os/bottlerocket.go
+++ b/test/e2e/os/bottlerocket.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/blang/semver/v4"
@@ -49,6 +50,7 @@ type brSettingsTomlInitData struct {
 	ClusterCertificate      string
 	HybridContainerUserData string
 	IamRA                   bool
+	BottlerocketRegistry    string
 }
 
 type BottleRocket struct {
@@ -123,32 +125,44 @@ credential_process = %s credential-process --certificate %s --private-key %s --p
 		bootstrapContainerCommand = fmt.Sprintf("%s --activation-id=%q --activation-code=%q --region=%q", ssmSetupBootstrapCommand, userDataInput.NodeadmConfig.Spec.Hybrid.SSM.ActivationID, userDataInput.NodeadmConfig.Spec.Hybrid.SSM.ActivationCode, userDataInput.Region)
 	}
 
-	// This is essentially the same AWS config used in the tests, but for the us-east-1 region.
-	// We need to do this since ECR Public is only supported in us-east-1.
-	awsConfig, err := e2e.NewAWSConfig(ctx, config.WithRegion("us-east-1"),
-		config.WithAppID("bottlerocket-e2e-test"),
-		config.WithRetryer(func() aws.Retryer {
-			return retry.AddWithMaxBackoffDelay(
-				retry.AddWithMaxAttempts(
-					retry.NewStandard(),
-					10, // Max 10 attempts
-				),
-				10*time.Second, // Max backoff delay
-			)
-		}),
-	)
-	if err != nil {
-		return nil, err
-	}
+	var adminContainerLatestTag, bootstrapContainerLatestTag, controlContainerLatestTag string
+	var bottlerocketRegistry string
 
-	authToken, err := getAuthToken(ctx, ecrpublic.NewFromConfig(awsConfig))
-	if err != nil {
-		return nil, err
-	}
+	if strings.HasPrefix(userDataInput.Region, "cn-") {
+		// Use China private ECR mirrors
+		var err error
+		adminContainerLatestTag, bootstrapContainerLatestTag, controlContainerLatestTag, bottlerocketRegistry, err = getLatestImageTagsFromChinaECR(ctx, userDataInput.Region)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		bottlerocketRegistry = "public.ecr.aws/bottlerocket"
+		// Use ECR Public for commercial regions
+		awsConfig, err := e2e.NewAWSConfig(ctx, config.WithRegion("us-east-1"),
+			config.WithAppID("bottlerocket-e2e-test"),
+			config.WithRetryer(func() aws.Retryer {
+				return retry.AddWithMaxBackoffDelay(
+					retry.AddWithMaxAttempts(
+						retry.NewStandard(),
+						10, // Max 10 attempts
+					),
+					10*time.Second, // Max backoff delay
+				)
+			}),
+		)
+		if err != nil {
+			return nil, err
+		}
 
-	adminContainerLatestTag, bootstrapContainerLatestTag, controlContainerLatestTag, err := getLatestImageTags(authToken)
-	if err != nil {
-		return nil, err
+		authToken, err := getAuthToken(ctx, ecrpublic.NewFromConfig(awsConfig))
+		if err != nil {
+			return nil, err
+		}
+
+		adminContainerLatestTag, bootstrapContainerLatestTag, controlContainerLatestTag, err = getLatestImageTags(authToken)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	data := brSettingsTomlInitData{
@@ -161,6 +175,7 @@ credential_process = %s credential-process --certificate %s --private-key %s --p
 		ClusterCertificate:      base64.StdEncoding.EncodeToString(userDataInput.ClusterCert),
 		IamRA:                   userDataInput.NodeadmConfig.Spec.Hybrid.SSM == nil,
 		HybridContainerUserData: base64.StdEncoding.EncodeToString([]byte(bootstrapContainerCommand)),
+		BottlerocketRegistry:    bottlerocketRegistry,
 	}
 
 	return executeTemplate(brSettingsToml, data)
@@ -241,4 +256,107 @@ func getLatestImageTags(authToken string) (string, string, string, error) {
 	}
 
 	return latestTags[0], latestTags[1], latestTags[2], nil
+}
+
+// getLatestImageTagsFromChinaECR gets Bottlerocket container tags and registry from China ECR mirrors
+// Returns: adminTag, bootstrapTag, controlTag, registry, error
+func getLatestImageTagsFromChinaECR(ctx context.Context, region string) (string, string, string, string, error) {
+	// China ECR registry account mapping
+	chinaECRAccounts := map[string]string{
+		"cn-north-1":     "183470599484",
+		"cn-northwest-1": "183901325759",
+	}
+
+	account, ok := chinaECRAccounts[region]
+	if !ok {
+		return "", "", "", "", fmt.Errorf("no China ECR account found for region %s", region)
+	}
+
+	// Construct registry URL
+	registry := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com.cn", account, region)
+
+	// Create ECR client for the China region
+	awsConfig, err := e2e.NewAWSConfig(ctx, config.WithRegion(region),
+		config.WithAppID("bottlerocket-e2e-test-china"),
+		config.WithRetryer(func() aws.Retryer {
+			return retry.AddWithMaxBackoffDelay(
+				retry.AddWithMaxAttempts(
+					retry.NewStandard(),
+					10, // Max 10 attempts
+				),
+				10*time.Second, // Max backoff delay
+			)
+		}),
+	)
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	ecrClient := ecr.NewFromConfig(awsConfig)
+
+	bottlerocketRepos := []string{
+		"bottlerocket-admin",
+		"bottlerocket-bootstrap",
+		"bottlerocket-control",
+	}
+	latestTags := []string{}
+
+	for _, repo := range bottlerocketRepos {
+		// Describe images in the China ECR repository
+		repoName := fmt.Sprintf("%s/%s", account, repo)
+
+		result, err := ecrClient.DescribeImages(ctx, &ecr.DescribeImagesInput{
+			RegistryId:     aws.String(account),
+			RepositoryName: aws.String(repo),
+		})
+		if err != nil {
+			// If describe fails, fall back to "latest" tag
+			latestTags = append(latestTags, "latest")
+			continue
+		}
+
+		if len(result.ImageDetails) == 0 {
+			latestTags = append(latestTags, "latest")
+			continue
+		}
+
+		// Find the latest semantic version tag
+		latest := "latest"
+		var latestSemver semver.Version
+		hasValidSemver := false
+
+		for _, image := range result.ImageDetails {
+			if image.ImageTags == nil || len(image.ImageTags) == 0 {
+				continue
+			}
+
+			for _, tag := range image.ImageTags {
+				if tag == "latest" {
+					latest = "latest"
+					break
+				}
+
+				// Try to parse as semver
+				tagSemver, err := semver.Parse(strings.TrimPrefix(tag, "v"))
+				if err != nil {
+					continue
+				}
+
+				if !hasValidSemver || tagSemver.GT(latestSemver) {
+					latest = tag
+					latestSemver = tagSemver
+					hasValidSemver = true
+				}
+			}
+		}
+
+		latestTags = append(latestTags, latest)
+		_ = repoName // For debugging if needed
+	}
+
+	if len(latestTags) != 3 {
+		return "", "", "", "", fmt.Errorf("failed to get tags for all Bottlerocket containers")
+	}
+
+	return latestTags[0], latestTags[1], latestTags[2], registry, nil
 }

--- a/test/e2e/os/bottlerocket.go
+++ b/test/e2e/os/bottlerocket.go
@@ -326,7 +326,7 @@ func getLatestImageTagsFromChinaECR(ctx context.Context, region string) (string,
 		hasValidSemver := false
 
 		for _, image := range result.ImageDetails {
-			if image.ImageTags == nil || len(image.ImageTags) == 0 {
+			if len(image.ImageTags) == 0 {
 				continue
 			}
 

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -15,7 +15,10 @@ import (
 	"github.com/aws/eks-hybrid/test/e2e"
 )
 
-const rhelAWSAccount = "309956199498"
+const (
+	rhelAWSAccount      = "309956199498" // Commercial regions
+	rhelChinaAWSAccount = "841258680906" // China regions
+)
 
 //go:embed testdata/rhel/8/cloud-init.txt
 var rhel8CloudInit []byte
@@ -74,7 +77,11 @@ func (r RedHat8) InstanceType(region string, instanceSize e2e.InstanceSize, comp
 func (r RedHat8) AMIName(ctx context.Context, awsConfig aws.Config, _ string, _ e2e.ComputeType) (string, error) {
 	// there is no rhel ssm parameter
 	// aws ec2 describe-images --owners 309956199498 --query 'sort_by(Images, &CreationDate)[-1].[ImageId]' --filters "Name=name,Values=RHEL-8*" "Name=architecture,Values=x86_64" --region us-west-2
-	return findLatestImage(ctx, ec2.NewFromConfig(awsConfig), "RHEL-8*", r.amiArchitecture)
+	account := rhelAWSAccount
+	if strings.HasPrefix(awsConfig.Region, "cn-") {
+		account = rhelChinaAWSAccount
+	}
+	return findLatestImageWithAccount(ctx, ec2.NewFromConfig(awsConfig), "RHEL-8*", r.amiArchitecture, account)
 }
 
 func (r RedHat8) BuildUserData(_ context.Context, userDataInput e2e.UserDataInput) ([]byte, error) {
@@ -153,7 +160,11 @@ func (r RedHat9) InstanceType(region string, instanceSize e2e.InstanceSize, comp
 func (r RedHat9) AMIName(ctx context.Context, awsConfig aws.Config, _ string, _ e2e.ComputeType) (string, error) {
 	// there is no rhel ssm parameter
 	// aws ec2 describe-images --owners 309956199498 --query 'sort_by(Images, &CreationDate)[-1].[ImageId]' --filters "Name=name,Values=RHEL-9*" "Name=architecture,Values=x86_64" --region us-west-2
-	return findLatestImage(ctx, ec2.NewFromConfig(awsConfig), "RHEL-9*", r.amiArchitecture)
+	account := rhelAWSAccount
+	if strings.HasPrefix(awsConfig.Region, "cn-") {
+		account = rhelChinaAWSAccount
+	}
+	return findLatestImageWithAccount(ctx, ec2.NewFromConfig(awsConfig), "RHEL-9*", r.amiArchitecture, account)
 }
 
 func (r RedHat9) BuildUserData(_ context.Context, userDataInput e2e.UserDataInput) ([]byte, error) {
@@ -199,10 +210,15 @@ type AMI struct {
 // this assumes that the return ami names follow the pattern `{amiPrefix}.<minor>.<patch?>_`
 // ex: amiPrefix: RHEL-8*, amiName: RHEL-8.8.0_HVM-20250116-x86_64-2339-Hourly2-GP3 or RHEL-8.8_HVM-20250116-x86_64-2339-Hourly2-GP3
 func findLatestImage(ctx context.Context, client *ec2.Client, amiPrefix, arch string) (string, error) {
+	return findLatestImageWithAccount(ctx, client, amiPrefix, arch, rhelAWSAccount)
+}
+
+// findLatestImageWithAccount returns the most recent redhat image matching the amiPrefix, arch, and owner account
+func findLatestImageWithAccount(ctx context.Context, client *ec2.Client, amiPrefix, arch, ownerAccount string) (string, error) {
 	var latestAMI AMI
 
 	in := &ec2.DescribeImagesInput{
-		Owners:     []string{rhelAWSAccount},
+		Owners:     []string{ownerAccount},
 		Filters:    []types.Filter{{Name: aws.String("name"), Values: []string{amiPrefix}}, {Name: aws.String("architecture"), Values: []string{arch}}},
 		MaxResults: aws.Int32(100),
 	}

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -206,13 +206,6 @@ type AMI struct {
 	Version   string
 }
 
-// findLatestImage returns the most recent redhat image matching the amiPrefix and and arch
-// this assumes that the return ami names follow the pattern `{amiPrefix}.<minor>.<patch?>_`
-// ex: amiPrefix: RHEL-8*, amiName: RHEL-8.8.0_HVM-20250116-x86_64-2339-Hourly2-GP3 or RHEL-8.8_HVM-20250116-x86_64-2339-Hourly2-GP3
-func findLatestImage(ctx context.Context, client *ec2.Client, amiPrefix, arch string) (string, error) {
-	return findLatestImageWithAccount(ctx, client, amiPrefix, arch, rhelAWSAccount)
-}
-
 // findLatestImageWithAccount returns the most recent redhat image matching the amiPrefix, arch, and owner account
 func findLatestImageWithAccount(ctx context.Context, client *ec2.Client, amiPrefix, arch, ownerAccount string) (string, error) {
 	var latestAMI AMI

--- a/test/e2e/os/testdata/bottlerocket/settings.toml
+++ b/test/e2e/os/testdata/bottlerocket/settings.toml
@@ -28,16 +28,16 @@ config = "{{ .AWSConfig }}"
 
 [settings.bootstrap-containers.eks-hybrid-setup]
 mode = "always"
-source = "public.ecr.aws/bottlerocket/bottlerocket-bootstrap:{{ .BootstrapContainerTag }}"
+source = "{{ .BottlerocketRegistry }}/bottlerocket-bootstrap:{{ .BootstrapContainerTag }}"
 user-data = "{{ .HybridContainerUserData }}"
 
 [settings.host-containers.admin]
 enabled = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-admin:{{ .AdminContainerTag }}"
+source = "{{ .BottlerocketRegistry }}/bottlerocket-admin:{{ .AdminContainerTag }}"
 user-data = "{{ .AdminContainerUserData }}"
 
 {{- if not .IamRA }}
 [settings.host-containers.control]
 enabled = true
-source = "public.ecr.aws/bottlerocket/bottlerocket-control:{{ .ControlContainerTag }}"
+source = "{{ .BottlerocketRegistry }}/bottlerocket-control:{{ .ControlContainerTag }}"
 {{- end }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In some regions, github cannot be used as a source for CodeBuild. Instead, we can upload the necessary files to the s3 bucket where github can be used and replicate the artifacts to regions where github cannot be used. 

This PR sets up uploading the test binaries and buildspecs to s3 while also modifying the test buildspec to download from s3 rather than using what's locally available. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

