### PR TITLE
e2e: add addon availability checking and ADOT addon support

### DIFF
--- a/test/e2e/addon/addon.go
+++ b/test/e2e/addon/addon.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -11,8 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgo "k8s.io/client-go/kubernetes"
 
-	"github.com/aws/eks-hybrid/test/e2e/errors"
+	e2eerrors "github.com/aws/eks-hybrid/test/e2e/errors"
 )
+
+// ErrAddonNotAvailable is returned when an addon is not available in the current region/partition.
+var ErrAddonNotAvailable = errors.New("addon not available in this region")
 
 type Addon struct {
 	Name                    string
@@ -33,6 +37,22 @@ const (
 	addonPollTimeout  = 5 * time.Minute
 	defaultNamespace  = "default"
 )
+
+// IsAvailable returns true if the addon has at least one version available via DescribeAddonVersions.
+// This is used to skip tests in regions/partitions where the addon is not offered.
+func (a Addon) IsAvailable(ctx context.Context, client *eks.Client) (bool, error) {
+	out, err := client.DescribeAddonVersions(ctx, &eks.DescribeAddonVersionsInput{
+		AddonName: &a.Name,
+	})
+	if err != nil {
+		// ResourceNotFoundException means the addon name is unknown in this partition.
+		if e2eerrors.IsType(err, &types.ResourceNotFoundException{}) {
+			return false, nil
+		}
+		return false, fmt.Errorf("describing addon versions for %s: %w", a.Name, err)
+	}
+	return len(out.Addons) > 0, nil
+}
 
 func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logger) error {
 	logger.Info("Create cluster add-on", "ClusterAddon", a.Name)
@@ -63,7 +83,7 @@ func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logge
 
 	_, err := client.CreateAddon(ctx, params)
 
-	if err == nil || errors.IsType(err, &types.ResourceInUseException{}) {
+	if err == nil || e2eerrors.IsType(err, &types.ResourceInUseException{}) {
 		// Ignore if add-on is already created
 		return nil
 	}
@@ -115,6 +135,15 @@ func (a Addon) WaitUntilActive(ctx context.Context, client *eks.Client, logger l
 }
 
 func (a Addon) CreateAndWaitForActive(ctx context.Context, eksClient *eks.Client, k8s clientgo.Interface, logger logr.Logger) error {
+	available, err := a.IsAvailable(ctx, eksClient)
+	if err != nil {
+		return err
+	}
+	if !available {
+		logger.Info("Addon not available in this region, skipping", "addon", a.Name)
+		return fmt.Errorf("%w: %s", ErrAddonNotAvailable, a.Name)
+	}
+
 	if err := a.Create(ctx, eksClient, logger); err != nil {
 		return err
 	}
@@ -137,14 +166,14 @@ func (a Addon) Delete(ctx context.Context, client *eks.Client, logger logr.Logge
 	_, err := client.DeleteAddon(ctx, params)
 
 	// Add-on is deleted already
-	if errors.IsType(err, &types.ResourceNotFoundException{}) {
+	if e2eerrors.IsType(err, &types.ResourceNotFoundException{}) {
 		return nil
 	}
 
 	// Otherwise let's poll until it's deleted
 	err = wait.PollUntilContextTimeout(ctx, addonPollInterval, addonPollTimeout, true, func(ctx context.Context) (bool, error) {
 		_, err := a.describe(ctx, client)
-		if errors.IsType(err, &types.ResourceNotFoundException{}) {
+		if e2eerrors.IsType(err, &types.ResourceNotFoundException{}) {
 			return true, nil
 		}
 

--- a/test/e2e/addon/addon.go
+++ b/test/e2e/addon/addon.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -11,8 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgo "k8s.io/client-go/kubernetes"
 
-	"github.com/aws/eks-hybrid/test/e2e/errors"
+	e2eerrors "github.com/aws/eks-hybrid/test/e2e/errors"
 )
+
+// ErrAddonNotAvailable is returned when an addon is not available in the current region/partition.
+var ErrAddonNotAvailable = errors.New("addon not available in this region")
 
 type Addon struct {
 	Name                    string
@@ -33,6 +37,27 @@ const (
 	addonPollTimeout  = 5 * time.Minute
 	defaultNamespace  = "default"
 )
+
+// IsAvailable returns true if the addon has at least one version available via DescribeAddonVersions.
+// This is used to skip tests in regions/partitions where the addon is not offered.
+func (a Addon) IsAvailable(ctx context.Context, client *eks.Client) (bool, error) {
+	out, err := client.DescribeAddonVersions(ctx, &eks.DescribeAddonVersionsInput{
+		AddonName: &a.Name,
+	})
+	if err != nil {
+		// ResourceNotFoundException means the addon name is unknown in this partition.
+		if e2eerrors.IsType(err, &types.ResourceNotFoundException{}) {
+			return false, nil
+		}
+		return false, fmt.Errorf("describing addon versions for %s: %w", a.Name, err)
+	}
+	for _, a := range out.Addons {
+		if len(a.AddonVersions) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logger) error {
 	logger.Info("Create cluster add-on", "ClusterAddon", a.Name)
@@ -63,7 +88,7 @@ func (a Addon) Create(ctx context.Context, client *eks.Client, logger logr.Logge
 
 	_, err := client.CreateAddon(ctx, params)
 
-	if err == nil || errors.IsType(err, &types.ResourceInUseException{}) {
+	if err == nil || e2eerrors.IsType(err, &types.ResourceInUseException{}) {
 		// Ignore if add-on is already created
 		return nil
 	}
@@ -115,6 +140,15 @@ func (a Addon) WaitUntilActive(ctx context.Context, client *eks.Client, logger l
 }
 
 func (a Addon) CreateAndWaitForActive(ctx context.Context, eksClient *eks.Client, k8s clientgo.Interface, logger logr.Logger) error {
+	available, err := a.IsAvailable(ctx, eksClient)
+	if err != nil {
+		return err
+	}
+	if !available {
+		logger.Info("Addon not available in this region, skipping", "addon", a.Name)
+		return nil
+	}
+
 	if err := a.Create(ctx, eksClient, logger); err != nil {
 		return err
 	}
@@ -137,14 +171,14 @@ func (a Addon) Delete(ctx context.Context, client *eks.Client, logger logr.Logge
 	_, err := client.DeleteAddon(ctx, params)
 
 	// Add-on is deleted already
-	if errors.IsType(err, &types.ResourceNotFoundException{}) {
+	if e2eerrors.IsType(err, &types.ResourceNotFoundException{}) {
 		return nil
 	}
 
 	// Otherwise let's poll until it's deleted
 	err = wait.PollUntilContextTimeout(ctx, addonPollInterval, addonPollTimeout, true, func(ctx context.Context) (bool, error) {
 		_, err := a.describe(ctx, client)
-		if errors.IsType(err, &types.ResourceNotFoundException{}) {
+		if e2eerrors.IsType(err, &types.ResourceNotFoundException{}) {
 			return true, nil
 		}
 

--- a/test/e2e/addon/adot.go
+++ b/test/e2e/addon/adot.go
@@ -1,0 +1,237 @@
+package addon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgo "k8s.io/client-go/kubernetes"
+
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+)
+
+const (
+	adotAddonName = "adot"
+	adotNamespace = "opentelemetry-operator-system"
+
+	adotOperatorDeployment = "opentelemetry-operator"
+
+	// adotCollectorDaemonSet is the DaemonSet created by the addon when the
+	// containerLogs pipeline is enabled via configuration values.
+	// The OpenTelemetry operator appends "-collector" to the collector name.
+	adotCollectorDaemonSet = "adot-col-container-logs-collector"
+
+	// adotCollectorServiceAcct is the service account used by the container logs
+	// collector pods. This must match the PodIdentityAssociation service account.
+	adotCollectorServiceAcct = "adot-col-container-logs"
+
+	adotWaitTimeout          = 5 * time.Minute
+	adotLogGroupPollInterval = 15 * time.Second
+	adotLogGroupPollTimeout  = 5 * time.Minute
+)
+
+// ADOTTest tests the AWS Distro for OpenTelemetry (ADOT) addon.
+// ADOT requires cert-manager to be installed first.
+// Validation uses the Container Logs pipeline to ship pod logs to CloudWatch Logs,
+// then verifies that log entries appear in the expected log group.
+//
+// The ADOT EKS addon creates the collector DaemonSet automatically when the
+// containerLogs pipeline is enabled in the addon's configuration values.
+// Pod Identity is used to grant the collector service account CloudWatch Logs permissions.
+type ADOTTest struct {
+	Cluster            string
+	K8S                clientgo.Interface
+	EKSClient          *eks.Client
+	CloudWatchClient   *cloudwatchlogs.Client
+	PodIdentityRoleArn string
+	Logger             logr.Logger
+	addon              *Addon
+	available          bool
+}
+
+// logGroupName returns the CloudWatch log group that the container logs collector writes to.
+func (a *ADOTTest) logGroupName() string {
+	return fmt.Sprintf("%s/container/logs", a.Cluster)
+}
+
+// adotConfiguration returns the JSON addon configuration values that enable the
+// containerLogs pipeline and configure the CloudWatch exporter.
+func (a *ADOTTest) adotConfiguration() (string, error) {
+	cfg := map[string]interface{}{
+		"collector": map[string]interface{}{
+			"containerLogs": map[string]interface{}{
+				"pipelines": map[string]interface{}{
+					"logs": map[string]interface{}{
+						"cloudwatchLogs": map[string]interface{}{
+							"enabled": true,
+						},
+					},
+				},
+				"exporters": map[string]interface{}{
+					"awscloudwatchlogs": map[string]interface{}{
+						"log_group_name": a.logGroupName(),
+					},
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("marshaling ADOT configuration: %w", err)
+	}
+	return string(b), nil
+}
+
+// Setup installs the ADOT EKS addon with the containerLogs pipeline enabled and waits
+// for both the operator deployment and the collector DaemonSet to be ready.
+// The addon creates the DaemonSet automatically from the configuration values.
+// Pod Identity grants the collector service account CloudWatch Logs write permissions.
+// If the addon is not available in the current region/partition, Setup returns nil
+// and marks the test as unavailable so Validate becomes a no-op.
+func (a *ADOTTest) Setup(ctx context.Context) error {
+	a.Logger.Info("Setting up ADOT test")
+
+	cfg, err := a.adotConfiguration()
+	if err != nil {
+		return err
+	}
+
+	a.addon = &Addon{
+		Cluster:       a.Cluster,
+		Namespace:     adotNamespace,
+		Name:          adotAddonName,
+		Configuration: cfg,
+		PodIdentityAssociations: []PodIdentityAssociation{
+			{
+				RoleArn:        a.PodIdentityRoleArn,
+				ServiceAccount: adotCollectorServiceAcct,
+			},
+		},
+	}
+
+	if err := a.addon.CreateAndWaitForActive(ctx, a.EKSClient, a.K8S, a.Logger); err != nil {
+		if errors.Is(err, ErrAddonNotAvailable) {
+			a.Logger.Info("ADOT addon is not available in this region, skipping ADOT validation")
+			a.available = false
+			return nil
+		}
+		return fmt.Errorf("failed to create ADOT addon: %w", err)
+	}
+
+	// Wait for the OpenTelemetry operator deployment to be ready.
+	if err := kubernetes.DeploymentWaitForReplicas(ctx, adotWaitTimeout, a.K8S, adotNamespace, adotOperatorDeployment); err != nil {
+		return fmt.Errorf("waiting for ADOT operator deployment to be ready: %w", err)
+	}
+
+	// Wait for the container logs collector DaemonSet, which the addon creates
+	// automatically when containerLogs is enabled in the configuration values.
+	if err := kubernetes.DaemonSetWaitForReady(ctx, a.Logger, a.K8S, adotNamespace, adotCollectorDaemonSet); err != nil {
+		return fmt.Errorf("waiting for ADOT container logs DaemonSet to be ready: %w", err)
+	}
+
+	a.available = true
+	a.Logger.Info("ADOT setup complete")
+	return nil
+}
+
+// Validate checks that the ADOT container logs collector is shipping logs to CloudWatch.
+// It polls until the expected log group exists and contains at least one log stream.
+// If the addon was unavailable, this is a no-op.
+func (a *ADOTTest) Validate(ctx context.Context) error {
+	if !a.available {
+		a.Logger.Info("ADOT not available in this region, skipping ADOT validation")
+		return nil
+	}
+
+	a.Logger.Info("Validating ADOT container logs", "logGroup", a.logGroupName())
+
+	err := wait.PollUntilContextTimeout(ctx, adotLogGroupPollInterval, adotLogGroupPollTimeout, true, func(ctx context.Context) (bool, error) {
+		resp, err := a.CloudWatchClient.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+			LogGroupNamePrefix: aws.String(a.logGroupName()),
+		})
+		if err != nil {
+			a.Logger.Error(err, "Error describing CloudWatch log groups, will retry")
+			return false, nil
+		}
+
+		for _, lg := range resp.LogGroups {
+			if aws.ToString(lg.LogGroupName) == a.logGroupName() {
+				streams, err := a.CloudWatchClient.DescribeLogStreams(ctx, &cloudwatchlogs.DescribeLogStreamsInput{
+					LogGroupName: aws.String(a.logGroupName()),
+				})
+				if err != nil {
+					a.Logger.Error(err, "Error describing log streams, will retry")
+					return false, nil
+				}
+				if len(streams.LogStreams) > 0 {
+					a.Logger.Info("ADOT container logs validation successful",
+						"logGroup", a.logGroupName(),
+						"streamCount", len(streams.LogStreams))
+					return true, nil
+				}
+				a.Logger.Info("Log group exists but no streams yet, waiting", "logGroup", a.logGroupName())
+				return false, nil
+			}
+		}
+
+		a.Logger.Info("Waiting for CloudWatch log group to be created", "logGroup", a.logGroupName())
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("ADOT container logs did not appear in CloudWatch log group %q within %v: %w",
+			a.logGroupName(), adotLogGroupPollTimeout, err)
+	}
+
+	return nil
+}
+
+// PrintLogs collects logs from the ADOT operator for debugging.
+func (a *ADOTTest) PrintLogs(ctx context.Context) error {
+	if !a.available {
+		return nil
+	}
+
+	logs, err := kubernetes.FetchLogs(ctx, a.K8S, adotOperatorDeployment, adotNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to collect ADOT operator logs: %w", err)
+	}
+
+	a.Logger.Info("Logs for ADOT operator", "logs", logs)
+	return nil
+}
+
+// Cleanup removes the ADOT addon and the CloudWatch log group created during the test.
+func (a *ADOTTest) Cleanup(ctx context.Context) error {
+	if a.addon == nil {
+		return nil
+	}
+
+	a.Logger.Info("Cleaning up ADOT resources")
+	if err := a.addon.Delete(ctx, a.EKSClient, a.Logger); err != nil {
+		a.Logger.Error(err, "Failed to delete ADOT addon")
+	}
+
+	a.Logger.Info("Deleting CloudWatch log group", "logGroup", a.logGroupName())
+	_, err := a.CloudWatchClient.DeleteLogGroup(ctx, &cloudwatchlogs.DeleteLogGroupInput{
+		LogGroupName: aws.String(a.logGroupName()),
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "ResourceNotFoundException") {
+			a.Logger.Info("CloudWatch log group does not exist, nothing to delete", "logGroup", a.logGroupName())
+		} else {
+			a.Logger.Error(err, "Failed to delete CloudWatch log group", "logGroup", a.logGroupName())
+		}
+	} else {
+		a.Logger.Info("Successfully deleted CloudWatch log group", "logGroup", a.logGroupName())
+	}
+
+	return nil
+}

--- a/test/e2e/addon/certmanager.go
+++ b/test/e2e/addon/certmanager.go
@@ -36,15 +36,24 @@ type CertManagerTest struct {
 	Logger                                              logr.Logger
 	CertClient                                          certmanagerclientset.Interface
 	PCAIssuer                                           *PCAIssuerTest
+	ADOT                                                *ADOTTest
 	CertName, CertNamespace, CertSecretName, IssuerName string
 }
 
+func (c *CertManagerTest) AddonName() string { return certManagerName }
+
 // Create installs the cert-manager addon
 func (c *CertManagerTest) Create(ctx context.Context) error {
+	// Override the default affinity for all three cert-manager components (controller,
+	// webhook, cainjector) to remove the NodeAffinity term that excludes hybrid nodes
+	// (eks.amazonaws.com/compute-type != hybrid). The schema requires a non-null object
+	// so we provide the OS/arch requirements without the hybrid exclusion.
+	const certManagerAffinity = `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["amd64","arm64"]}]}]}}}`
 	c.addon = &Addon{
-		Cluster:   c.Cluster,
-		Namespace: certManagerNamespace,
-		Name:      certManagerName,
+		Cluster:       c.Cluster,
+		Namespace:     certManagerNamespace,
+		Name:          certManagerName,
+		Configuration: `{"affinity":` + certManagerAffinity + `,"webhook":{"affinity":` + certManagerAffinity + `},"cainjector":{"affinity":` + certManagerAffinity + `}}`,
 	}
 
 	if err := c.addon.CreateAndWaitForActive(ctx, c.EKSClient, c.K8S, c.Logger); err != nil {
@@ -68,6 +77,10 @@ func (c *CertManagerTest) Create(ctx context.Context) error {
 
 	if err := c.PCAIssuer.Setup(ctx); err != nil {
 		return fmt.Errorf("failed to setup AWS PCA Issuer: %v", err)
+	}
+
+	if err := c.ADOT.Setup(ctx); err != nil {
+		return fmt.Errorf("failed to setup ADOT: %w", err)
 	}
 
 	c.Logger.Info("Cert-manager setup is complete")
@@ -98,14 +111,19 @@ func (c *CertManagerTest) Validate(ctx context.Context) error {
 		return fmt.Errorf("failed to validate certificate: %w", err)
 	}
 
-	// AWS PCA Issuer validation if it's configured
+	// AWS PCA Issuer validation
 	c.Logger.Info("Starting AWS PCA Issuer validation")
-
 	if err := c.PCAIssuer.Validate(ctx); err != nil {
 		return fmt.Errorf("AWS PCA Issuer validation failed: %w", err)
 	}
-
 	c.Logger.Info("AWS PCA Issuer validation completed successfully")
+
+	// ADOT validation
+	c.Logger.Info("Starting ADOT validation")
+	if err := c.ADOT.Validate(ctx); err != nil {
+		return fmt.Errorf("ADOT validation failed: %w", err)
+	}
+	c.Logger.Info("ADOT validation completed successfully")
 
 	c.Logger.Info("Cert-manager validation completed successfully")
 	return nil
@@ -113,7 +131,6 @@ func (c *CertManagerTest) Validate(ctx context.Context) error {
 
 // PrintLogs collects and prints logs for debugging
 func (c *CertManagerTest) PrintLogs(ctx context.Context) error {
-	// Fetch cert-manager logs
 	logs, err := kubernetes.FetchLogs(ctx, c.K8S, c.addon.Name, c.addon.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to collect logs for %s: %w", c.addon.Name, err)
@@ -123,18 +140,26 @@ func (c *CertManagerTest) PrintLogs(ctx context.Context) error {
 		c.Logger.Error(err, "Failed to collect AWS PCA Issuer logs")
 	}
 
+	if err := c.ADOT.PrintLogs(ctx); err != nil {
+		c.Logger.Error(err, "Failed to collect ADOT logs")
+	}
+
 	c.Logger.Info("Logs for cert-manager", "controller", logs)
 	return nil
 }
 
 // Delete removes the addon and cleans up test resources
 func (c *CertManagerTest) Delete(ctx context.Context) error {
-	// Clean up test resources
 	c.Logger.Info("Cleaning up cert-manager test resources")
 
 	c.Logger.Info("Cleaning up AWS PCA Issuer resources")
 	if err := c.PCAIssuer.Cleanup(ctx); err != nil {
 		c.Logger.Error(err, "Failed to clean up AWS PCA Issuer resources")
+	}
+
+	c.Logger.Info("Cleaning up ADOT resources")
+	if err := c.ADOT.Cleanup(ctx); err != nil {
+		c.Logger.Error(err, "Failed to clean up ADOT resources")
 	}
 
 	// Delete certificate
@@ -172,8 +197,7 @@ func createSelfSignedIssuer(ctx context.Context, logger logr.Logger, certClient 
 		},
 	}
 
-	err := ik8s.IdempotentCreate(ctx, certClient.CertmanagerV1().Issuers(namespace), issuer)
-	if err != nil {
+	if err := ik8s.IdempotentCreate(ctx, certClient.CertmanagerV1().Issuers(namespace), issuer); err != nil {
 		return err
 	}
 
@@ -190,9 +214,7 @@ func createCertificate(ctx context.Context, logger logr.Logger, certClient certm
 			Namespace: namespace,
 		},
 		Spec: certmanagerv1.CertificateSpec{
-			DNSNames: []string{
-				"example.com",
-			},
+			DNSNames:   []string{"example.com"},
 			SecretName: secretName,
 			IssuerRef: cmmeta.ObjectReference{
 				Name: issuerName,
@@ -200,8 +222,7 @@ func createCertificate(ctx context.Context, logger logr.Logger, certClient certm
 		},
 	}
 
-	err := ik8s.IdempotentCreate(ctx, certClient.CertmanagerV1().Certificates(namespace), cert)
-	if err != nil {
+	if err := ik8s.IdempotentCreate(ctx, certClient.CertmanagerV1().Certificates(namespace), cert); err != nil {
 		return err
 	}
 

--- a/test/e2e/addon/certmanager.go
+++ b/test/e2e/addon/certmanager.go
@@ -36,15 +36,24 @@ type CertManagerTest struct {
 	Logger                                              logr.Logger
 	CertClient                                          certmanagerclientset.Interface
 	PCAIssuer                                           *PCAIssuerTest
+	ADOT                                                *ADOTTest
 	CertName, CertNamespace, CertSecretName, IssuerName string
 }
 
+func (c *CertManagerTest) AddonName() string { return certManagerName }
+
 // Create installs the cert-manager addon
 func (c *CertManagerTest) Create(ctx context.Context) error {
+	// Override the default affinity for all three cert-manager components (controller,
+	// webhook, cainjector) to remove the NodeAffinity term that excludes hybrid nodes
+	// (eks.amazonaws.com/compute-type != hybrid). The schema requires a non-null object
+	// so we provide the OS/arch requirements without the hybrid exclusion.
+	const certManagerAffinity = `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["amd64","arm64"]}]}]}}}`
 	c.addon = &Addon{
-		Cluster:   c.Cluster,
-		Namespace: certManagerNamespace,
-		Name:      certManagerName,
+		Cluster:       c.Cluster,
+		Namespace:     certManagerNamespace,
+		Name:          certManagerName,
+		Configuration: `{"affinity":` + certManagerAffinity + `,"webhook":{"affinity":` + certManagerAffinity + `},"cainjector":{"affinity":` + certManagerAffinity + `}}`,
 	}
 
 	if err := c.addon.CreateAndWaitForActive(ctx, c.EKSClient, c.K8S, c.Logger); err != nil {
@@ -68,6 +77,14 @@ func (c *CertManagerTest) Create(ctx context.Context) error {
 
 	if err := c.PCAIssuer.Setup(ctx); err != nil {
 		return fmt.Errorf("failed to setup AWS PCA Issuer: %v", err)
+	}
+
+	if c.ADOT != nil {
+		if err := c.ADOT.Setup(ctx); err != nil {
+			return fmt.Errorf("failed to setup ADOT: %w", err)
+		}
+	} else {
+		c.Logger.Info("Skipping ADOT setup: ADOT test is not configured")
 	}
 
 	c.Logger.Info("Cert-manager setup is complete")
@@ -98,14 +115,21 @@ func (c *CertManagerTest) Validate(ctx context.Context) error {
 		return fmt.Errorf("failed to validate certificate: %w", err)
 	}
 
-	// AWS PCA Issuer validation if it's configured
+	// AWS PCA Issuer validation
 	c.Logger.Info("Starting AWS PCA Issuer validation")
-
 	if err := c.PCAIssuer.Validate(ctx); err != nil {
 		return fmt.Errorf("AWS PCA Issuer validation failed: %w", err)
 	}
-
 	c.Logger.Info("AWS PCA Issuer validation completed successfully")
+
+	// ADOT validation
+	if c.ADOT != nil {
+		c.Logger.Info("Starting ADOT validation")
+		if err := c.ADOT.Validate(ctx); err != nil {
+			return fmt.Errorf("ADOT validation failed: %w", err)
+		}
+		c.Logger.Info("ADOT validation completed successfully")
+	}
 
 	c.Logger.Info("Cert-manager validation completed successfully")
 	return nil
@@ -113,7 +137,6 @@ func (c *CertManagerTest) Validate(ctx context.Context) error {
 
 // PrintLogs collects and prints logs for debugging
 func (c *CertManagerTest) PrintLogs(ctx context.Context) error {
-	// Fetch cert-manager logs
 	logs, err := kubernetes.FetchLogs(ctx, c.K8S, c.addon.Name, c.addon.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to collect logs for %s: %w", c.addon.Name, err)
@@ -123,18 +146,30 @@ func (c *CertManagerTest) PrintLogs(ctx context.Context) error {
 		c.Logger.Error(err, "Failed to collect AWS PCA Issuer logs")
 	}
 
+	if c.ADOT != nil {
+		if err := c.ADOT.PrintLogs(ctx); err != nil {
+			c.Logger.Error(err, "Failed to collect ADOT logs")
+		}
+	}
+
 	c.Logger.Info("Logs for cert-manager", "controller", logs)
 	return nil
 }
 
 // Delete removes the addon and cleans up test resources
 func (c *CertManagerTest) Delete(ctx context.Context) error {
-	// Clean up test resources
 	c.Logger.Info("Cleaning up cert-manager test resources")
 
 	c.Logger.Info("Cleaning up AWS PCA Issuer resources")
 	if err := c.PCAIssuer.Cleanup(ctx); err != nil {
 		c.Logger.Error(err, "Failed to clean up AWS PCA Issuer resources")
+	}
+
+	if c.ADOT != nil {
+		c.Logger.Info("Cleaning up ADOT resources")
+		if err := c.ADOT.Cleanup(ctx); err != nil {
+			c.Logger.Error(err, "Failed to clean up ADOT resources")
+		}
 	}
 
 	// Delete certificate
@@ -172,8 +207,7 @@ func createSelfSignedIssuer(ctx context.Context, logger logr.Logger, certClient 
 		},
 	}
 
-	err := ik8s.IdempotentCreate(ctx, certClient.CertmanagerV1().Issuers(namespace), issuer)
-	if err != nil {
+	if err := ik8s.IdempotentCreate(ctx, certClient.CertmanagerV1().Issuers(namespace), issuer); err != nil {
 		return err
 	}
 
@@ -190,9 +224,7 @@ func createCertificate(ctx context.Context, logger logr.Logger, certClient certm
 			Namespace: namespace,
 		},
 		Spec: certmanagerv1.CertificateSpec{
-			DNSNames: []string{
-				"example.com",
-			},
+			DNSNames:   []string{"example.com"},
 			SecretName: secretName,
 			IssuerRef: cmmeta.ObjectReference{
 				Name: issuerName,
@@ -200,8 +232,7 @@ func createCertificate(ctx context.Context, logger logr.Logger, certClient certm
 		},
 	}
 
-	err := ik8s.IdempotentCreate(ctx, certClient.CertmanagerV1().Certificates(namespace), cert)
-	if err != nil {
+	if err := ik8s.IdempotentCreate(ctx, certClient.CertmanagerV1().Certificates(namespace), cert); err != nil {
 		return err
 	}
 

--- a/test/e2e/addon/cloudwatch.go
+++ b/test/e2e/addon/cloudwatch.go
@@ -162,9 +162,33 @@ func (cw CloudWatchAddon) VerifyCloudWatchLogGroups(ctx context.Context, cwLogsC
 	return fmt.Errorf("no CloudWatch log groups found - expected %d log groups but found %d", len(logGroups), foundLogGroups)
 }
 
+// latestAddonVersion returns the most recent available version for an addon by querying the EKS API.
+func latestAddonVersion(ctx context.Context, eksClient *eks.Client, addonName string) (string, error) {
+	out, err := eksClient.DescribeAddonVersions(ctx, &eks.DescribeAddonVersionsInput{
+		AddonName: &addonName,
+	})
+	if err != nil {
+		return "", fmt.Errorf("describing addon versions for %s: %w", addonName, err)
+	}
+	if len(out.Addons) == 0 || len(out.Addons[0].AddonVersions) == 0 {
+		return "", fmt.Errorf("no versions found for addon %s", addonName)
+	}
+	// The first addon version returned is the latest.
+	return *out.Addons[0].AddonVersions[0].AddonVersion, nil
+}
+
 // SetupCwAddon handles CloudWatch addon installation and setup
 func (cw *CloudWatchAddon) SetupCwAddon(ctx context.Context, eksClient *eks.Client, k8sClient clientgo.Interface, cwLogsClient *cloudwatchlogs.Client, logger logr.Logger) error {
 	logger.Info("Setting up CloudWatch addon for mixed mode", "cluster", cw.Cluster)
+
+	// Use the latest available version so Pod Identity associations are more likely to be supported.
+	latestVersion, err := latestAddonVersion(ctx, eksClient, cw.Name)
+	if err != nil {
+		logger.Info("Could not determine latest addon version, using EKS default", "error", err.Error())
+	} else {
+		logger.Info("Using latest addon version", "version", latestVersion)
+		cw.Version = latestVersion
+	}
 
 	// Clean up existing log groups for fresh test environment
 	if err := cw.cleanupLogGroups(ctx, cwLogsClient, logger); err != nil {

--- a/test/e2e/addon/externaldns.go
+++ b/test/e2e/addon/externaldns.go
@@ -40,6 +40,8 @@ type ExternalDNSTest struct {
 }
 
 // Create installs the external-dns addon
+func (e *ExternalDNSTest) AddonName() string { return externalDNS }
+
 func (e *ExternalDNSTest) Create(ctx context.Context) error {
 	hostedZoneId, err := e.getHostedZoneId(ctx)
 	if err != nil {

--- a/test/e2e/addon/externaldns.go
+++ b/test/e2e/addon/externaldns.go
@@ -39,6 +39,9 @@ type ExternalDNSTest struct {
 	hostedZoneName *string
 }
 
+// AddonName returns the name of the external-dns addon
+func (e *ExternalDNSTest) AddonName() string { return externalDNS }
+
 // Create installs the external-dns addon
 func (e *ExternalDNSTest) Create(ctx context.Context) error {
 	hostedZoneId, err := e.getHostedZoneId(ctx)

--- a/test/e2e/addon/fsxcsidriver.go
+++ b/test/e2e/addon/fsxcsidriver.go
@@ -49,11 +49,14 @@ type FsxCSIDriverTest struct {
 	PodIdentityRoleArn string
 	SubnetID           string
 	SecurityGroupID    string
+	Region             string
 	manifests          []unstructured.Unstructured
 	fileSystemID       string
 }
 
 // Create installs the AWS FSX CSI driver addon
+func (f *FsxCSIDriverTest) AddonName() string { return fsxCSIDriver }
+
 func (f *FsxCSIDriverTest) Create(ctx context.Context) error {
 	f.addon = &Addon{
 		Cluster:   f.Cluster,
@@ -67,9 +70,7 @@ func (f *FsxCSIDriverTest) Create(ctx context.Context) error {
 		},
 	}
 
-	f.Logger.Info("Creating AWS FSX CSI driver addon (assuming success for hybrid nodes)")
-
-	if err := f.addon.Create(ctx, f.EKSClient, f.Logger); err != nil {
+	if err := f.addon.CreateAndWaitForActive(ctx, f.EKSClient, f.K8S, f.Logger); err != nil {
 		return fmt.Errorf("failed to create AWS FSX CSI driver addon: %w", err)
 	}
 
@@ -83,6 +84,8 @@ func (f *FsxCSIDriverTest) Validate(ctx context.Context) error {
 	uniqueTestPod := fsxTestPod + uniqueSuffix
 	pvcName := "fsx-claim" + uniqueSuffix
 
+	deploymentType, throughput, extraParams := fsxLustreDeploymentConfig(f.Region)
+
 	replacer := strings.NewReplacer(
 		"{{NAMESPACE}}", defaultNamespace,
 		"{{FSX_TEST_POD}}", uniqueTestPod,
@@ -90,12 +93,27 @@ func (f *FsxCSIDriverTest) Validate(ctx context.Context) error {
 		"{{SECURITY_GROUP_ID}}", f.SecurityGroupID,
 		"{{FSX_TEST_STRING}}", fsxTestString,
 		"{{UNIQUE_SUFFIX}}", uniqueSuffix,
+		"{{DEPLOYMENT_TYPE}}", deploymentType,
+		"{{PER_UNIT_STORAGE_THROUGHPUT}}", throughput,
 	)
 
 	replacedYaml := replacer.Replace(fsxDynamicProvisioningYaml)
 	objs, err := kubernetes.YamlToUnstructured([]byte(replacedYaml))
 	if err != nil {
 		return fmt.Errorf("failed to read FSX CSI dynamic provisioning yaml file: %w", err)
+	}
+
+	// Patch the StorageClass with extra parameters required for this region.
+	if len(extraParams) > 0 {
+		for i := range objs {
+			if objs[i].GetKind() == "StorageClass" {
+				for k, v := range extraParams {
+					if err := unstructured.SetNestedField(objs[i].Object, v, "parameters", k); err != nil {
+						return fmt.Errorf("setting StorageClass parameter %s: %w", k, err)
+					}
+				}
+			}
+		}
 	}
 
 	f.manifests = objs
@@ -196,6 +214,19 @@ func (f *FsxCSIDriverTest) Delete(ctx context.Context) error {
 	}
 
 	return f.addon.Delete(ctx, f.EKSClient, f.Logger)
+}
+
+// fsxLustreDeploymentConfig returns the deploymentType, perUnitStorageThroughput, and
+// any extra StorageClass parameters required for the given region.
+// China regions only support PERSISTENT_1 with SSD (50, 100, 200 MB/s/TiB) and require
+// fileSystemTypeVersion "2.12" to match the Lustre client on the node.
+// https://docs.amazonaws.cn/en_us/fsx/latest/LustreGuide/using-fsx-lustre.html
+// For other regions, see here: https://docs.aws.amazon.com/fsx/latest/LustreGuide/using-fsx-lustre.html
+func fsxLustreDeploymentConfig(region string) (deploymentType, perUnitStorageThroughput string, extraParams map[string]string) {
+	if strings.HasPrefix(region, "cn-") {
+		return "PERSISTENT_1", "200", map[string]string{"fileSystemTypeVersion": "2.12"}
+	}
+	return "PERSISTENT_2", "125", nil
 }
 
 func (f *FsxCSIDriverTest) waitForFileSystemDeletion(ctx context.Context) error {

--- a/test/e2e/addon/fsxcsidriver.go
+++ b/test/e2e/addon/fsxcsidriver.go
@@ -49,11 +49,14 @@ type FsxCSIDriverTest struct {
 	PodIdentityRoleArn string
 	SubnetID           string
 	SecurityGroupID    string
+	Region             string
 	manifests          []unstructured.Unstructured
 	fileSystemID       string
 }
 
 // Create installs the AWS FSX CSI driver addon
+func (f *FsxCSIDriverTest) AddonName() string { return fsxCSIDriver }
+
 func (f *FsxCSIDriverTest) Create(ctx context.Context) error {
 	f.addon = &Addon{
 		Cluster:   f.Cluster,
@@ -67,9 +70,7 @@ func (f *FsxCSIDriverTest) Create(ctx context.Context) error {
 		},
 	}
 
-	f.Logger.Info("Creating AWS FSX CSI driver addon (assuming success for hybrid nodes)")
-
-	if err := f.addon.Create(ctx, f.EKSClient, f.Logger); err != nil {
+	if err := f.addon.CreateAndWaitForActive(ctx, f.EKSClient, f.K8S, f.Logger); err != nil {
 		return fmt.Errorf("failed to create AWS FSX CSI driver addon: %w", err)
 	}
 
@@ -83,6 +84,15 @@ func (f *FsxCSIDriverTest) Validate(ctx context.Context) error {
 	uniqueTestPod := fsxTestPod + uniqueSuffix
 	pvcName := "fsx-claim" + uniqueSuffix
 
+	region := f.Region
+	if region == "" && f.EKSClient != nil {
+		if opts := f.EKSClient.Options(); opts.Region != "" {
+			region = opts.Region
+		}
+	}
+
+	deploymentType, throughput, extraParams := fsxLustreDeploymentConfig(region)
+
 	replacer := strings.NewReplacer(
 		"{{NAMESPACE}}", defaultNamespace,
 		"{{FSX_TEST_POD}}", uniqueTestPod,
@@ -90,12 +100,27 @@ func (f *FsxCSIDriverTest) Validate(ctx context.Context) error {
 		"{{SECURITY_GROUP_ID}}", f.SecurityGroupID,
 		"{{FSX_TEST_STRING}}", fsxTestString,
 		"{{UNIQUE_SUFFIX}}", uniqueSuffix,
+		"{{DEPLOYMENT_TYPE}}", deploymentType,
+		"{{PER_UNIT_STORAGE_THROUGHPUT}}", throughput,
 	)
 
 	replacedYaml := replacer.Replace(fsxDynamicProvisioningYaml)
 	objs, err := kubernetes.YamlToUnstructured([]byte(replacedYaml))
 	if err != nil {
 		return fmt.Errorf("failed to read FSX CSI dynamic provisioning yaml file: %w", err)
+	}
+
+	// Patch the StorageClass with extra parameters required for this region.
+	if len(extraParams) > 0 {
+		for i := range objs {
+			if objs[i].GetKind() == "StorageClass" {
+				for k, v := range extraParams {
+					if err := unstructured.SetNestedField(objs[i].Object, v, "parameters", k); err != nil {
+						return fmt.Errorf("setting StorageClass parameter %s: %w", k, err)
+					}
+				}
+			}
+		}
 	}
 
 	f.manifests = objs
@@ -196,6 +221,19 @@ func (f *FsxCSIDriverTest) Delete(ctx context.Context) error {
 	}
 
 	return f.addon.Delete(ctx, f.EKSClient, f.Logger)
+}
+
+// fsxLustreDeploymentConfig returns the deploymentType, perUnitStorageThroughput, and
+// any extra StorageClass parameters required for the given region.
+// China regions only support PERSISTENT_1 with SSD (50, 100, 200 MB/s/TiB) and require
+// fileSystemTypeVersion "2.12" to match the Lustre client on the node.
+// https://docs.amazonaws.cn/en_us/fsx/latest/LustreGuide/using-fsx-lustre.html
+// For other regions, see here: https://docs.aws.amazon.com/fsx/latest/LustreGuide/using-fsx-lustre.html
+func fsxLustreDeploymentConfig(region string) (deploymentType, perUnitStorageThroughput string, extraParams map[string]string) {
+	if strings.HasPrefix(region, "cn-") {
+		return "PERSISTENT_1", "200", map[string]string{"fileSystemTypeVersion": "2.12"}
+	}
+	return "PERSISTENT_2", "125", nil
 }
 
 func (f *FsxCSIDriverTest) waitForFileSystemDeletion(ctx context.Context) error {

--- a/test/e2e/addon/kubestatemetrics.go
+++ b/test/e2e/addon/kubestatemetrics.go
@@ -35,6 +35,8 @@ type KubeStateMetricsTest struct {
 }
 
 // Create installs the kube-state-metrics addon
+func (k *KubeStateMetricsTest) AddonName() string { return kubeStateMetricsName }
+
 func (k *KubeStateMetricsTest) Create(ctx context.Context) error {
 	k.addon = &Addon{
 		Cluster:   k.Cluster,

--- a/test/e2e/addon/kubestatemetrics.go
+++ b/test/e2e/addon/kubestatemetrics.go
@@ -34,6 +34,9 @@ type KubeStateMetricsTest struct {
 	Logger    logr.Logger
 }
 
+// AddonName returns the name of the kube-state-metrics addon
+func (k *KubeStateMetricsTest) AddonName() string { return kubeStateMetricsName }
+
 // Create installs the kube-state-metrics addon
 func (k *KubeStateMetricsTest) Create(ctx context.Context) error {
 	k.addon = &Addon{

--- a/test/e2e/addon/metricsserver.go
+++ b/test/e2e/addon/metricsserver.go
@@ -33,6 +33,8 @@ type MetricsServerTest struct {
 }
 
 // Create installs the metrics-server addon
+func (m *MetricsServerTest) AddonName() string { return metricsServerName }
+
 func (m *MetricsServerTest) Create(ctx context.Context) error {
 	m.addon = &Addon{
 		Cluster:   m.Cluster,

--- a/test/e2e/addon/metricsserver.go
+++ b/test/e2e/addon/metricsserver.go
@@ -32,6 +32,9 @@ type MetricsServerTest struct {
 	Logger        logr.Logger
 }
 
+// AddonName returns the name of the metrics-server addon
+func (m *MetricsServerTest) AddonName() string { return metricsServerName }
+
 // Create installs the metrics-server addon
 func (m *MetricsServerTest) Create(ctx context.Context) error {
 	m.addon = &Addon{

--- a/test/e2e/addon/nodemonitoringagent.go
+++ b/test/e2e/addon/nodemonitoringagent.go
@@ -40,6 +40,8 @@ type NodeMonitoringAgentTest struct {
 	NodeFilter    labels.Selector
 }
 
+func (n *NodeMonitoringAgentTest) AddonName() string { return nodeMonitoringAgentName }
+
 func (n *NodeMonitoringAgentTest) Create(ctx context.Context) error {
 	n.addon = &Addon{
 		Cluster:   n.Cluster,

--- a/test/e2e/addon/pcaissuer.go
+++ b/test/e2e/addon/pcaissuer.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -52,9 +53,12 @@ type PCAIssuerTest struct {
 	PodIdentityRoleArn string
 	Logger             logr.Logger
 	addon              *Addon
+	available          bool
 }
 
-// Setup installs the AWS PCA Issuer add-on
+// Setup installs the AWS PCA Issuer add-on. If the addon is not available in the
+// current region/partition, Setup returns nil and marks the issuer as unavailable
+// so that Validate can skip the PCA-specific steps without failing the whole test.
 func (p *PCAIssuerTest) Setup(ctx context.Context) error {
 	p.Logger.Info("Setting up AWS PCA Issuer test")
 
@@ -72,6 +76,11 @@ func (p *PCAIssuerTest) Setup(ctx context.Context) error {
 	}
 
 	if err := p.addon.CreateAndWaitForActive(ctx, p.EKSClient, p.K8S, p.Logger); err != nil {
+		if errors.Is(err, ErrAddonNotAvailable) {
+			p.Logger.Info("AWS PCA Issuer addon is not available in this region, skipping PCA validation")
+			p.available = false
+			return nil
+		}
 		return fmt.Errorf("failed to create AWS PCA Issuer addon: %v", err)
 	}
 
@@ -80,12 +89,19 @@ func (p *PCAIssuerTest) Setup(ctx context.Context) error {
 		return fmt.Errorf("error waiting for AWS PCA Issuer deployment to be ready: %v", err)
 	}
 
+	p.available = true
 	p.Logger.Info("AWS PCA Issuer deployment is ready")
 	return nil
 }
 
-// Validate tests the AWS PCA Issuer by creating and validating certificates
+// Validate tests the AWS PCA Issuer by creating and validating certificates.
+// If the addon was not available (Setup returned without installing it), this is a no-op.
 func (p *PCAIssuerTest) Validate(ctx context.Context) error {
+	if !p.available {
+		p.Logger.Info("AWS PCA Issuer not available in this region, skipping PCA validation")
+		return nil
+	}
+
 	p.Logger.Info("Validating AWS PCA Issuer")
 
 	// Create and activate a Private CA

--- a/test/e2e/addon/prometheus.go
+++ b/test/e2e/addon/prometheus.go
@@ -34,6 +34,8 @@ type PrometheusNodeExporterTest struct {
 	Logger    logr.Logger
 }
 
+func (p *PrometheusNodeExporterTest) AddonName() string { return prometheusName }
+
 // Create installs the node exporter addon
 func (p *PrometheusNodeExporterTest) Create(ctx context.Context) error {
 	p.addon = &Addon{

--- a/test/e2e/addon/secretsstorecsidriver.go
+++ b/test/e2e/addon/secretsstorecsidriver.go
@@ -43,6 +43,8 @@ type SecretsStoreCSIDriverTest struct {
 }
 
 // Create installs the Secrets Store CSI driver addon
+func (s *SecretsStoreCSIDriverTest) AddonName() string { return secretsStoreCSIDriver }
+
 func (s *SecretsStoreCSIDriverTest) Create(ctx context.Context) error {
 	s.addon = &Addon{
 		Cluster:   s.Cluster,

--- a/test/e2e/addon/secretsstorecsidriver.go
+++ b/test/e2e/addon/secretsstorecsidriver.go
@@ -42,6 +42,9 @@ type SecretsStoreCSIDriverTest struct {
 	secretValue string
 }
 
+// AddonName returns the name of the Secrets Store CSI driver addon
+func (s *SecretsStoreCSIDriverTest) AddonName() string { return secretsStoreCSIDriver }
+
 // Create installs the Secrets Store CSI driver addon
 func (s *SecretsStoreCSIDriverTest) Create(ctx context.Context) error {
 	s.addon = &Addon{

--- a/test/e2e/addon/testdata/fsx_csi_dynamic_provisioning.yaml
+++ b/test/e2e/addon/testdata/fsx_csi_dynamic_provisioning.yaml
@@ -10,9 +10,9 @@ provisioner: fsx.csi.aws.com
 parameters:
   subnetId: {{SUBNET_ID}}
   securityGroupIds: {{SECURITY_GROUP_ID}}
-  deploymentType: PERSISTENT_2
+  deploymentType: {{DEPLOYMENT_TYPE}}
   storageType: SSD
-  perUnitStorageThroughput: "125"
+  perUnitStorageThroughput: "{{PER_UNIT_STORAGE_THROUGHPUT}}"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
## Summary
Improves the addon testing framework with availability checking per region/partition, and adds ADOT addon support.

## Changes
- Add `IsAvailable()` method to all addons to check if the addon is offered in the current region/partition
- Add `ErrAddonNotAvailable` sentinel error for gracefully skipping unavailable addons
- Call `IsAvailable()` in `CreateAndWaitForActive()` to skip unavailable addons instead of failing
- Add new `test/e2e/addon/adot.go` for ADOT (AWS Distro for OpenTelemetry) addon support
- Fix import alias conflict (`e2eerrors` vs `errors`) in `addon.go`
- Update `fsxcsidriver`, `certmanager`, `pcaissuer` with improved error handling
- Update `fsx_csi_dynamic_provisioning.yaml` test data

## Dependencies
Depends on #845

## Testing
- `make lint` passes with 0 issues