### PR TITLE
Add smoke test for Network Flow Monitor agent Addon

### DIFF
--- a/test/e2e/addon/networkflowmonitor.go
+++ b/test/e2e/addon/networkflowmonitor.go
@@ -1,0 +1,155 @@
+package addon
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+)
+
+const (
+	networkFlowMonitorNamespace      = "amazon-network-flow-monitor"
+	networkFlowMonitorAddonName      = "aws-network-flow-monitoring-agent"
+	networkFlowMonitorDaemonSet      = "aws-network-flow-monitor-agent"
+	networkFlowMonitorServiceAccount = "aws-network-flow-monitor-agent-service-account"
+	networkFlowMonitorLabelSelector  = "app.kubernetes.io/name=" + networkFlowMonitorDaemonSet
+	networkFlowMonitorWaitTimeout    = 3 * time.Minute
+
+	trafficGenPodName = "nfm-traffic-gen"
+)
+
+type NetworkFlowMonitorTest struct {
+	AddonTestConfig
+	PodIdentityRoleArn string
+	addon              *Addon
+}
+
+func (n *NetworkFlowMonitorTest) Create(ctx context.Context) error {
+	n.addon = &Addon{
+		Cluster:   n.Cluster,
+		Namespace: networkFlowMonitorNamespace,
+		Name:      networkFlowMonitorAddonName,
+		PodIdentityAssociations: []PodIdentityAssociation{
+			{
+				RoleArn:        n.PodIdentityRoleArn,
+				ServiceAccount: networkFlowMonitorServiceAccount,
+			},
+		},
+	}
+
+	if err := n.addon.CreateAndWaitForActive(ctx, n.EKSClient, n.K8S, n.Logger); err != nil {
+		return err
+	}
+
+	if err := kubernetes.DaemonSetWaitForReady(ctx, n.Logger, n.K8S, networkFlowMonitorNamespace, networkFlowMonitorDaemonSet); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (n *NetworkFlowMonitorTest) Validate(ctx context.Context) error {
+	hybridNodes, err := kubernetes.ListNodesWithLabels(ctx, n.K8S, kubernetes.HybridNodeLabelSelector)
+	if err != nil {
+		return err
+	}
+	if len(hybridNodes.Items) == 0 {
+		return fmt.Errorf("no hybrid nodes found in cluster")
+	}
+
+	if err := n.generateTraffic(ctx, hybridNodes.Items[0].Name); err != nil {
+		return err
+	}
+
+	pods, err := kubernetes.ListPodsWithLabels(ctx, n.K8S, networkFlowMonitorNamespace, networkFlowMonitorLabelSelector)
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no network flow monitor agent pods found")
+	}
+
+	if err := n.validateAgentLogs(ctx, pods); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (n *NetworkFlowMonitorTest) generateTraffic(ctx context.Context, targetNode string) error {
+	n.Logger.Info("Deploying nginx pod to generate network flows for the agent to capture", "node", targetNode)
+
+	if err := kubernetes.CreateNginxPodInNode(ctx, n.K8S, targetNode, networkFlowMonitorNamespace, n.Region, n.Logger, n.DNSSuffix, n.EcrAccount, trafficGenPodName); err != nil {
+		return fmt.Errorf("creating traffic generator pod: %v", err)
+	}
+
+	n.Logger.Info("Traffic generator pod running, nginx serving requests will create network flows")
+	return nil
+}
+
+func (n *NetworkFlowMonitorTest) validateAgentLogs(ctx context.Context, pods *v1.PodList) error {
+	n.Logger.Info("Checking agent logs for report publishing")
+
+	for _, pod := range pods.Items {
+		n.Logger.Info("Validating agent logs", "pod", pod.Name, "node", pod.Spec.NodeName)
+
+		err := wait.PollUntilContextTimeout(ctx, 10*time.Second, networkFlowMonitorWaitTimeout, true, func(ctx context.Context) (bool, error) {
+			logStr, err := kubernetes.GetPodLogsWithRetries(ctx, n.K8S, pod.Name, networkFlowMonitorNamespace)
+			if err != nil {
+				n.Logger.Info("Failed to get logs, retrying", "pod", pod.Name, "error", err)
+				return false, nil
+			}
+
+			if strings.Contains(logStr, "Error getting credentials") {
+				return false, fmt.Errorf("agent on pod %s has credential errors", pod.Name)
+			}
+			if strings.Contains(logStr, "Error sending request") {
+				return false, fmt.Errorf("agent on pod %s failed to send report to endpoint", pod.Name)
+			}
+
+			// Agent logs "Publishing report" before each attempt and "status":200 after a successful publish
+			if strings.Contains(logStr, "Publishing report") && strings.Contains(logStr, `"status":200`) {
+				n.Logger.Info("Agent is publishing reports to endpoint",
+					"pod", pod.Name,
+					"node", pod.Spec.NodeName,
+				)
+				return true, nil
+			}
+
+			n.Logger.Info("Waiting for agent to publish reports", "pod", pod.Name)
+			return false, nil
+		})
+		if err != nil {
+			return fmt.Errorf("agent on pod %s did not publish reports within timeout: %v", pod.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func (n *NetworkFlowMonitorTest) PrintLogs(ctx context.Context) error {
+	pods, err := kubernetes.ListPodsWithLabels(ctx, n.K8S, networkFlowMonitorNamespace, networkFlowMonitorLabelSelector)
+	if err != nil {
+		return fmt.Errorf("failed to list pods for %s: %v", n.addon.Name, err)
+	}
+
+	for _, pod := range pods.Items {
+		logs, err := kubernetes.GetPodLogsWithRetries(ctx, n.K8S, pod.Name, pod.Namespace)
+		if err != nil {
+			return fmt.Errorf("failed to get logs for pod %s: %v", pod.Name, err)
+		}
+		n.Logger.Info("Logs for network flow monitor agent", "pod", pod.Name, "logs", logs)
+	}
+
+	return nil
+}
+
+func (n *NetworkFlowMonitorTest) Delete(ctx context.Context) error {
+	_ = kubernetes.DeletePod(ctx, n.K8S, trafficGenPodName, networkFlowMonitorNamespace)
+	return n.addon.Delete(ctx, n.EKSClient, n.Logger)
+}

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -646,6 +646,7 @@ Resources:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AWSPrivateCAConnectorForKubernetesPolicy'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonFSxFullAccess'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchNetworkFlowMonitorAgentPublishPolicy'
       Policies:
         - PolicyName: pod-identity-association-role-policy
           PolicyDocument:

--- a/test/e2e/kubernetes/node.go
+++ b/test/e2e/kubernetes/node.go
@@ -24,6 +24,8 @@ const (
 	hybridNodeWaitTimeout    = 10 * time.Minute
 	hybridNodeUpgradeTimeout = 2 * time.Minute
 	nodeCordonTimeout        = 30 * time.Second
+
+	HybridNodeLabelSelector = "eks.amazonaws.com/compute-type=hybrid"
 )
 
 // WaitForNode wait for the node to join the cluster and fetches the node info which has the nodeName label
@@ -334,7 +336,7 @@ func PatchNode(ctx context.Context, k8s kubernetes.Interface, nodeName string, p
 // LabelHybridNodesForTopology adds topology.kubernetes.io/zone=onprem label to hybrid nodes
 func LabelHybridNodesForTopology(ctx context.Context, k8s kubernetes.Interface, logger logr.Logger) error {
 	// Find all hybrid nodes
-	nodes, err := ListNodesWithLabels(ctx, k8s, "eks.amazonaws.com/compute-type=hybrid")
+	nodes, err := ListNodesWithLabels(ctx, k8s, HybridNodeLabelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to list hybrid nodes: %w", err)
 	}

--- a/test/e2e/suite/addon_ec2.go
+++ b/test/e2e/suite/addon_ec2.go
@@ -50,6 +50,23 @@ func (a *AddonEc2Test) NewNodeMonitoringAgentTest() *addon.NodeMonitoringAgentTe
 	}
 }
 
+// NewNetworkFlowMonitorTest creates a new NetworkFlowMonitorTest
+func (a *AddonEc2Test) NewNetworkFlowMonitorTest(ctx context.Context) (*addon.NetworkFlowMonitorTest, error) {
+	podIdentityRoleArn, err := addon.PodIdentityRole(ctx, a.IAMClient, a.Cluster.Name)
+	if err != nil {
+		a.Logger.Error(err, "Failed to get pod identity role ARN")
+		return nil, err
+	}
+
+	config := a.addonTestConfig()
+	config.Logger = config.Logger.WithName("NetworkFlowMonitorTest")
+
+	return &addon.NetworkFlowMonitorTest{
+		AddonTestConfig:    config,
+		PodIdentityRoleArn: podIdentityRoleArn,
+	}, nil
+}
+
 // NewVerifyPodIdentityAddon creates a new VerifyPodIdentityAddon
 func (a *AddonEc2Test) NewVerifyPodIdentityAddon(nodeName string) *addon.VerifyPodIdentityAddon {
 	return &addon.VerifyPodIdentityAddon{

--- a/test/e2e/suite/addons/addons_test.go
+++ b/test/e2e/suite/addons/addons_test.go
@@ -457,6 +457,36 @@ var _ = Describe("Hybrid Nodes", func() {
 					)
 				})
 			}, Label("fsx-csi-driver"))
+
+			// Network Flow Monitor addon test - commented out until hybrid support is enabled
+			// Context("runs network flow monitor tests", func() {
+			// 	It("uses all OS", func(ctx context.Context) {
+			// 		networkFlowMonitor, err := addonEc2Test.NewNetworkFlowMonitorTest(ctx)
+			// 		Expect(err).To(Succeed(), "should have created network flow monitor test")
+			//
+			// 		DeferCleanup(func(ctx context.Context) {
+			// 			Expect(networkFlowMonitor.Delete(ctx)).To(Succeed(), "should cleanup network flow monitor successfully")
+			// 		})
+			//
+			// 		Expect(networkFlowMonitor.Create(ctx)).To(
+			// 			Succeed(), "network flow monitor should have created successfully",
+			// 		)
+			//
+			// 		DeferCleanup(func(ctx context.Context) {
+			// 			report := CurrentSpecReport()
+			// 			if report.State.Is(types.SpecStateFailed) {
+			// 				err := networkFlowMonitor.PrintLogs(ctx)
+			// 				if err != nil {
+			// 					GinkgoWriter.Printf("Failed to get network flow monitor logs: %v\n", err)
+			// 				}
+			// 			}
+			// 		})
+			//
+			// 		Expect(networkFlowMonitor.Validate(ctx)).To(
+			// 			Succeed(), "network flow monitor should have been validated successfully",
+			// 		)
+			// 	})
+			// }, Label("network-flow-monitor"))
 		})
 	})
 })


### PR DESCRIPTION


*Description of changes:*
This pr adds an e2e smoke test for the Network Flow Monitor agent addon on hybrid nodes. The test validates that the network flow monitor agent installs, runs, obtains credentials via Pod Identity, and successfully publishes flow reports.

The addon is not yet in the compatible with hybrid . The test will be uncommented once the addon team enables hybrid node support and releases a new addon version.


