### PR TITLE
Add fallback instance types for nodeadm tests

### DIFF
--- a/cmd/e2e-test/node/create.go
+++ b/cmd/e2e-test/node/create.go
@@ -57,7 +57,7 @@ func NewCreateCommand() cli.Command {
 	createCmd.String(&cmd.os, "o", "os", "OS to use (al23, ubuntu2004, ubuntu2204, ubuntu2404, rhel8, rhel9, bottlerocket).")
 	createCmd.String(&cmd.arch, "a", "arch", "Architecture to use (amd64, arm64).")
 	createCmd.String(&cmd.instanceSize, "s", "instance-size", "Instance size to use (Large, XLarge).")
-	createCmd.String(&cmd.instanceType, "t", "instance-type", "Instance type to use (t3.large, g4dn.xlarge, etc). If provided, instance size would be ignored.")
+	createCmd.String(&cmd.instanceType, "t", "instance-type", "Instance type to use (t3.large, g4dn.xlarge, etc). If provided, instance size and the default instance type fallbacks are ignored.")
 
 	cmd.flaggy = createCmd
 

--- a/test/e2e/ec2/instance.go
+++ b/test/e2e/ec2/instance.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"time"
 
@@ -23,10 +24,12 @@ const nodeRunningTimeout = 5 * time.Minute
 
 // instanceConfig holds the configuration for the EC2 instance.
 type InstanceConfig struct {
-	ClusterName        string
-	InstanceName       string
-	AmiID              string
-	InstanceType       string
+	ClusterName  string
+	InstanceName string
+	AmiID        string
+	// InstanceTypes is an ordered list of instance types. They are attempted in
+	// order and the first one that launches is used.
+	InstanceTypes      []string
 	InstanceProfileARN string
 	VolumeSize         int32
 	UserData           []byte
@@ -39,6 +42,19 @@ type Instance struct {
 	ID   string
 	Name string
 	IP   string
+}
+
+// skipInstanceTypeErrorsRetryer wraps a retryer to make instance type related
+// errors non retryable.
+type skipInstanceTypeErrorsRetryer struct {
+	aws.Retryer
+}
+
+func (r *skipInstanceTypeErrorsRetryer) IsErrorRetryable(err error) bool {
+	if e2eErrors.IsInvalidInstanceTypeParameter(err) {
+		return false
+	}
+	return r.Retryer.IsErrorRetryable(err)
 }
 
 func (e *InstanceConfig) Create(ctx context.Context, ec2Client *ec2.Client, ssmClient *ssm.Client) (Instance, error) {
@@ -83,11 +99,43 @@ func (e *InstanceConfig) Create(ctx context.Context, ec2Client *ec2.Client, ssmC
 	}
 	userDataEncoded := base64.StdEncoding.EncodeToString(userDataBuffer.Bytes())
 
+	if len(e.InstanceTypes) == 0 {
+		return Instance{}, fmt.Errorf("no instance types provided for instance %s", e.InstanceName)
+	}
+
+	// Launch the first instance type that works. Skip to the next type only when the
+	// launch failed because of the type itself. Anything else, like a permission or subnet problem,
+	// would fail the same way for every type, so return it right away.
+	logger := logr.FromContextOrDiscard(ctx)
+
+	var attemptErrs []error
+	for _, instanceType := range e.InstanceTypes {
+		instance, err := e.runInstance(ctx, ec2Client, instanceType, userDataEncoded)
+		if err == nil {
+			logger.Info("Created EC2 instance", "instanceID", instance.ID, "instanceType", instanceType)
+			return instance, nil
+		}
+
+		if !e2eErrors.IsInstanceTypeUnavailable(err) {
+			return Instance{}, fmt.Errorf("could not create hybrid EC2 instance with instance type %s: %w", instanceType, err)
+		}
+
+		logger.Info("Instance type unavailable, trying next candidate", "instanceType", instanceType, "error", err.Error())
+		attemptErrs = append(attemptErrs, fmt.Errorf("%s: %w", instanceType, err))
+	}
+
+	return Instance{}, fmt.Errorf("could not create hybrid EC2 instance, none of the instance types %v are available: %w",
+		e.InstanceTypes, errors.Join(attemptErrs...))
+}
+
+// runInstance launches a single EC2 instance with the given instance type.
+func (e *InstanceConfig) runInstance(ctx context.Context, ec2Client *ec2.Client, instanceType, userDataEncoded string) (Instance, error) {
 	runResult, err := ec2Client.RunInstances(ctx, &ec2.RunInstancesInput{
 		ImageId:      aws.String(e.AmiID),
-		InstanceType: types.InstanceType(e.InstanceType),
+		InstanceType: types.InstanceType(instanceType),
 		MinCount:     aws.Int32(1),
 		MaxCount:     aws.Int32(1),
+
 		IamInstanceProfile: &types.IamInstanceProfileSpecification{
 			Arn: aws.String(e.InstanceProfileARN),
 		},
@@ -131,9 +179,12 @@ func (e *InstanceConfig) Create(ctx context.Context, ec2Client *ec2.Client, ssmC
 			HttpEndpoint: types.InstanceMetadataEndpointStateEnabled,
 		},
 	}, func(o *ec2.Options) {
+		// InvalidParameterValue is retried persistently to wait out IAM propagation, but
+		// when it refers to the instance type it will never succeed, so it is excluded to
+		// avoid spending all 60 attempts before falling back to the next type.
 		clientRetryer := o.Retryer
 		persistentInvalidParameterValueRetryer := retry.AddWithMaxAttempts(retry.AddWithErrorCodes(clientRetryer, "InvalidParameterValue"), 60)
-		o.Retryer = persistentInvalidParameterValueRetryer
+		o.Retryer = &skipInstanceTypeErrorsRetryer{Retryer: persistentInvalidParameterValueRetryer}
 	})
 	if err != nil {
 		return Instance{}, fmt.Errorf("could not create hybrid EC2 instance: %w", err)

--- a/test/e2e/errors/aws.go
+++ b/test/e2e/errors/aws.go
@@ -35,6 +35,53 @@ func IsAwsError(err error, code string) bool {
 	return err != nil && ok && awsErr.ErrorCode() == code
 }
 
+// instanceTypeUnavailableCodes are the RunInstances error codes that indicate the
+// requested instance type could not be launched, and that trying a different
+// instance type is likely to succeed.
+//
+// Account level quota errors (VcpuLimitExceeded, InstanceLimitExceeded) are
+// deliberately excluded as all instance types would run into the same issue.
+var instanceTypeUnavailableCodes = []string{
+	// The instance type is not offered in the requested region or availability zone.
+	"Unsupported",
+	"InvalidInstanceType",
+	// AWS does not currently have enough capacity for this instance type in the AZ.
+	// This is transient, but trying another type is cheaper than waiting.
+	"InsufficientInstanceCapacity",
+	"InsufficientHostCapacity",
+}
+
+// IsInstanceTypeUnavailable returns true if the error indicates the requested instance
+// type cannot be launched and a different instance type should be tried instead.
+func IsInstanceTypeUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	for _, code := range instanceTypeUnavailableCodes {
+		if IsAwsError(err, code) {
+			return true
+		}
+	}
+
+	// InvalidParameterValue is returned for an unusable instance type but also for
+	// a not-yet-propagated IAM instance profile, which is retryable.
+	return IsInvalidInstanceTypeParameter(err)
+}
+
+// IsInvalidInstanceTypeParameter returns true if the error is an InvalidParameterValue
+// error whose message refers to the instance type. This distinguishes a permanently
+// unusable instance type from other InvalidParameterValue causes, such as IAM instance
+// profile propagation delays.
+func IsInvalidInstanceTypeParameter(err error) bool {
+	var ae smithy.APIError
+	if !errors.As(err, &ae) || ae.ErrorCode() != "InvalidParameterValue" {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(ae.ErrorMessage()), "instance type")
+}
+
 // IsIAMRoleNotFound returns true if the error is an IAM role not found error.
 func IsIAMRoleNotFound(err error) bool {
 	if IsType(err, &iamTypes.NoSuchEntityException{}) {

--- a/test/e2e/errors/aws_test.go
+++ b/test/e2e/errors/aws_test.go
@@ -1,0 +1,132 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/smithy-go"
+)
+
+func apiErr(code, message string) error {
+	return &smithy.GenericAPIError{Code: code, Message: message}
+}
+
+func TestIsInstanceTypeUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "insufficient instance capacity",
+			err:  apiErr("InsufficientInstanceCapacity", "We currently do not have sufficient t3.large capacity in the Availability Zone you requested"),
+			want: true,
+		},
+		{
+			name: "unsupported in availability zone",
+			err:  apiErr("Unsupported", "Your requested instance type (t3.large) is not supported in your requested Availability Zone"),
+			want: true,
+		},
+		{
+			name: "invalid instance type",
+			err:  apiErr("InvalidInstanceType", "The instance type is not valid"),
+			want: true,
+		},
+		{
+			name: "insufficient host capacity",
+			err:  apiErr("InsufficientHostCapacity", "There is insufficient capacity on the host"),
+			want: true,
+		},
+		{
+			name: "invalid parameter value referencing instance type",
+			err:  apiErr("InvalidParameterValue", "Invalid value 't3.large' for InstanceType. The instance type is not available"),
+			want: true,
+		},
+		{
+			name: "wrapped unavailable error is detected",
+			err:  fmt.Errorf("could not create hybrid EC2 instance: %w", apiErr("Unsupported", "instance type not supported")),
+			want: true,
+		},
+		{
+			// This must not be treated as an unavailable instance type. It is retryable
+			// while the IAM instance profile propagates, and falling through to another
+			// instance type would not help.
+			name: "invalid parameter value for iam instance profile",
+			err:  apiErr("InvalidParameterValue", "Value (test-profile) for parameter iamInstanceProfile.arn is invalid"),
+			want: false,
+		},
+		{
+			// Quota errors are shared across instance families, so a different type
+			// would hit the same limit. These must surface rather than fall through.
+			name: "vcpu limit exceeded",
+			err:  apiErr("VcpuLimitExceeded", "You have requested more vCPU capacity than your current vCPU limit"),
+			want: false,
+		},
+		{
+			name: "instance limit exceeded",
+			err:  apiErr("InstanceLimitExceeded", "You have reached your quota for maximum number of instances"),
+			want: false,
+		},
+		{
+			name: "unrelated aws error",
+			err:  apiErr("UnauthorizedOperation", "You are not authorized to perform this operation"),
+			want: false,
+		},
+		{
+			name: "non aws error",
+			err:  errors.New("some other failure"),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsInstanceTypeUnavailable(tc.err); got != tc.want {
+				t.Errorf("IsInstanceTypeUnavailable() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsInvalidInstanceTypeParameter(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "instance type message",
+			err:  apiErr("InvalidParameterValue", "Invalid value for InstanceType. The instance type is not available"),
+			want: true,
+		},
+		{
+			name: "iam instance profile message is retryable",
+			err:  apiErr("InvalidParameterValue", "Value (test-profile) for parameter iamInstanceProfile.arn is invalid"),
+			want: false,
+		},
+		{
+			name: "different error code",
+			err:  apiErr("Unsupported", "instance type not supported"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsInvalidInstanceTypeParameter(tc.err); got != tc.want {
+				t.Errorf("IsInvalidInstanceTypeParameter() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/test/e2e/nodeadm.go
+++ b/test/e2e/nodeadm.go
@@ -16,7 +16,10 @@ type NodeadmOS interface {
 	Name() string
 	AMIName(ctx context.Context, awsConfig aws.Config, kubernetesVersion string, computeType ComputeType) (string, error)
 	BuildUserData(ctx context.Context, userDataInput UserDataInput) ([]byte, error)
-	InstanceType(region string, instanceSize InstanceSize, computeType ComputeType) string
+	// InstanceTypes returns an ordered list of candidate instance types. Callers should
+	// attempt them in order, falling back to the next when a type is unavailable in the
+	// target region or availability zone.
+	InstanceTypes(region string, instanceSize InstanceSize, computeType ComputeType) []string
 }
 
 type InstanceSize int

--- a/test/e2e/os/amazonlinux.go
+++ b/test/e2e/os/amazonlinux.go
@@ -41,8 +41,8 @@ func (a AmazonLinux2023) Name() string {
 	return "al23-" + a.architecture.String()
 }
 
-func (a AmazonLinux2023) InstanceType(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
-	return getInstanceTypeFromRegionAndArch(region, a.architecture, instanceSize, computeType)
+func (a AmazonLinux2023) InstanceTypes(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) []string {
+	return getInstanceTypesFromRegionAndArch(region, a.architecture, instanceSize, computeType)
 }
 
 func (a AmazonLinux2023) AMIName(ctx context.Context, awsConfig aws.Config, _ string, _ e2e.ComputeType) (string, error) {

--- a/test/e2e/os/arch.go
+++ b/test/e2e/os/arch.go
@@ -29,25 +29,29 @@ const (
 	arm64 architecture = "arm64"
 )
 
-var instanceSizeToType = map[architecture]map[e2e.InstanceSize]string{
+// instanceSizeToTypes maps an architecture and instance size to an ordered list of
+// candidate EC2 instance types. The first entry is the preferred type; the rest are
+// fallbacks used when the preferred type is not available in the target region/AZ
+var instanceSizeToTypes = map[architecture]map[e2e.InstanceSize][]string{
 	amd64: {
-		e2e.XLarge: "t3.xlarge",
-		e2e.Large:  "t3.large",
+		e2e.XLarge: {"t3.xlarge", "t3a.xlarge", "m6i.xlarge", "m6a.xlarge", "m5.xlarge"},
+		e2e.Large:  {"t3.large", "t3a.large", "m6i.large", "m6a.large", "m5.large"},
 	},
 	arm64: {
-		e2e.XLarge: "t4g.xlarge",
-		e2e.Large:  "t4g.large",
+		e2e.XLarge: {"t4g.xlarge", "m7g.xlarge", "m6g.xlarge"},
+		e2e.Large:  {"t4g.large", "m7g.large", "m6g.large"},
 	},
 }
 
-var gpuInstanceSizeToType = map[architecture]map[e2e.InstanceSize]string{
+// gpuInstanceSizeToTypes intentionally lists a single type per architecture and size.
+var gpuInstanceSizeToTypes = map[architecture]map[e2e.InstanceSize][]string{
 	amd64: {
-		e2e.XLarge: "g4dn.2xlarge",
-		e2e.Large:  "g4dn.xlarge",
+		e2e.XLarge: {"g4dn.2xlarge"},
+		e2e.Large:  {"g4dn.xlarge"},
 	},
 	arm64: {
-		e2e.XLarge: "g5g.2xlarge",
-		e2e.Large:  "g5g.xlarge",
+		e2e.XLarge: {"g5g.2xlarge"},
+		e2e.Large:  {"g5g.xlarge"},
 	},
 }
 
@@ -124,21 +128,25 @@ func getAmiIDFromSSM(ctx context.Context, client *ssm.Client, amiName string) (s
 	return *output.Parameter.Value, nil
 }
 
+// getInstanceTypesFromRegionAndArch returns the ordered list of candidate instance types
+// for the given architecture, size and compute type. The caller is expected to try them in
+// order, falling back to the next candidate when a type is unavailable in the target region.
+//
 // an unknown size and arch combination is a coding error, so we panic
-func getInstanceTypeFromRegionAndArch(_ string, arch architecture, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
-	var instanceType string
+func getInstanceTypesFromRegionAndArch(_ string, arch architecture, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) []string {
+	var instanceTypes []string
 	var ok bool
 
 	if computeType == e2e.GPUInstance {
-		instanceType, ok = gpuInstanceSizeToType[arch][instanceSize]
+		instanceTypes, ok = gpuInstanceSizeToTypes[arch][instanceSize]
 	} else {
-		instanceType, ok = instanceSizeToType[arch][instanceSize]
+		instanceTypes, ok = instanceSizeToTypes[arch][instanceSize]
 	}
 
-	if !ok {
+	if !ok || len(instanceTypes) == 0 {
 		panic(fmt.Errorf("unknown instance size %d for architecture %s", instanceSize, arch))
 	}
-	return instanceType
+	return instanceTypes
 }
 
 func generateNodeadmConfigYaml(nodeadmConfig *api.NodeConfig) (string, error) {

--- a/test/e2e/os/arch_test.go
+++ b/test/e2e/os/arch_test.go
@@ -1,0 +1,75 @@
+package os
+
+import (
+	"testing"
+
+	"github.com/aws/eks-hybrid/test/e2e"
+)
+
+// TestGetInstanceTypesFromRegionAndArchPreferredType pins the first candidate for every
+// combination. The first entry is the type that was used before fallback support was added,
+// so this guards against accidentally changing the instance type used on the happy path.
+func TestGetInstanceTypesFromRegionAndArchPreferredType(t *testing.T) {
+	tests := []struct {
+		name        string
+		arch        architecture
+		size        e2e.InstanceSize
+		computeType e2e.ComputeType
+		want        string
+	}{
+		{"amd64 large cpu", amd64, e2e.Large, e2e.CPUInstance, "t3.large"},
+		{"amd64 xlarge cpu", amd64, e2e.XLarge, e2e.CPUInstance, "t3.xlarge"},
+		{"arm64 large cpu", arm64, e2e.Large, e2e.CPUInstance, "t4g.large"},
+		{"arm64 xlarge cpu", arm64, e2e.XLarge, e2e.CPUInstance, "t4g.xlarge"},
+		{"amd64 large gpu", amd64, e2e.Large, e2e.GPUInstance, "g4dn.xlarge"},
+		{"amd64 xlarge gpu", amd64, e2e.XLarge, e2e.GPUInstance, "g4dn.2xlarge"},
+		{"arm64 large gpu", arm64, e2e.Large, e2e.GPUInstance, "g5g.xlarge"},
+		{"arm64 xlarge gpu", arm64, e2e.XLarge, e2e.GPUInstance, "g5g.2xlarge"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getInstanceTypesFromRegionAndArch("us-west-2", tc.arch, tc.size, tc.computeType)
+			if len(got) == 0 {
+				t.Fatalf("expected at least one instance type, got none")
+			}
+			if got[0] != tc.want {
+				t.Errorf("preferred instance type = %q, want %q", got[0], tc.want)
+			}
+		})
+	}
+}
+
+// TestGetInstanceTypesFromRegionAndArchCPUHasFallbacks verifies CPU instances have fallback
+// candidates, which is what allows nodes to launch in regions that do not offer the
+// preferred burstable instance type.
+func TestGetInstanceTypesFromRegionAndArchCPUHasFallbacks(t *testing.T) {
+	for _, arch := range []architecture{amd64, arm64} {
+		for _, size := range []e2e.InstanceSize{e2e.Large, e2e.XLarge} {
+			types := getInstanceTypesFromRegionAndArch("ap-southeast-7", arch, size, e2e.CPUInstance)
+			if len(types) < 2 {
+				t.Errorf("arch %s size %d: expected fallback instance types, got %v", arch, size, types)
+			}
+
+			seen := map[string]bool{}
+			for _, instanceType := range types {
+				if seen[instanceType] {
+					t.Errorf("arch %s size %d: duplicate instance type %q in %v", arch, size, instanceType, types)
+				}
+				seen[instanceType] = true
+			}
+		}
+	}
+}
+
+// TestGetInstanceTypesFromRegionAndArchUnknownSizePanics documents that an unknown
+// combination is treated as a coding error.
+func TestGetInstanceTypesFromRegionAndArchUnknownSizePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for unknown instance size, got none")
+		}
+	}()
+
+	getInstanceTypesFromRegionAndArch("us-west-2", amd64, e2e.InstanceSize(99), e2e.CPUInstance)
+}

--- a/test/e2e/os/bottlerocket.go
+++ b/test/e2e/os/bottlerocket.go
@@ -75,8 +75,8 @@ func (a BottleRocket) Name() string {
 	return "bottlerocket-" + a.architecture.String()
 }
 
-func (a BottleRocket) InstanceType(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
-	return getInstanceTypeFromRegionAndArch(region, a.architecture, instanceSize, computeType)
+func (a BottleRocket) InstanceTypes(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) []string {
+	return getInstanceTypesFromRegionAndArch(region, a.architecture, instanceSize, computeType)
 }
 
 func (a BottleRocket) AMIName(ctx context.Context, awsConfig aws.Config, kubernetesVersion string, computeType e2e.ComputeType) (string, error) {

--- a/test/e2e/os/rhel.go
+++ b/test/e2e/os/rhel.go
@@ -70,8 +70,8 @@ func (r RedHat8) Name() string {
 	return "rhel8-" + r.architecture.String()
 }
 
-func (r RedHat8) InstanceType(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
-	return getInstanceTypeFromRegionAndArch(region, r.architecture, instanceSize, computeType)
+func (r RedHat8) InstanceTypes(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) []string {
+	return getInstanceTypesFromRegionAndArch(region, r.architecture, instanceSize, computeType)
 }
 
 func (r RedHat8) AMIName(ctx context.Context, awsConfig aws.Config, _ string, _ e2e.ComputeType) (string, error) {
@@ -153,8 +153,8 @@ func (r RedHat9) Name() string {
 	return name
 }
 
-func (r RedHat9) InstanceType(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
-	return getInstanceTypeFromRegionAndArch(region, r.architecture, instanceSize, computeType)
+func (r RedHat9) InstanceTypes(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) []string {
+	return getInstanceTypesFromRegionAndArch(region, r.architecture, instanceSize, computeType)
 }
 
 func (r RedHat9) AMIName(ctx context.Context, awsConfig aws.Config, _ string, _ e2e.ComputeType) (string, error) {

--- a/test/e2e/os/ubuntu.go
+++ b/test/e2e/os/ubuntu.go
@@ -75,8 +75,8 @@ func (u Ubuntu2004) Name() string {
 	return name
 }
 
-func (u Ubuntu2004) InstanceType(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
-	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize, computeType)
+func (u Ubuntu2004) InstanceTypes(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) []string {
+	return getInstanceTypesFromRegionAndArch(region, u.architecture, instanceSize, computeType)
 }
 
 func (u Ubuntu2004) AMIName(ctx context.Context, awsConfig aws.Config, _ string, _ e2e.ComputeType) (string, error) {
@@ -148,8 +148,8 @@ func (u Ubuntu2204) Name() string {
 	return name
 }
 
-func (u Ubuntu2204) InstanceType(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
-	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize, computeType)
+func (u Ubuntu2204) InstanceTypes(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) []string {
+	return getInstanceTypesFromRegionAndArch(region, u.architecture, instanceSize, computeType)
 }
 
 func (u Ubuntu2204) AMIName(ctx context.Context, awsConfig aws.Config, _ string, _ e2e.ComputeType) (string, error) {
@@ -232,8 +232,8 @@ func (u Ubuntu2404) Name() string {
 	return name
 }
 
-func (u Ubuntu2404) InstanceType(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) string {
-	return getInstanceTypeFromRegionAndArch(region, u.architecture, instanceSize, computeType)
+func (u Ubuntu2404) InstanceTypes(region string, instanceSize e2e.InstanceSize, computeType e2e.ComputeType) []string {
+	return getInstanceTypesFromRegionAndArch(region, u.architecture, instanceSize, computeType)
 }
 
 func (u Ubuntu2404) AMIName(ctx context.Context, awsConfig aws.Config, _ string, _ e2e.ComputeType) (string, error) {

--- a/test/e2e/peered/node.go
+++ b/test/e2e/peered/node.go
@@ -142,9 +142,12 @@ func (c NodeCreate) Create(ctx context.Context, spec *NodeSpec) (PeeredInstance,
 		return PeeredInstance{}, fmt.Errorf("expected to successfully retrieve ami id: %w", err)
 	}
 
-	instanceType := spec.InstanceType
-	if instanceType == "" {
-		instanceType = spec.OS.InstanceType(c.Cluster.Region, spec.InstanceSize, spec.ComputeType)
+	// An explicit instance type overrides the candidate list. Otherwise the OS provides an
+	// ordered list of candidates and the first available one is used, so tests can run in
+	// regions that do not offer the preferred instance type.
+	instanceTypes := spec.OS.InstanceTypes(c.Cluster.Region, spec.InstanceSize, spec.ComputeType)
+	if spec.InstanceType != "" {
+		instanceTypes = []string{spec.InstanceType}
 	}
 
 	// Use the spec-level instance profile if explicitly provided.
@@ -157,10 +160,11 @@ func (c NodeCreate) Create(ctx context.Context, spec *NodeSpec) (PeeredInstance,
 	}
 
 	ec2Input := ec2.InstanceConfig{
-		ClusterName:        c.Cluster.Name,
-		InstanceName:       spec.InstanceName,
-		AmiID:              amiId,
-		InstanceType:       instanceType,
+		ClusterName:   c.Cluster.Name,
+		InstanceName:  spec.InstanceName,
+		AmiID:         amiId,
+		InstanceTypes: instanceTypes,
+
 		VolumeSize:         ec2VolumeSize,
 		SubnetID:           c.Cluster.SubnetID,
 		SecurityGroupID:    c.Cluster.SecurityGroupID,


### PR DESCRIPTION
*Description of changes:*
Add fallback behavior for nodeadm tests. 
Fixes InsufficientInstanceCapacity on t3.large in ap-southeast-7b that blocked the nodeadm canary. The ec2.InstanceConfig now takes an ordered candidate list; the first launch that succeeds wins, falling back on instance-type-specific errors only

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

