### PR TITLE
cdk: add logs:DescribeLogStreams permission to test policy

### DIFF
--- a/hybrid-nodes-cdk/lib/nodeadm/policies.ts
+++ b/hybrid-nodes-cdk/lib/nodeadm/policies.ts
@@ -410,7 +410,7 @@ export function createNodeadmTestsCreationCleanupPolicies(
         conditions: requestTagCondition,
       }),
       new iam.PolicyStatement({
-        actions: ['logs:DescribeLogGroups'],
+        actions: ['logs:DescribeLogGroups', 'logs:DescribeLogStreams'],
         resources: ['*'],
         effect: iam.Effect.ALLOW,
       }),


### PR DESCRIPTION
## Summary
Adds a missing IAM permission to the CDK test policy.

## Changes
- Add `logs:DescribeLogStreams` to `hybrid-nodes-cdk/lib/nodeadm/policies.ts`

## Why
Required to list log streams when verifying CloudWatch log output during e2e tests. Without this permission, the test role cannot enumerate log streams and CloudWatch log validation fails.

## Testing
- `make lint` passes with 0 issues