### PR TITLE
override assets host in validate release buildspec

### DIFF
--- a/buildspecs/prod-release-nodeadm.yml
+++ b/buildspecs/prod-release-nodeadm.yml
@@ -16,7 +16,7 @@ phases:
         cat << EOF > awscliconfig
         [profile artifacts-production]
         role_arn=${PROD_ARTIFACT_DEPLOYMENT_ROLE}
-        region=us-east-1
+        region=${PROD_REGION:-us-east-1}
         credential_source=EcsContainer
         EOF
       - export AWS_CONFIG_FILE=$(pwd)/awscliconfig
@@ -30,4 +30,6 @@ phases:
     commands:
       - AWS_PROFILE=artifacts-production ./hack/validate-release-artifacts.sh $PROD_BUCKET releases/${VERSION}
       - AWS_PROFILE=artifacts-production ./hack/validate-release-artifacts.sh $PROD_BUCKET releases/latest
-      - AWS_PROFILE=artifacts-production ./hack/validate-release.sh "${CLOUDFRONT_DISTRIBUTION_ID}" "latest/GIT_VERSION"
+      # RELEASE_ASSET_HOST is the public host fronting the prod bucket:
+      # hybrid-assets.eks.amazonaws.com (commercial) or eks-hybrid-assets.awsstatic.cn (China).
+      - AWS_PROFILE=artifacts-production ./hack/validate-release.sh "${CLOUDFRONT_DISTRIBUTION_ID}" "latest/GIT_VERSION" "${RELEASE_ASSET_HOST:-hybrid-assets.eks.amazonaws.com}"

--- a/hack/validate-release.sh
+++ b/hack/validate-release.sh
@@ -7,6 +7,12 @@ set -o pipefail
 CLOUDFRONT_ID=$1
 VERSION_FILE=$2
 
+# Optional argument: base host serving the released assets (behind CloudFront).
+# Defaults to the commercial host so existing callers are unchanged. For the
+# China partition (aws-cn) pass eks-hybrid-assets.awsstatic.cn. Also honors the
+# RELEASE_ASSET_HOST env var if the positional arg is not provided.
+RELEASE_ASSET_HOST="${3:-${RELEASE_ASSET_HOST:-hybrid-assets.eks.amazonaws.com}}"
+
 echo "Starting release validation..."
 
 # Create and wait for CloudFront invalidation
@@ -30,7 +36,7 @@ echo "CloudFront invalidation completed successfully"
 
 # Validate released version
 echo "Validating released version..."
-curl -L -o released_nodeadm https://hybrid-assets.eks.amazonaws.com/releases/latest/bin/linux/amd64/nodeadm
+curl -L -o released_nodeadm "https://${RELEASE_ASSET_HOST}/releases/latest/bin/linux/amd64/nodeadm"
 chmod +x released_nodeadm
 
 # Extract just the semantic version using regex i.e. 'Version: v1.0.5' -> 'v1.0.5'


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
The validate step was hardcoded to check against hybrid-assets.eks.amazonaws.com. Now it accepts an argument. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

