### PR TITLE
Use public.ecr to pull nginx for china e2es

### DIFF
--- a/test/e2e/addon/externaldns.go
+++ b/test/e2e/addon/externaldns.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/aws/eks-hybrid/test/e2e/constants"
+	"github.com/aws/eks-hybrid/test/e2e/images"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 )
 
@@ -99,9 +100,7 @@ func (e *ExternalDNSTest) Validate(ctx context.Context) error {
 		"{{TEST_SERVICE}}", externalDNSTestService,
 		"{{NAMESPACE}}", defaultNamespace,
 		"{{HOSTED_ZONE_NAME}}", hostedZoneName,
-		"{{ECR_ACCOUNT_ID}}", e.EcrAccount,
-		"{{REGION}}", e.Region,
-		"{{DNS_SUFFIX}}", e.DNSSuffix,
+		"{{NGINX_IMAGE}}", images.Nginx(e.Region, e.DNSSuffix, e.EcrAccount),
 	)
 	replacedTestServiceYAML := replacer.Replace(testServiceYAML)
 

--- a/test/e2e/addon/podidentityverify.go
+++ b/test/e2e/addon/podidentityverify.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/aws/eks-hybrid/test/e2e/images"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 )
 
@@ -66,7 +67,7 @@ func (v VerifyPodIdentityAddon) Run(ctx context.Context) error {
 			Containers: []corev1.Container{
 				{
 					Name:  sanitizeContainerName(podName),
-					Image: fmt.Sprintf("%s.dkr.ecr.%s.%s/ecr-public/aws-cli/aws-cli:latest", v.EcrAccount, v.Region, v.DNSSuffix),
+					Image: images.AwsCli(v.Region, v.DNSSuffix, v.EcrAccount),
 					Env: []corev1.EnvVar{
 						// default value for AWS_MAX_ATTEMPTS is 3. We are seeing the s3 cp command
 						// fail due to rate limits form additional tests so increasing the number of retries

--- a/test/e2e/addon/secretsstorecsidriver.go
+++ b/test/e2e/addon/secretsstorecsidriver.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/aws/eks-hybrid/test/e2e/constants"
 	"github.com/aws/eks-hybrid/test/e2e/errors"
+	"github.com/aws/eks-hybrid/test/e2e/images"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 )
 
@@ -95,9 +96,8 @@ func (s *SecretsStoreCSIDriverTest) Validate(ctx context.Context) error {
 		"{{SECRETS_STORE_TEST_POD}}", secretsStoreTestPod,
 		"{{SECRET_NAME}}", s.secretName,
 		"{{SERVICE_ACCOUNT_NAME}}", secretsStoreTestPodServiceAccount,
-		"{{ECR_ACCOUNT_ID}}", s.EcrAccount,
 		"{{REGION}}", s.Region,
-		"{{DNS_SUFFIX}}", s.DNSSuffix,
+		"{{NGINX_IMAGE}}", images.Nginx(s.Region, s.DNSSuffix, s.EcrAccount),
 	)
 
 	replacedYaml := replacer.Replace(secretsStoreStaticProvisioningYaml)

--- a/test/e2e/addon/testdata/nginx-external-dns.yaml
+++ b/test/e2e/addon/testdata/nginx-external-dns.yaml
@@ -29,7 +29,7 @@ spec:
         app: {{TEST_SERVICE}}
     spec:
       containers:
-      - image: "{{ECR_ACCOUNT_ID}}.dkr.ecr.{{REGION}}.{{DNS_SUFFIX}}/ecr-public/nginx/nginx:latest"
+      - image: "{{NGINX_IMAGE}}"
         name: {{TEST_SERVICE}}
         ports:
         - containerPort: 80

--- a/test/e2e/addon/testdata/secrets_store_csi_static_provisioning.yaml
+++ b/test/e2e/addon/testdata/secrets_store_csi_static_provisioning.yaml
@@ -31,7 +31,7 @@ spec:
   serviceAccountName: {{SERVICE_ACCOUNT_NAME}}
   containers:
     - name: nginx
-      image: "{{ECR_ACCOUNT_ID}}.dkr.ecr.{{REGION}}.{{DNS_SUFFIX}}/ecr-public/nginx/nginx:latest"
+      image: "{{NGINX_IMAGE}}"
       ports:
         - containerPort: 80
       volumeMounts:

--- a/test/e2e/cni/cilium.go
+++ b/test/e2e/cni/cilium.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/aws/eks-hybrid/test/e2e/constants"
+	"github.com/aws/eks-hybrid/test/e2e/images"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
 )
 
@@ -53,16 +54,11 @@ func NewCilium(k8s dynamic.Interface, podCIDR, region, kubernetesVersion string)
 	}
 }
 
-// isChinaRegion returns true if the region is a China region
-func isChinaRegion(region string) bool {
-	return strings.HasPrefix(region, "cn-")
-}
-
 // getCiliumImageConfig returns the appropriate image repository and tag based on region.
 // For China regions, it uses the China ECR registry (constants.ChinaCiliumEcrAccountId).
 // The same Cilium version (read from testdata/cilium/VERSION) is used for all regions.
 func getCiliumImageConfig(region string) (ciliumRepo, operatorRepo, tag string) {
-	if isChinaRegion(region) {
+	if images.IsChinaRegion(region) {
 		baseRepo := constants.ChinaCiliumEcrAccountId + ".dkr.ecr." + region + ".amazonaws.com.cn"
 		return baseRepo + "/cilium/cilium",
 			baseRepo + "/cilium/operator-generic",

--- a/test/e2e/constants/constants.go
+++ b/test/e2e/constants/constants.go
@@ -13,8 +13,11 @@ const (
 	// ChinaCiliumEcrAccountId is the ECR account ID used in AWS China (aws-cn) regions for Cilium images.
 	// This account mirrors Cilium images for use in China regions.
 	ChinaCiliumEcrAccountId = "907723705730"
+	// PublicEcrRegistry is the public ECR registry. It is anonymously pullable from every
+	// partition, including AWS China (aws-cn).
+	PublicEcrRegistry = "public.ecr.aws"
 	// CiliumPublicEcrRegistry is the public ECR registry used for Cilium images in standard regions.
-	CiliumPublicEcrRegistry         = "public.ecr.aws/eks"
+	CiliumPublicEcrRegistry         = PublicEcrRegistry + "/eks"
 	LogCollectorBundleFileName      = "bundle.tar.gz"
 	JumpboxLogBundleFileName        = "jumpbox-bundle.tar.gz"
 	TestCredentialsStackNamePrefix  = "EKSHybridCI"

--- a/test/e2e/images/images.go
+++ b/test/e2e/images/images.go
@@ -1,0 +1,37 @@
+// Package images resolves the container image references used by the e2e tests.
+//
+// Test images are normally served out of the team's private ECR account through an ECR
+// pull-through cache. For China regions we pull from public.ecr.aws directly instead.
+
+package images
+
+import (
+	"fmt"
+
+	awsinternal "github.com/aws/eks-hybrid/internal/aws"
+	"github.com/aws/eks-hybrid/test/e2e/constants"
+)
+
+// Nginx returns the nginx image reference to use for the given region.
+func Nginx(region, dnsSuffix, ecrAccount string) string {
+	return testImage("nginx/nginx", region, dnsSuffix, ecrAccount)
+}
+
+// AwsCli returns the aws-cli image reference to use for the given region.
+func AwsCli(region, dnsSuffix, ecrAccount string) string {
+	return testImage("aws-cli/aws-cli", region, dnsSuffix, ecrAccount)
+}
+
+// testImage returns the reference for a repository mirrored from public.ecr.aws, using
+// public ECR directly in China regions since the pull-through cache is unavailable there.
+func testImage(repository, region, dnsSuffix, ecrAccount string) string {
+	if IsChinaRegion(region) {
+		return fmt.Sprintf("%s/%s:latest", constants.PublicEcrRegistry, repository)
+	}
+	return fmt.Sprintf("%s.dkr.ecr.%s.%s/ecr-public/%s:latest", ecrAccount, region, dnsSuffix, repository)
+}
+
+// IsChinaRegion returns true if the region belongs to the AWS China (aws-cn) partition.
+func IsChinaRegion(region string) bool {
+	return awsinternal.GetPartitionFromRegionFallback(region) == "aws-cn"
+}

--- a/test/e2e/images/images_test.go
+++ b/test/e2e/images/images_test.go
@@ -1,0 +1,109 @@
+package images_test
+
+import (
+	"testing"
+
+	"github.com/aws/eks-hybrid/test/e2e/constants"
+	"github.com/aws/eks-hybrid/test/e2e/images"
+)
+
+func TestNginx(t *testing.T) {
+	tests := []struct {
+		name       string
+		region     string
+		dnsSuffix  string
+		ecrAccount string
+		want       string
+	}{
+		{
+			name:       "china region uses public ecr directly",
+			region:     "cn-northwest-1",
+			dnsSuffix:  "amazonaws.com.cn",
+			ecrAccount: constants.ChinaEcrAccountId,
+			want:       "public.ecr.aws/nginx/nginx:latest",
+		},
+		{
+			name:       "other china region uses public ecr directly",
+			region:     "cn-north-1",
+			dnsSuffix:  "amazonaws.com.cn",
+			ecrAccount: constants.ChinaEcrAccountId,
+			want:       "public.ecr.aws/nginx/nginx:latest",
+		},
+		{
+			name:       "commercial region uses pull through cache",
+			region:     "us-west-2",
+			dnsSuffix:  "amazonaws.com",
+			ecrAccount: constants.EcrAccountId,
+			want:       "381492195191.dkr.ecr.us-west-2.amazonaws.com/ecr-public/nginx/nginx:latest",
+		},
+		{
+			name:       "govcloud region uses pull through cache",
+			region:     "us-gov-west-1",
+			dnsSuffix:  "amazonaws.com",
+			ecrAccount: constants.EcrAccountId,
+			want:       "381492195191.dkr.ecr.us-gov-west-1.amazonaws.com/ecr-public/nginx/nginx:latest",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := images.Nginx(tc.region, tc.dnsSuffix, tc.ecrAccount); got != tc.want {
+				t.Errorf("Nginx(%q, %q, %q) = %q, want %q", tc.region, tc.dnsSuffix, tc.ecrAccount, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAwsCli(t *testing.T) {
+	tests := []struct {
+		name       string
+		region     string
+		dnsSuffix  string
+		ecrAccount string
+		want       string
+	}{
+		{
+			name:       "china region uses public ecr directly",
+			region:     "cn-northwest-1",
+			dnsSuffix:  "amazonaws.com.cn",
+			ecrAccount: constants.ChinaEcrAccountId,
+			want:       "public.ecr.aws/aws-cli/aws-cli:latest",
+		},
+		{
+			name:       "commercial region uses pull through cache",
+			region:     "us-west-2",
+			dnsSuffix:  "amazonaws.com",
+			ecrAccount: constants.EcrAccountId,
+			want:       "381492195191.dkr.ecr.us-west-2.amazonaws.com/ecr-public/aws-cli/aws-cli:latest",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := images.AwsCli(tc.region, tc.dnsSuffix, tc.ecrAccount); got != tc.want {
+				t.Errorf("AwsCli(%q, %q, %q) = %q, want %q", tc.region, tc.dnsSuffix, tc.ecrAccount, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsChinaRegion(t *testing.T) {
+	tests := []struct {
+		region string
+		want   bool
+	}{
+		{region: "cn-north-1", want: true},
+		{region: "cn-northwest-1", want: true},
+		{region: "us-west-2", want: false},
+		{region: "us-gov-west-1", want: false},
+		{region: "eu-central-1", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.region, func(t *testing.T) {
+			if got := images.IsChinaRegion(tc.region); got != tc.want {
+				t.Errorf("IsChinaRegion(%q) = %v, want %v", tc.region, got, tc.want)
+			}
+		})
+	}
+}

--- a/test/e2e/kubernetes/deployment.go
+++ b/test/e2e/kubernetes/deployment.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	ik8s "github.com/aws/eks-hybrid/internal/kubernetes"
+	"github.com/aws/eks-hybrid/test/e2e/images"
 )
 
 // CreateDeployment creates a deployment with the specified configuration
@@ -65,7 +66,7 @@ func CreateDeployment(
 					Containers: []corev1.Container{
 						{
 							Name:    name,
-							Image:   fmt.Sprintf("%s.dkr.ecr.%s.%s/ecr-public/nginx/nginx:latest", ecrAccount, region, dnsSuffix),
+							Image:   images.Nginx(region, dnsSuffix, ecrAccount),
 							Command: containerCommand,
 							Ports: []corev1.ContainerPort{
 								{ContainerPort: actualTargetPort, Protocol: corev1.ProtocolTCP},

--- a/test/e2e/kubernetes/pod.go
+++ b/test/e2e/kubernetes/pod.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 
 	ik8s "github.com/aws/eks-hybrid/internal/kubernetes"
+	"github.com/aws/eks-hybrid/test/e2e/images"
 )
 
 const (
@@ -61,7 +62,7 @@ func CreateNginxPodInNode(ctx context.Context, k8s kubernetes.Interface, nodeNam
 			Containers: []corev1.Container{
 				{
 					Name:  "nginx",
-					Image: fmt.Sprintf("%s.dkr.ecr.%s.%s/ecr-public/nginx/nginx:latest", ecrAccount, region, dnsSuffix),
+					Image: images.Nginx(region, dnsSuffix, ecrAccount),
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: 80,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
E2E tests in `cn-north-1` / `cn-northwest-1` were failing at the pod-verification step. The nginx test pod never reaches `Running` and the 3-minute `nodePodWaitTimeout` expires with `context deadline exceeded`.

The node itself is healthy — it installs, joins, goes `Ready`, and `nodeadm debug` passes all checks. The failure is purely that the test pod's image cannot be pulled.

The test images were addressed through an ECR **pull-through cache** path, but this does not work in China:

```
858475954877.dkr.ecr.cn-northwest-1.amazonaws.com.cn/ecr-public/nginx/nginx:latest
```


Updating the tests so that China regions pull from `public.ecr.aws` directly, while all other partitions keep the existing pull-through cache path unchanged for both nginx and aws-cli

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

