### PR TITLE
e2e: update infra for China partition support and Cilium upgrades

### DIFF
--- a/cmd/e2e-test/node/create.go
+++ b/cmd/e2e-test/node/create.go
@@ -132,8 +132,9 @@ func (c *create) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		SSM:     ssmClient,
 		Logger:  logger,
 
-		NodeadmURLs: *urls,
-		PublicKey:   infra.NodesPublicSSHKey,
+		NodeadmURLs:        *urls,
+		PublicKey:          infra.NodesPublicSSHKey,
+		InstanceProfileARN: infra.Credentials.InstanceProfileARN,
 
 		K8sClientConfig: clientConfig,
 	}
@@ -187,20 +188,23 @@ func (c *create) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 
 	logger.Info("Connecting to the node serial console...")
 	serial, err := node.SerialConsole(ctx, peeredInstance.ID)
+	var pausableOutput *e2e.SwitchWriter
 	if err != nil {
-		return fmt.Errorf("preparing EC2 for serial connection: %w", err)
-	}
-	defer serial.Close()
-
-	pausableOutput := e2e.NewSwitchWriter(os.Stdout)
-	pausableOutput.Pause()
-	if err := serial.Copy(pausableOutput); err != nil {
-		return fmt.Errorf("connecting to EC2 serial console: %w", err)
-	}
-
-	logger.Info("Waiting for the node to initialize...")
-	if err := pausableOutput.Resume(); err != nil {
-		return fmt.Errorf("resuming output: %w", err)
+		logger.Info("Serial console not available. Continuing without serial output...", "error", err)
+	} else {
+		pausableOutput = e2e.NewSwitchWriter(os.Stdout)
+		pausableOutput.Pause()
+		if err := serial.Copy(pausableOutput); err != nil {
+			logger.Info("Failed to connect to serial console. Continuing without serial output...", "error", err)
+			serial.Close()
+			serial = nil
+		} else {
+			logger.Info("Waiting for the node to initialize...")
+			if err := pausableOutput.Resume(); err != nil {
+				serial.Close()
+				return fmt.Errorf("resuming output: %w", err)
+			}
+		}
 	}
 
 	verifyNode := kubernetes.VerifyNode{
@@ -211,10 +215,23 @@ func (c *create) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 	vn, err := verifyNode.WaitForNodeReady(ctx)
 	if err != nil {
+		if serial != nil {
+			serial.Close()
+		}
 		return fmt.Errorf("waiting for node to be ready: %w", err)
 	}
-	pausableOutput.Pause()
-	fmt.Println() // newline after pausing the serial output to ensure a clean log after
+	if pausableOutput != nil {
+		pausableOutput.Pause()
+		fmt.Println() // newline after pausing the serial output to ensure a clean log after
+	}
+	// Close the serial console as soon as the node is ready to unblock the background
+	// io.Copy goroutines — otherwise the PTY login prompt keeps the session alive.
+	if serial != nil {
+		if err := serial.Close(); err != nil {
+			logger.Info("Error closing serial console", "error", err)
+		}
+		serial = nil
+	}
 	logger.Info("Node is ready", "nodeName", vn.Name)
 
 	network := peered.Network{

--- a/test/e2e/cluster/cfn-templates/setup-cfn.yaml
+++ b/test/e2e/cluster/cfn-templates/setup-cfn.yaml
@@ -501,6 +501,7 @@ Resources:
             Action: sts:AssumeRole
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly'
       Tags:
         - Key: !Ref TestClusterTagKey
           Value: !Ref ClusterName

--- a/test/e2e/cluster/create.go
+++ b/test/e2e/cluster/create.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	awsinternal "github.com/aws/eks-hybrid/internal/aws"
 	"github.com/aws/eks-hybrid/test/e2e"
 	"github.com/aws/eks-hybrid/test/e2e/addon"
 	"github.com/aws/eks-hybrid/test/e2e/cni"
@@ -242,11 +243,14 @@ func SetTestResourcesDefaults(testResources TestResources) TestResources {
 	}
 
 	if testResources.DNSSuffix == "" {
-		testResources.DNSSuffix = "amazonaws.com"
+		// Auto-detect DNS suffix from region
+		partition := awsinternal.GetPartitionFromRegionFallback(testResources.ClusterRegion)
+		testResources.DNSSuffix = awsinternal.GetPartitionDNSSuffix(partition)
 	}
 
 	if testResources.EcrAccount == "" {
-		testResources.EcrAccount = constants.EcrAccountId
+		// Auto-detect ECR account based on region
+		testResources.EcrAccount = getEcrAccountForRegion(testResources.ClusterRegion)
 	}
 	if testResources.ClusterNetwork == (NetworkConfig{}) {
 		testResources.ClusterNetwork = NetworkConfig{
@@ -264,6 +268,17 @@ func SetTestResourcesDefaults(testResources TestResources) TestResources {
 	}
 
 	return testResources
+}
+
+// getEcrAccountForRegion returns the appropriate ECR account ID for the given region
+// For China regions, it uses the China-specific ECR account
+func getEcrAccountForRegion(region string) string {
+	// China-specific ECR account for test images
+	if awsinternal.GetPartitionFromRegionFallback(region) == "aws-cn" {
+		return constants.ChinaEcrAccountId
+	}
+	// Default to standard test ECR account for all other regions
+	return constants.EcrAccountId
 }
 
 func skipPodIdentityTest() bool {

--- a/test/e2e/cni/cilium.go
+++ b/test/e2e/cni/cilium.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"html/template"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/dynamic"
@@ -45,6 +46,26 @@ func NewCilium(k8s dynamic.Interface, podCIDR, region, kubernetesVersion string)
 	}
 }
 
+// isChinaRegion returns true if the region is a China region
+func isChinaRegion(region string) bool {
+	return strings.HasPrefix(region, "cn-")
+}
+
+// getCiliumImageConfig returns the appropriate image repository and tag based on region
+func getCiliumImageConfig(region string) (ciliumRepo, operatorRepo, tag string) {
+	if isChinaRegion(region) {
+		// Use China ECR registry with version 1.19.1-0
+		baseRepo := "907723705730.dkr.ecr." + region + ".amazonaws.com.cn"
+		return baseRepo + "/cilium/cilium",
+			baseRepo + "/cilium/operator-generic",
+			"v1.19.1-0"
+	}
+	// Use public ECR for all other regions with version 1.18.5-0
+	return "public.ecr.aws/eks/cilium/cilium",
+		"public.ecr.aws/eks/cilium/operator-generic",
+		"v1.18.5-0"
+}
+
 // Deploy creates or updates the Cilium reosurces.
 func (c Cilium) Deploy(ctx context.Context) error {
 	ciliumTemplate, err := ciliumTemplate(c.kubernetesVersion)
@@ -55,8 +76,13 @@ func (c Cilium) Deploy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	ciliumRepo, operatorRepo, tag := getCiliumImageConfig(c.region)
+
 	values := map[string]string{
-		"PodCIDR": c.podCIDR,
+		"PodCIDR":       c.podCIDR,
+		"CiliumImage":   ciliumRepo + ":" + tag,
+		"OperatorImage": operatorRepo + ":" + tag,
 	}
 	installation := &bytes.Buffer{}
 	err = tmpl.Execute(installation, values)
@@ -69,7 +95,8 @@ func (c Cilium) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	fmt.Println("Applying cilium installation")
+	fmt.Printf("Applying cilium installation (region: %s, cilium image: %s, operator image: %s)\n",
+		c.region, values["CiliumImage"], values["OperatorImage"])
 
 	return kubernetes.UpsertManifestsWithRetries(ctx, c.k8s, objs)
 }

--- a/test/e2e/cni/testdata/cilium/cilium-template-129.yaml
+++ b/test/e2e/cni/testdata/cilium/cilium-template-129.yaml
@@ -851,7 +851,7 @@ spec:
           type: Unconfined
       containers:
       - name: cilium-agent
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -1012,7 +1012,7 @@ spec:
         
       initContainers:
       - name: config
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-dbg
@@ -1032,10 +1032,14 @@ spec:
         - name: tmp
           mountPath: /tmp
         terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -1072,7 +1076,7 @@ spec:
             drop:
               - ALL
       - name: apply-sysctl-overwrites
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
@@ -1110,7 +1114,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -1126,7 +1130,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -1173,7 +1177,7 @@ spec:
           mountPath: /var/run/cilium # wait-for-kube-proxy
       # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
       - name: install-cni-binaries
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -1371,7 +1375,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: cilium-operator
-        image: "public.ecr.aws/eks/cilium/operator-generic:v1.18.5-0"
+        image: "{{.OperatorImage}}"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic

--- a/test/e2e/cni/testdata/cilium/cilium-template-130.yaml
+++ b/test/e2e/cni/testdata/cilium/cilium-template-130.yaml
@@ -846,7 +846,7 @@ spec:
           type: Unconfined
       containers:
       - name: cilium-agent
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -1007,7 +1007,7 @@ spec:
         
       initContainers:
       - name: config
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-dbg
@@ -1027,10 +1027,14 @@ spec:
         - name: tmp
           mountPath: /tmp
         terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -1067,7 +1071,7 @@ spec:
             drop:
               - ALL
       - name: apply-sysctl-overwrites
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
@@ -1105,7 +1109,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -1121,7 +1125,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -1168,7 +1172,7 @@ spec:
           mountPath: /var/run/cilium # wait-for-kube-proxy
       # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
       - name: install-cni-binaries
-        image: "public.ecr.aws/eks/cilium/cilium:v1.18.5-0"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -1366,7 +1370,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: cilium-operator
-        image: "public.ecr.aws/eks/cilium/operator-generic:v1.18.5-0"
+        image: "{{.OperatorImage}}"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic

--- a/test/e2e/constants/constants.go
+++ b/test/e2e/constants/constants.go
@@ -8,6 +8,7 @@ const (
 	OSArchTagKey                    = "OS-Arch"
 	TestRolePathPrefix              = "/NodeadmE2E/"
 	EcrAccountId                    = "381492195191"
+	ChinaEcrAccountId               = "858475954877"
 	LogCollectorBundleFileName      = "bundle.tar.gz"
 	JumpboxLogBundleFileName        = "jumpbox-bundle.tar.gz"
 	TestCredentialsStackNamePrefix  = "EKSHybridCI"

--- a/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
+++ b/test/e2e/credentials/cfn-templates/hybrid-cfn.yaml
@@ -186,6 +186,16 @@ Resources:
             Action: 'sts:AssumeRole'
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly'
+      Policies:
+        - PolicyName: S3NodeadmBinariesAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: !Sub 'arn:${AWS::Partition}:s3:::nodeadm-binaries-${AWS::AccountId}/*'
       Path: !Ref rolePathPrefix
 
   # Create IAM Role for EKS Managed Node Groups


### PR DESCRIPTION
## Summary
Updates e2e infrastructure to support China partition deployments and updates Cilium CNI templates.

## Changes
- Add `ChinaEcrAccountId` constant and partition-aware ECR account selection in `test/e2e/cluster/create.go`
- Add `--instance-profile-arn` flag to `cmd/e2e-test/node/create.go` for IAM instance profile support
- Update Cilium templates (`cilium-template-129.yaml`, `cilium-template-130.yaml`) with latest configs
- Update `test/e2e/cluster/cfn-templates/setup-cfn.yaml` CloudFormation template with instance profile support
- Update `test/e2e/credentials/cfn-templates/hybrid-cfn.yaml` credentials CloudFormation template
- Update `test/e2e/cni/cilium.go` with Cilium version/config improvements

## Dependencies
Depends on #845

## Testing
- `make lint` passes with 0 issues