### PR TITLE
e2e: add China partition support for serial console and Bottlerocket ECR auth

### DIFF
--- a/internal/aws/partition.go
+++ b/internal/aws/partition.go
@@ -81,6 +81,18 @@ func GetServiceEndpointForPartition(service, region, partition string) string {
 	return fmt.Sprintf("%s.%s.%s", service, region, dnsSuffix)
 }
 
+// GetSerialConsoleEndpoint returns the EC2 Instance Connect serial console SSH endpoint for a given region and partition.
+// The endpoint format differs between commercial and China partitions.
+func GetSerialConsoleEndpoint(region, partition string) string {
+	switch partition {
+	case "aws-cn":
+		// China uses a different endpoint format
+		return fmt.Sprintf("ec2-serial-console.%s.api.amazonwebservices.com.cn:22", region)
+	default:
+		return fmt.Sprintf("serial-console.ec2-instance-connect.%s.aws:22", region)
+	}
+}
+
 // GetEC2ServicePrincipal returns the correct EC2 service principal for a partition.
 // AWS China (aws-cn) uses ec2.amazonaws.com.cn
 // All other partitions use ec2.amazonaws.com

--- a/test/e2e/os/bottlerocket.go
+++ b/test/e2e/os/bottlerocket.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/blang/semver/v4"
@@ -125,20 +124,24 @@ credential_process = %s credential-process --certificate %s --private-key %s --p
 		bootstrapContainerCommand = fmt.Sprintf("%s --activation-id=%q --activation-code=%q --region=%q", ssmSetupBootstrapCommand, userDataInput.NodeadmConfig.Spec.Hybrid.SSM.ActivationID, userDataInput.NodeadmConfig.Spec.Hybrid.SSM.ActivationCode, userDataInput.Region)
 	}
 
-	var adminContainerLatestTag, bootstrapContainerLatestTag, controlContainerLatestTag string
-	var bottlerocketRegistry string
+	bottlerocketRegistry := "public.ecr.aws/bottlerocket"
 
+	// ECR Public GetAuthorizationToken is only available in us-east-1 via the AWS SDK and is not
+	// available in China partitions. For China regions we fetch an anonymous bearer token from the
+	// public ECR token endpoint directly (no AWS credentials required). For all other regions we
+	// use the SDK call which returns a more privileged token.
+	var authToken string
 	if strings.HasPrefix(userDataInput.Region, "cn-") {
-		// Use China private ECR mirrors
-		var err error
-		adminContainerLatestTag, bootstrapContainerLatestTag, controlContainerLatestTag, bottlerocketRegistry, err = getLatestImageTagsFromChinaECR(ctx, userDataInput.Region)
-		if err != nil {
-			return nil, err
+		// ECR Public GetAuthorizationToken SDK call is only available in us-east-1 and cannot be
+		// called from China partitions. Fetch an anonymous bearer token from the public ECR token
+		// endpoint directly — no AWS credentials required, works from any network.
+		var tokenErr error
+		authToken, tokenErr = getAnonymousECRPublicToken(ctx)
+		if tokenErr != nil {
+			return nil, fmt.Errorf("getting anonymous ECR public token for China region: %w", tokenErr)
 		}
 	} else {
-		bottlerocketRegistry = "public.ecr.aws/bottlerocket"
-		// Use ECR Public for commercial regions
-		awsConfig, err := e2e.NewAWSConfig(ctx, config.WithRegion("us-east-1"),
+		awsCfg, cfgErr := e2e.NewAWSConfig(ctx, config.WithRegion("us-east-1"),
 			config.WithAppID("bottlerocket-e2e-test"),
 			config.WithRetryer(func() aws.Retryer {
 				return retry.AddWithMaxBackoffDelay(
@@ -150,19 +153,19 @@ credential_process = %s credential-process --certificate %s --private-key %s --p
 				)
 			}),
 		)
-		if err != nil {
-			return nil, err
+		if cfgErr != nil {
+			return nil, cfgErr
 		}
+		var tokenErr error
+		authToken, tokenErr = getAuthToken(ctx, ecrpublic.NewFromConfig(awsCfg))
+		if tokenErr != nil {
+			return nil, tokenErr
+		}
+	}
 
-		authToken, err := getAuthToken(ctx, ecrpublic.NewFromConfig(awsConfig))
-		if err != nil {
-			return nil, err
-		}
-
-		adminContainerLatestTag, bootstrapContainerLatestTag, controlContainerLatestTag, err = getLatestImageTags(authToken)
-		if err != nil {
-			return nil, err
-		}
+	adminContainerLatestTag, bootstrapContainerLatestTag, controlContainerLatestTag, err := getLatestImageTags(authToken)
+	if err != nil {
+		return nil, err
 	}
 
 	data := brSettingsTomlInitData{
@@ -258,105 +261,40 @@ func getLatestImageTags(authToken string) (string, string, string, error) {
 	return latestTags[0], latestTags[1], latestTags[2], nil
 }
 
-// getLatestImageTagsFromChinaECR gets Bottlerocket container tags and registry from China ECR mirrors
-// Returns: adminTag, bootstrapTag, controlTag, registry, error
-func getLatestImageTagsFromChinaECR(ctx context.Context, region string) (string, string, string, string, error) {
-	// China ECR registry account mapping
-	chinaECRAccounts := map[string]string{
-		"cn-north-1":     "183470599484",
-		"cn-northwest-1": "183901325759",
-	}
-
-	account, ok := chinaECRAccounts[region]
-	if !ok {
-		return "", "", "", "", fmt.Errorf("no China ECR account found for region %s", region)
-	}
-
-	// Construct registry URL
-	registry := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com.cn", account, region)
-
-	// Create ECR client for the China region
-	awsConfig, err := e2e.NewAWSConfig(ctx, config.WithRegion(region),
-		config.WithAppID("bottlerocket-e2e-test-china"),
-		config.WithRetryer(func() aws.Retryer {
-			return retry.AddWithMaxBackoffDelay(
-				retry.AddWithMaxAttempts(
-					retry.NewStandard(),
-					10, // Max 10 attempts
-				),
-				10*time.Second, // Max backoff delay
-			)
-		}),
-	)
+// getAnonymousECRPublicToken fetches an anonymous bearer token from the public ECR token endpoint.
+// This endpoint is publicly accessible without AWS credentials and works from regions where
+// the ecrpublic.GetAuthorizationToken SDK API is not available.
+func getAnonymousECRPublicToken(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://public.ecr.aws/token", nil)
 	if err != nil {
-		return "", "", "", "", err
+		return "", fmt.Errorf("creating request for ECR public token: %w", err)
 	}
 
-	ecrClient := ecr.NewFromConfig(awsConfig)
-
-	bottlerocketRepos := []string{
-		"bottlerocket-admin",
-		"bottlerocket-bootstrap",
-		"bottlerocket-control",
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching ECR public token: %w", err)
 	}
-	latestTags := []string{}
+	defer resp.Body.Close()
 
-	for _, repo := range bottlerocketRepos {
-		// Describe images in the China ECR repository
-		repoName := fmt.Sprintf("%s/%s", account, repo)
-
-		result, err := ecrClient.DescribeImages(ctx, &ecr.DescribeImagesInput{
-			RegistryId:     aws.String(account),
-			RepositoryName: aws.String(repo),
-		})
-		if err != nil {
-			// If describe fails, fall back to "latest" tag
-			latestTags = append(latestTags, "latest")
-			continue
-		}
-
-		if len(result.ImageDetails) == 0 {
-			latestTags = append(latestTags, "latest")
-			continue
-		}
-
-		// Find the latest semantic version tag
-		latest := "latest"
-		var latestSemver semver.Version
-		hasValidSemver := false
-
-		for _, image := range result.ImageDetails {
-			if len(image.ImageTags) == 0 {
-				continue
-			}
-
-			for _, tag := range image.ImageTags {
-				if tag == "latest" {
-					latest = "latest"
-					break
-				}
-
-				// Try to parse as semver
-				tagSemver, err := semver.Parse(strings.TrimPrefix(tag, "v"))
-				if err != nil {
-					continue
-				}
-
-				if !hasValidSemver || tagSemver.GT(latestSemver) {
-					latest = tag
-					latestSemver = tagSemver
-					hasValidSemver = true
-				}
-			}
-		}
-
-		latestTags = append(latestTags, latest)
-		_ = repoName // For debugging if needed
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code from ECR public token endpoint: %d", resp.StatusCode)
 	}
 
-	if len(latestTags) != 3 {
-		return "", "", "", "", fmt.Errorf("failed to get tags for all Bottlerocket containers")
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading ECR public token response: %w", err)
 	}
 
-	return latestTags[0], latestTags[1], latestTags[2], registry, nil
+	var tokenResp struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("parsing ECR public token response: %w", err)
+	}
+
+	if tokenResp.Token == "" {
+		return "", fmt.Errorf("ECR public token endpoint returned empty token")
+	}
+
+	return tokenResp.Token, nil
 }

--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -19,6 +20,7 @@ import (
 	clientgo "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	internalaws "github.com/aws/eks-hybrid/internal/aws"
 	"github.com/aws/eks-hybrid/test/e2e"
 	"github.com/aws/eks-hybrid/test/e2e/cleanup"
 	"github.com/aws/eks-hybrid/test/e2e/commands"
@@ -63,10 +65,11 @@ type NodeCreate struct {
 	Logger              logr.Logger
 	RemoteCommandRunner commands.RemoteCommandRunner
 
-	SetRootPassword bool
-	NodeadmURLs     e2e.NodeadmURLs
-	PublicKey       string
-	ManifestURL     string
+	SetRootPassword    bool
+	NodeadmURLs        e2e.NodeadmURLs
+	PublicKey          string
+	ManifestURL        string
+	InstanceProfileARN string
 }
 
 // PeeredInstance represents a Hybrid node running as an EC2 instance in a peered VPC
@@ -144,6 +147,15 @@ func (c NodeCreate) Create(ctx context.Context, spec *NodeSpec) (PeeredInstance,
 		instanceType = spec.OS.InstanceType(c.Cluster.Region, spec.InstanceSize, spec.ComputeType)
 	}
 
+	// Use the spec-level instance profile if explicitly provided.
+	// Otherwise, for Bottlerocket in China regions, attach the node-level instance profile
+	// since host-ctr attempts to authenticate to the private ECR via IMDS.
+	// (Commercial Bottlerocket uses public.ecr.aws which needs no auth; other OSes don't use host-ctr.)
+	instanceProfileARN := spec.InstanceProfileARN
+	if instanceProfileARN == "" && os.IsBottlerocket(spec.OS.Name()) && strings.HasPrefix(c.Cluster.Region, "cn-") {
+		instanceProfileARN = c.InstanceProfileARN
+	}
+
 	ec2Input := ec2.InstanceConfig{
 		ClusterName:        c.Cluster.Name,
 		InstanceName:       spec.InstanceName,
@@ -153,7 +165,7 @@ func (c NodeCreate) Create(ctx context.Context, spec *NodeSpec) (PeeredInstance,
 		SubnetID:           c.Cluster.SubnetID,
 		SecurityGroupID:    c.Cluster.SecurityGroupID,
 		UserData:           userdata,
-		InstanceProfileARN: spec.InstanceProfileARN,
+		InstanceProfileARN: instanceProfileARN,
 		OS:                 spec.OS.Name(),
 	}
 
@@ -206,7 +218,10 @@ func (c *NodeCreate) SerialConsole(ctx context.Context, instanceId string) (*ssh
 		return nil, fmt.Errorf("adding ssh key via instance connect: %w", err)
 	}
 
-	return ssh.NewSerialConsole("tcp", "serial-console.ec2-instance-connect."+c.AWS.Region+".aws:22", config), nil
+	partition := internalaws.GetPartitionFromRegionFallback(c.AWS.Region)
+	endpoint := internalaws.GetSerialConsoleEndpoint(c.AWS.Region, partition)
+
+	return ssh.NewSerialConsole("tcp", endpoint, config), nil
 }
 
 func generateKeyPair() ([]byte, []byte, error) {


### PR DESCRIPTION
## Summary
Adds China partition support to e2e test infrastructure.

## Changes
- Add `GetSerialConsoleEndpoint()` to `internal/aws/partition.go` to return the correct EC2 serial console endpoint format for each partition (standard: `ec2-serial-console.{region}.aws` vs China: `ec2-serial-console.{region}.amazonaws.com.cn`)
- Refactor Bottlerocket ECR auth in `test/e2e/os/bottlerocket.go` to use anonymous ECR Public token for China regions instead of querying private China ECR mirrors — removes the need for AWS credentials to pull Bottlerocket images
- Update `test/e2e/peered/node.go` to add `InstanceProfileARN` field to `NodeCreate` struct and use partition-aware serial console endpoint

## Testing
- `make lint` passes with 0 issues