### PR TITLE
Add support for SLES 15 and 16

### DIFF
--- a/cmd/e2e-test/node/create.go
+++ b/cmd/e2e-test/node/create.go
@@ -54,7 +54,7 @@ func NewCreateCommand() cli.Command {
 	createCmd.AddPositionalValue(&cmd.instanceName, "INSTANCE_NAME", 1, true, "Name of the instance to create.")
 	createCmd.String(&cmd.configFile, "f", "config-file", "Path tests config file.")
 	createCmd.String(&cmd.credsProvider, "c", "creds-provider", "Credentials provider to use (iam-ra, ssm).")
-	createCmd.String(&cmd.os, "o", "os", "OS to use (al23, ubuntu2004, ubuntu2204, ubuntu2404, rhel8, rhel9, bottlerocket).")
+	createCmd.String(&cmd.os, "o", "os", "OS to use (al23, ubuntu2004, ubuntu2204, ubuntu2404, rhel8, rhel9, sles15sp7, sles16, bottlerocket).")
 	createCmd.String(&cmd.arch, "a", "arch", "Architecture to use (amd64, arm64).")
 	createCmd.String(&cmd.instanceSize, "s", "instance-size", "Instance size to use (Large, XLarge).")
 	createCmd.String(&cmd.instanceType, "t", "instance-type", "Instance type to use (t3.large, g4dn.xlarge, etc). If provided, instance size would be ignored.")
@@ -297,6 +297,14 @@ var oses = map[string]map[string]func() e2e.NodeadmOS{
 		"arm64": func() e2e.NodeadmOS {
 			return osystem.NewRedHat9ARM(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD"))
 		},
+	},
+	"sles15sp7": {
+		"amd64": func() e2e.NodeadmOS { return osystem.NewSLES15SP7AMD() },
+		"arm64": func() e2e.NodeadmOS { return osystem.NewSLES15SP7ARM() },
+	},
+	"sles16": {
+		"amd64": func() e2e.NodeadmOS { return osystem.NewSLES16AMD() },
+		"arm64": func() e2e.NodeadmOS { return osystem.NewSLES16ARM() },
 	},
 	"bottlerocket": {
 		"amd64": func() e2e.NodeadmOS { return osystem.NewBottleRocket() },

--- a/internal/kubelet/kubelet.service
+++ b/internal/kubelet/kubelet.service
@@ -7,7 +7,7 @@ Requires=containerd.service
 [Service]
 Slice=runtime.slice
 EnvironmentFile=/etc/eks/kubelet/environment
-ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
+ExecStartPre=iptables -P FORWARD ACCEPT -w 5
 ExecStart=/usr/bin/kubelet \
     --config /etc/kubernetes/kubelet/config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \

--- a/internal/network/proxy_validator.go
+++ b/internal/network/proxy_validator.go
@@ -111,6 +111,8 @@ func validatePackageManagerProxyConfig(osName string) error {
 		return validateYumProxyConfig(httpProxy, httpsProxy)
 	case system.AmazonOsName:
 		return validateDnfProxyConfig(httpProxy, httpsProxy)
+	case system.SlesOsName:
+		return validateZypperProxyConfig(httpProxy, httpsProxy)
 	default:
 		return fmt.Errorf("unsupported operating system: %s", osName)
 	}
@@ -180,7 +182,7 @@ func validateSSMProxyConfig(osName string) error {
 	switch osName {
 	case system.UbuntuOsName:
 		ssmServicePath = "/etc/systemd/system/snap.amazon-ssm-agent.amazon-ssm-agent.service.d/http-proxy.conf"
-	case system.RhelOsName, system.AmazonOsName:
+	case system.RhelOsName, system.AmazonOsName, system.SlesOsName:
 		ssmServicePath = "/etc/systemd/system/amazon-ssm-agent.service.d/http-proxy.conf"
 	default:
 		return fmt.Errorf("unsupported operating system: %s", osName)
@@ -278,6 +280,46 @@ func validateDnfProxyConfig(httpProxy, httpsProxy string) error {
 			fmt.Errorf("dnf configuration file does not contain correct proxy setting"),
 			fmt.Sprintf("Update the dnf configuration file at %s with the correct proxy setting: proxy=%s",
 				dnfConfPath, httpProxy),
+		)
+	}
+
+	return nil
+}
+
+// validateZypperProxyConfig validates the zypper proxy configuration.
+// SUSE's system-wide proxy convention is /etc/sysconfig/proxy (unlike
+// yum/dnf, zypper has no manager-specific proxy.conf)
+func validateZypperProxyConfig(httpProxy, httpsProxy string) error {
+	proxyConfPath := "/etc/sysconfig/proxy"
+	if !fileExists(proxyConfPath) {
+		return validation.WithRemediation(
+			fmt.Errorf("proxy configuration file not found: %s", proxyConfPath),
+			fmt.Sprintf("Create the proxy configuration file at %s with the following content:\n"+
+				"PROXY_ENABLED=\"yes\"\n"+
+				"HTTP_PROXY=\"%s\"\n"+
+				"HTTPS_PROXY=\"%s\"",
+				proxyConfPath, httpProxy, httpsProxy),
+		)
+	}
+
+	content, err := os.ReadFile(proxyConfPath)
+	if err != nil {
+		return fmt.Errorf("failed to read proxy configuration file: %w", err)
+	}
+
+	if httpProxy != "" && !strings.Contains(string(content), fmt.Sprintf("HTTP_PROXY=\"%s\"", httpProxy)) {
+		return validation.WithRemediation(
+			fmt.Errorf("proxy configuration file does not contain correct HTTP_PROXY value"),
+			fmt.Sprintf("Update the proxy configuration file at %s with the correct HTTP_PROXY value: HTTP_PROXY=\"%s\"",
+				proxyConfPath, httpProxy),
+		)
+	}
+
+	if httpsProxy != "" && !strings.Contains(string(content), fmt.Sprintf("HTTPS_PROXY=\"%s\"", httpsProxy)) {
+		return validation.WithRemediation(
+			fmt.Errorf("proxy configuration file does not contain correct HTTPS_PROXY value"),
+			fmt.Sprintf("Update the proxy configuration file at %s with the correct HTTPS_PROXY value: HTTPS_PROXY=\"%s\"",
+				proxyConfPath, httpsProxy),
 		)
 	}
 

--- a/internal/packagemanager/packagemanager.go
+++ b/internal/packagemanager/packagemanager.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	aptPackageManager  = "apt"
-	snapPackageManager = "snap"
-	yumPackageManager  = "yum"
+	aptPackageManager    = "apt"
+	snapPackageManager   = "snap"
+	yumPackageManager    = "yum"
+	zypperPackageManager = "zypper"
 
 	snapInstallVerb = "install"
 	snapUpdateVerb  = "refresh"
@@ -46,7 +47,7 @@ const (
 	ssmPkgName      = "amazon-ssm-agent"
 )
 
-// DistroPackageManager defines a new package manager using apt or yum
+// DistroPackageManager defines a new package manager using apt, yum, or zypper
 type DistroPackageManager struct {
 	manager             string
 	installVerb         string
@@ -201,11 +202,23 @@ func (pm *DistroPackageManager) appendPackageVersion(packageName, version string
 	switch pm.manager {
 	case yumPackageManager:
 		return fmt.Sprintf("%s-%s", packageName, version)
-	case aptPackageManager:
+	case aptPackageManager, zypperPackageManager:
 		return fmt.Sprintf("%s=%s", packageName, version)
 	default:
 		return packageName
 	}
+}
+
+// newAutoConfirmCmd builds a package manager command that runs non-interactively.
+// zypper only honors the confirm flag immediately after the subcommand
+// (e.g. "zypper install -y pkg")
+// Centralized here so every package getter gets the right flag placement
+// without repeating the zypper special case at each call site.
+func (pm *DistroPackageManager) newAutoConfirmCmd(verb, packageName string) artifact.Cmd {
+	if pm.manager == zypperPackageManager {
+		return artifact.NewCmd(pm.manager, verb, "-y", packageName)
+	}
+	return artifact.NewCmd(pm.manager, verb, packageName, "-y")
 }
 
 func (pm *DistroPackageManager) getContainerdPackageNameWithVersionConstraint(version string) string {
@@ -230,18 +243,18 @@ func (pm *DistroPackageManager) refreshMetadataCacheCommand(ctx context.Context)
 func (pm *DistroPackageManager) GetContainerd(versionConstraint string) artifact.Package {
 	packageName := pm.getContainerdPackageNameWithVersionConstraint(versionConstraint)
 	return artifact.NewPackageSource(
-		artifact.NewCmd(pm.manager, pm.installVerb, packageName, "-y"),
-		artifact.NewCmd(pm.manager, pm.deleteVerb, packageName, "-y"),
-		artifact.NewCmd(pm.manager, pm.updateVerb, packageName, "-y"),
+		pm.newAutoConfirmCmd(pm.installVerb, packageName),
+		pm.newAutoConfirmCmd(pm.deleteVerb, packageName),
+		pm.newAutoConfirmCmd(pm.updateVerb, packageName),
 	)
 }
 
 // GetIptables satisfies the getiptables source interface
 func (pm *DistroPackageManager) GetIptables() artifact.Package {
 	return artifact.NewPackageSource(
-		artifact.NewCmd(pm.manager, pm.installVerb, iptablesPkgName, "-y"),
-		artifact.NewCmd(pm.manager, pm.deleteVerb, iptablesPkgName, "-y"),
-		artifact.NewCmd(pm.manager, pm.updateVerb, iptablesPkgName, "-y"),
+		pm.newAutoConfirmCmd(pm.installVerb, iptablesPkgName),
+		pm.newAutoConfirmCmd(pm.deleteVerb, iptablesPkgName),
+		pm.newAutoConfirmCmd(pm.updateVerb, iptablesPkgName),
 	)
 }
 
@@ -256,34 +269,48 @@ func (pm *DistroPackageManager) GetSSMPackage() artifact.Package {
 			artifact.NewCmd(snapPackageManager, snapUpdateVerb, ssmPkgName),
 		)
 	}
+	// SSM on SLES is not installed through zypper, so there is nothing
+	// for the package manager to install/remove/update.
+	// This matters for uninstall. yum and apt return exit 0 when removing
+	// a package that was never installed.
+	// zypper returns a non-zero exit (ZYPPER_EXIT_INF_CAP_NOT_FOUND).
+	// cmd.Retry has no retry limit around `nodeadm uninstall`, so a
+	// non-zero exit would retry forever.
+	if pm.manager == zypperPackageManager {
+		return artifact.NewPackageSource(
+			artifact.NewCmd("true"),
+			artifact.NewCmd("true"),
+			artifact.NewCmd("true"),
+		)
+	}
 	return artifact.NewPackageSource(
-		artifact.NewCmd(pm.manager, pm.installVerb, ssmPkgName, "-y"),
-		artifact.NewCmd(pm.manager, pm.deleteVerb, ssmPkgName, "-y"),
-		artifact.NewCmd(pm.manager, pm.updateVerb, ssmPkgName, "-y"),
+		pm.newAutoConfirmCmd(pm.installVerb, ssmPkgName),
+		pm.newAutoConfirmCmd(pm.deleteVerb, ssmPkgName),
+		pm.newAutoConfirmCmd(pm.updateVerb, ssmPkgName),
 	)
 }
 
 func (pm *DistroPackageManager) caCertsPackage() artifact.Package {
 	return artifact.NewPackageSource(
-		artifact.NewCmd(pm.manager, pm.installVerb, caCertsPkgName, "-y"),
-		artifact.NewCmd(pm.manager, pm.deleteVerb, caCertsPkgName, "-y"),
-		artifact.NewCmd(pm.manager, pm.updateVerb, caCertsPkgName, "-y"),
+		pm.newAutoConfirmCmd(pm.installVerb, caCertsPkgName),
+		pm.newAutoConfirmCmd(pm.deleteVerb, caCertsPkgName),
+		pm.newAutoConfirmCmd(pm.updateVerb, caCertsPkgName),
 	)
 }
 
 func (pm *DistroPackageManager) yumUtilsPackage() artifact.Package {
 	return artifact.NewPackageSource(
-		artifact.NewCmd(pm.manager, pm.installVerb, yumUtilsManagerPkg, "-y"),
-		artifact.NewCmd(pm.manager, pm.deleteVerb, yumUtilsManagerPkg, "-y"),
-		artifact.NewCmd(pm.manager, pm.updateVerb, yumUtilsManagerPkg, "-y"),
+		pm.newAutoConfirmCmd(pm.installVerb, yumUtilsManagerPkg),
+		pm.newAutoConfirmCmd(pm.deleteVerb, yumUtilsManagerPkg),
+		pm.newAutoConfirmCmd(pm.updateVerb, yumUtilsManagerPkg),
 	)
 }
 
 func (pm *DistroPackageManager) runcPackage() artifact.Package {
 	return artifact.NewPackageSource(
-		artifact.NewCmd(pm.manager, pm.installVerb, runcPkgName, "-y"),
-		artifact.NewCmd(pm.manager, pm.deleteVerb, runcPkgName, "-y"),
-		artifact.NewCmd(pm.manager, pm.updateVerb, runcPkgName, "-y"),
+		pm.newAutoConfirmCmd(pm.installVerb, runcPkgName),
+		pm.newAutoConfirmCmd(pm.deleteVerb, runcPkgName),
+		pm.newAutoConfirmCmd(pm.updateVerb, runcPkgName),
 	)
 }
 
@@ -300,7 +327,7 @@ func (pm *DistroPackageManager) Cleanup() error {
 }
 
 func getOsPackageManager() (string, error) {
-	supportedManagers := []string{yumPackageManager, aptPackageManager}
+	supportedManagers := []string{yumPackageManager, aptPackageManager, zypperPackageManager}
 	for _, manager := range supportedManagers {
 		if _, err := exec.LookPath(manager); err == nil {
 			return manager, nil
@@ -310,25 +337,31 @@ func getOsPackageManager() (string, error) {
 }
 
 var packageManagerInstallCmd = map[string]string{
-	aptPackageManager: "install",
-	yumPackageManager: "install",
+	aptPackageManager:    "install",
+	yumPackageManager:    "install",
+	zypperPackageManager: "install",
 }
 
 var packageManagerUpdateCmd = map[string]string{
-	aptPackageManager: "upgrade",
-	yumPackageManager: "update",
+	aptPackageManager:    "upgrade",
+	yumPackageManager:    "update",
+	zypperPackageManager: "update",
 }
 
 var packageManagerDeleteCmd = map[string]string{
-	aptPackageManager: "autoremove",
-	yumPackageManager: "remove",
+	aptPackageManager:    "autoremove",
+	yumPackageManager:    "remove",
+	zypperPackageManager: "remove",
 }
 
 var packageManagerMetadataRefreshCmd = map[string]string{
-	aptPackageManager: "update",
-	yumPackageManager: "makecache",
+	aptPackageManager:    "update",
+	yumPackageManager:    "makecache",
+	zypperPackageManager: "refresh",
 }
 
+// managerToDockerRepoMap intentionally has no zypper entry: Docker does not
+// publish an official docker-ce repo for SLES/openSUSE
 var managerToDockerRepoMap = map[string]string{
 	yumPackageManager: "https://download.docker.com/linux/centos/docker-ce.repo",
 	aptPackageManager: "https://download.docker.com/linux/ubuntu",

--- a/internal/ssm/daemon.go
+++ b/internal/ssm/daemon.go
@@ -123,6 +123,7 @@ func setDaemonName() {
 		system.UbuntuOsName: "snap.amazon-ssm-agent.amazon-ssm-agent",
 		system.RhelOsName:   "amazon-ssm-agent",
 		system.AmazonOsName: "amazon-ssm-agent",
+		system.SlesOsName:   "amazon-ssm-agent",
 	}
 	osName := system.GetOsName()
 	if daemonName, ok := osToDaemonName[osName]; ok {

--- a/internal/ssm/source.go
+++ b/internal/ssm/source.go
@@ -166,9 +166,10 @@ func (s ssmInstallerSource) defaultBuildSSMURL() (string, error) {
 // package manager in use.
 func detectPlatformVariant() (string, error) {
 	toVariant := map[string]string{
-		"apt": "debian",
-		"dnf": "linux",
-		"yum": "linux",
+		"apt":    "debian",
+		"dnf":    "linux",
+		"yum":    "linux",
+		"zypper": "linux",
 	}
 
 	for pkgManager := range toVariant {

--- a/internal/system/os.go
+++ b/internal/system/os.go
@@ -6,6 +6,7 @@ const (
 	UbuntuOsName = "ubuntu"
 	RhelOsName   = "rhel"
 	AmazonOsName = "amzn"
+	SlesOsName   = "sles"
 
 	UbuntuResolvConfPath = "/run/systemd/resolve/resolv.conf"
 )

--- a/test/e2e/os/sles.go
+++ b/test/e2e/os/sles.go
@@ -1,0 +1,147 @@
+package os
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+
+	"github.com/aws/eks-hybrid/test/e2e"
+)
+
+// SUSE AMI ids for public images are under this SSM parameter tree.
+// aws ssm get-parameter --name /aws/service/suse/sles/<sku>/<arch>/latest
+const (
+	sles15SP7SKU = "15-sp7"
+	sles16SKU    = "16.0"
+)
+
+const (
+	slesSsmAgentAMD = "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm"
+	slesSsmAgentARM = "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm"
+)
+
+//go:embed testdata/sles/15-sp7/cloud-init.txt
+var sles15SP7CloudInit []byte
+
+//go:embed testdata/sles/16.0/cloud-init.txt
+var sles16CloudInit []byte
+
+type slesCloudInitData struct {
+	e2e.UserDataInput
+	NodeadmUrl  string
+	SSMAgentURL string
+}
+
+type SLES15SP7 struct {
+	amiArchitecture string
+	architecture    architecture
+}
+
+func NewSLES15SP7AMD() *SLES15SP7 {
+	s := new(SLES15SP7)
+	s.amiArchitecture = x8664Arch
+	s.architecture = amd64
+	return s
+}
+
+func NewSLES15SP7ARM() *SLES15SP7 {
+	s := new(SLES15SP7)
+	s.amiArchitecture = arm64Arch
+	s.architecture = arm64
+	return s
+}
+
+func (s SLES15SP7) Name() string {
+	return "sles15sp7-" + s.architecture.String()
+}
+
+func (s SLES15SP7) InstanceType(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
+	return getInstanceTypeFromRegionAndArch(region, s.architecture, instanceSize, computeType)
+}
+
+func (s SLES15SP7) AMIName(ctx context.Context, awsConfig aws.Config, _ string, _ e2e.ComputeType) (string, error) {
+	return getAmiIDFromSSM(ctx, ssm.NewFromConfig(awsConfig), "/aws/service/suse/sles/"+sles15SP7SKU+"/"+s.amiArchitecture+"/latest")
+}
+
+func (s SLES15SP7) BuildUserData(_ context.Context, userDataInput e2e.UserDataInput) ([]byte, error) {
+	nodeadmConfigYaml, err := generateNodeadmConfigYaml(userDataInput.NodeadmConfig)
+	if err != nil {
+		return nil, err
+	}
+	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
+
+	if err := populateBaseScripts(&userDataInput); err != nil {
+		return nil, err
+	}
+
+	data := slesCloudInitData{
+		UserDataInput: userDataInput,
+		NodeadmUrl:    userDataInput.NodeadmUrls.AMD,
+		SSMAgentURL:   slesSsmAgentAMD,
+	}
+
+	if s.architecture.arm() {
+		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
+		data.SSMAgentURL = slesSsmAgentARM
+	}
+
+	return executeTemplate(sles15SP7CloudInit, data)
+}
+
+type SLES16 struct {
+	amiArchitecture string
+	architecture    architecture
+}
+
+func NewSLES16AMD() *SLES16 {
+	s := new(SLES16)
+	s.amiArchitecture = x8664Arch
+	s.architecture = amd64
+	return s
+}
+
+func NewSLES16ARM() *SLES16 {
+	s := new(SLES16)
+	s.amiArchitecture = arm64Arch
+	s.architecture = arm64
+	return s
+}
+
+func (s SLES16) Name() string {
+	return "sles16-" + s.architecture.String()
+}
+
+func (s SLES16) InstanceType(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
+	return getInstanceTypeFromRegionAndArch(region, s.architecture, instanceSize, computeType)
+}
+
+func (s SLES16) AMIName(ctx context.Context, awsConfig aws.Config, _ string, _ e2e.ComputeType) (string, error) {
+	return getAmiIDFromSSM(ctx, ssm.NewFromConfig(awsConfig), "/aws/service/suse/sles/"+sles16SKU+"/"+s.amiArchitecture+"/latest")
+}
+
+func (s SLES16) BuildUserData(_ context.Context, userDataInput e2e.UserDataInput) ([]byte, error) {
+	nodeadmConfigYaml, err := generateNodeadmConfigYaml(userDataInput.NodeadmConfig)
+	if err != nil {
+		return nil, err
+	}
+	userDataInput.NodeadmConfigYaml = nodeadmConfigYaml
+
+	if err := populateBaseScripts(&userDataInput); err != nil {
+		return nil, err
+	}
+
+	data := slesCloudInitData{
+		UserDataInput: userDataInput,
+		NodeadmUrl:    userDataInput.NodeadmUrls.AMD,
+		SSMAgentURL:   slesSsmAgentAMD,
+	}
+
+	if s.architecture.arm() {
+		data.NodeadmUrl = userDataInput.NodeadmUrls.ARM
+		data.SSMAgentURL = slesSsmAgentARM
+	}
+
+	return executeTemplate(sles16CloudInit, data)
+}

--- a/test/e2e/os/testdata/sles/15-sp7/cloud-init.txt
+++ b/test/e2e/os/testdata/sles/15-sp7/cloud-init.txt
@@ -1,0 +1,29 @@
+#cloud-config
+users:
+  - name: root
+    lock_passwd: false
+    ssh_authorized_keys:
+      - {{ .PublicKey }}
+{{- if .RootPasswordHash }}
+    hashed_passwd: {{ .RootPasswordHash }}
+{{- end }}
+package_update: true
+write_files:
+  - content: |
+{{ .NodeadmConfigYaml | indent 6 }}
+    path: nodeadm-config.yaml
+{{ range $file := .Files }}
+  - content: |
+{{ $file.Content | indent 6 }}
+    path: {{ $file.Path }}
+{{if $file.Permissions}}
+    permissions: '{{ $file.Permissions }}'
+{{- end }}
+{{- end }}
+
+runcmd:
+  - ln -sf /run/log/journal /var/log/journal
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}"
+  - /tmp/nvidia-driver-install.sh
+
+final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/os/testdata/sles/16.0/cloud-init.txt
+++ b/test/e2e/os/testdata/sles/16.0/cloud-init.txt
@@ -1,0 +1,29 @@
+#cloud-config
+users:
+  - name: root
+    lock_passwd: false
+    ssh_authorized_keys:
+      - {{ .PublicKey }}
+{{- if .RootPasswordHash }}
+    hashed_passwd: {{ .RootPasswordHash }}
+{{- end }}
+package_update: true
+write_files:
+  - content: |
+{{ .NodeadmConfigYaml | indent 6 }}
+    path: nodeadm-config.yaml
+{{ range $file := .Files }}
+  - content: |
+{{ $file.Content | indent 6 }}
+    path: {{ $file.Path }}
+{{if $file.Permissions}}
+    permissions: '{{ $file.Permissions }}'
+{{- end }}
+{{- end }}
+
+runcmd:
+  - ln -sf /run/log/journal /var/log/journal
+  - /tmp/nodeadm-init.sh "{{ .NodeadmUrl }}" "{{ .KubernetesVersion }}" "{{ .Provider }}" "{{ .Region }}"
+  - /tmp/nvidia-driver-install.sh
+
+final_message: "The system is prepped, after $UPTIME seconds"

--- a/test/e2e/suite/peered_vpc.go
+++ b/test/e2e/suite/peered_vpc.go
@@ -490,6 +490,10 @@ func OSProviderList(credentialProviders []e2e.NodeadmCredentialsProvider, region
 		osystem.NewRedHat9AMD(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
 		osystem.NewRedHat9ARM(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
 		osystem.NewRedHat9NoDockerSource(os.Getenv("RHEL_USERNAME"), os.Getenv("RHEL_PASSWORD")),
+		osystem.NewSLES15SP7AMD(),
+		osystem.NewSLES15SP7ARM(),
+		osystem.NewSLES16AMD(),
+		osystem.NewSLES16ARM(),
 	}
 	osProviderList := []OSProvider{}
 	for _, nodeOS := range osList {


### PR DESCRIPTION
*Issue #, if available:* 
N/A

*Description of changes:*
Added OS support for SLES 15 SP7 and SLES 16.0 (amd64 and arm64)
- Added SLES (zypper) support into nodeadm
- Added SLES tests into e2e suite
- Updated `kubelet.service` to use relative path for `iptables` instead of absolute

*Testing (if applicable):*
- [x] Go unit tests for nodeadm changes
- [x] Integration tests for all SLES OS variants
- [x] Full e2e test against all SLES OS variants and EKS Kubernetes version (1.31-1.36)
- [x] Regression check e2e validation against existing OS variants

*Documentation added/planned (if applicable):*
- [ ] EKS User Guide, Hybrid Nodes Supported OS docs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

