### PR TITLE
Remove Kubernetes version 1.29 from CDK

### DIFF
--- a/hybrid-nodes-cdk/lib/constants.ts
+++ b/hybrid-nodes-cdk/lib/constants.ts
@@ -1,5 +1,5 @@
 export const builderBaseImage = 'public.ecr.aws/eks-distro-build-tooling/builder-base:standard-latest.al2';
-export const kubernetesVersions = ['1.29', '1.30', '1.31', '1.32', '1.33', '1.34', '1.35'];
+export const kubernetesVersions = ['1.30', '1.31', '1.32', '1.33', '1.34', '1.35'];
 export const betaKubeVersions: Array<string> = [];
 export const cnis = ['calico', 'cilium'];
 export const eksHybridBetaBucketARN = 'arn:aws:s3:::eks-hybrid-beta';

--- a/test/e2e/kubernetes/version.go
+++ b/test/e2e/kubernetes/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	MinimumVersion = "1.29"
+	MinimumVersion = "1.30"
 )
 
 func PreviousVersion(kubernetesVersion string) (string, error) {

--- a/test/integration/test-constants.sh
+++ b/test/integration/test-constants.sh
@@ -4,7 +4,7 @@
 # This file centralizes version definitions used across integration tests
 
 # Supported Kubernetes versions for install/uninstall tests
-declare SUPPORTED_VERSIONS=(1.29 1.30 1.31 1.32 1.33 1.34 1.35)
+declare SUPPORTED_VERSIONS=(1.30 1.31 1.32 1.33 1.34 1.35)
 
 # Default versions for upgrade tests and single-version tests
 declare DEFAULT_INITIAL_VERSION=1.34


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove Kubernetes version 1.29 from CDK

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

